### PR TITLE
Changed namespaces of Execute extension methods so as not to require …

### DIFF
--- a/samples/mssql/ServerSideBlazorApp/Service/PersonService.cs
+++ b/samples/mssql/ServerSideBlazorApp/Service/PersonService.cs
@@ -1,4 +1,4 @@
-﻿using HatTrick.DbEx.Sql.Builder;
+﻿using HatTrick.DbEx.Sql;
 using ServerSideBlazorApp.Data;
 using ServerSideBlazorApp.dboData;
 using ServerSideBlazorApp.DataService;
@@ -55,7 +55,5 @@ namespace ServerSideBlazorApp.Service
 
             return creditLimit;
         }
-
-        //GWG to JROD: Here's what I put as "Application arguments" in HatTrick.DbEx.Tools to gen code in the ./Data/_Generated folder: "gen -p d:/src/db-ex/samples/mssql/ServerSideBlazorApp/DbExConfig.json -o d:/src/db-ex/samples/mssql/ServerSideBlazorApp/Data/_Generated"
     }
 }

--- a/src/HatTrick.DbEx.Sql/_Extensions/_Builder/SqlExpressionBuilderExtensions.cs
+++ b/src/HatTrick.DbEx.Sql/_Extensions/_Builder/SqlExpressionBuilderExtensions.cs
@@ -4,12 +4,11 @@ using HatTrick.DbEx.Sql.Expression;
 using HatTrick.DbEx.Sql.Pipeline;
 using System;
 using System.Collections.Generic;
-using System.Data.Common;
 using System.Dynamic;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace HatTrick.DbEx.Sql.Builder
+namespace HatTrick.DbEx.Sql
 {
     public static class SqlExpressionBuilderExtensions
     {

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/Arithmetic.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/Arithmetic.cs
@@ -1,7 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Delete/Delete.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Delete/Delete.cs
@@ -3,7 +3,7 @@ using DbEx.Data.dbo;
 using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_ExecuteOverloads/SelectMany.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_ExecuteOverloads/SelectMany.cs
@@ -2,7 +2,7 @@
 using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_ExecuteOverloads/SelectOne.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_ExecuteOverloads/SelectOne.cs
@@ -2,7 +2,7 @@
 using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System.Threading.Tasks;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_FieldExpressions/NullableDateTimeFieldExpression.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_FieldExpressions/NullableDateTimeFieldExpression.cs
@@ -2,7 +2,7 @@
 using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using System.Linq;
 using System.Threading.Tasks;

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_FieldExpressions/NullableGuidFieldExpression.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_FieldExpressions/NullableGuidFieldExpression.cs
@@ -2,10 +2,9 @@
 using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using System.Linq;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_FieldExpressions/StringFieldExpression.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_FieldExpressions/StringFieldExpression.cs
@@ -1,8 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System;
+using HatTrick.DbEx.Sql;
 using System.Collections.Generic;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Average.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Average.cs
@@ -1,8 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Cast.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Cast.cs
@@ -1,8 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System;
+using HatTrick.DbEx.Sql;
 using System.Collections.Generic;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Coalesce.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Coalesce.cs
@@ -1,7 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using System.Collections.Generic;
 using Xunit;
@@ -51,29 +51,28 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             dates.Should().HaveCount(expected);
         }
 
-        //MEDIATOR
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Expression", "Arithmetic")]
-        //public void Does_coalesceing_ship_date_and_getdate_plus_purchase_date_succeed(int version, int expected = 15)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Expression", "Arithmetic")]
+        public void Does_coalesceing_ship_date_and_getdate_plus_purchase_date_succeed(int version, int expected = 15)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
 
-        //    var exp = db.SelectMany(
-        //            dbo.Purchase.TotalPurchaseAmount,
-        //            db.fx.Coalesce(
-        //                dbo.Purchase.ShipDate,
-        //                db.fx.GetDate() + dbo.Purchase.PurchaseDate
-        //            ).As("relevant_date")
-        //        ).From(dbo.Purchase);
+            var exp = db.SelectMany(
+                    dbo.Purchase.TotalPurchaseAmount,
+                    db.fx.Coalesce(
+                        dbo.Purchase.ShipDate,
+                        db.fx.GetDate() + dbo.Purchase.PurchaseDate
+                    ).As("relevant_date")
+                ).From(dbo.Purchase);
 
-        //    //when               
-        //    IList<dynamic> dates = exp.Execute();
+            //when               
+            IList<dynamic> dates = exp.Execute();
 
-        //    //then
-        //    dates.Should().HaveCount(expected);
-        //}
+            //then
+            dates.Should().HaveCount(expected);
+        }
 
         [Theory]
         [MsSqlVersions.AllVersions]

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Count.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Count.cs
@@ -1,7 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/DateAdd.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/DateAdd.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using Xunit;
 
@@ -131,47 +131,5 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             //then
             result.Value.Year.Should().Be(expected);
         }
-
-        //MILESTONE: Shared Parameters
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Can_group_by_dateadd_of_year_to_null_ship_date_succeed(int version)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.DateAdd(DateParts.Year, 1, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .GroupBy(db.fx.DateAdd(DateParts.Year, 1, dbo.Purchase.ShipDate));
-
-        //    //when               
-        //    DateTime? result = exp.Execute();
-
-        //    //then
-        //    result.Should().BeNull();
-        //}
-
-        //MILESTONE: Shared Parameters
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Can_group_by_dateadd_of_year_to_null_ship_date_and_aliasing_succeed(int version, int expected = 2018)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.DateAdd(DateParts.Year, 1, dbo.Purchase.ShipDate).As("alias")
-        //        ).From(dbo.Purchase)
-        //        .GroupBy(db.fx.DateAdd(DateParts.Year, 1, dbo.Purchase.ShipDate));
-
-        //    //when               
-        //    DateTime? result = exp.Execute();
-
-        //    //then
-        //    result.Value.Year.Should().Be(expected);
-        //}
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/DateDiff.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/DateDiff.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/DatePart.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/DatePart.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/IsNull.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/IsNull.cs
@@ -1,12 +1,10 @@
 ﻿using DbEx.Data;
-using DbEx.Data.dbo;
 using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Maximum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Maximum.cs
@@ -1,7 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Minimum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Minimum.cs
@@ -1,7 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/PopulationStandardDeviation.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/PopulationStandardDeviation.cs
@@ -1,7 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/PopulationVariance.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/PopulationVariance.cs
@@ -1,7 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/StandardDeviation.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/StandardDeviation.cs
@@ -1,7 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Sum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Sum.cs
@@ -1,7 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Variance.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Variance.cs
@@ -1,7 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/AverageAndDateDiff.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/AverageAndDateDiff.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/AverageAndDatePart.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/AverageAndDatePart.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndAverage.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndAverage.cs
@@ -1,9 +1,7 @@
-﻿using DbEx.Data;
-using DbEx.DataService;
+﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndCoalesce.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndCoalesce.cs
@@ -1,8 +1,7 @@
-﻿using DbEx.Data;
-using DbEx.DataService;
+﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndCount.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndCount.cs
@@ -1,9 +1,7 @@
-﻿using DbEx.Data;
-using DbEx.DataService;
+﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndDateAdd.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndDateAdd.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndDateDiff.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndDateDiff.cs
@@ -1,10 +1,8 @@
-﻿using DbEx.Data.dbo;
-using DbEx.DataService;
+﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System;
+using HatTrick.DbEx.Sql;
 using System.Collections.Generic;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndDatePart.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndDatePart.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System.Collections.Generic;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndIsNull.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndIsNull.cs
@@ -1,7 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndMaximum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndMaximum.cs
@@ -1,8 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndMinimum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndMinimum.cs
@@ -1,8 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndPopulationVariance.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndPopulationVariance.cs
@@ -1,8 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndStandardDeviation.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndStandardDeviation.cs
@@ -1,9 +1,7 @@
-﻿using DbEx.Data;
-using DbEx.DataService;
+﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndStandardDeviationPopulation.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndStandardDeviationPopulation.cs
@@ -1,9 +1,7 @@
-﻿using DbEx.Data;
-using DbEx.DataService;
+﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndSum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndSum.cs
@@ -1,8 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndVariance.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CastAndVariance.cs
@@ -2,8 +2,7 @@
 using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndAverage.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndAverage.cs
@@ -1,9 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
-using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System;
+using HatTrick.DbEx.Sql;
 using System.Collections.Generic;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndDateAdd.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndDateAdd.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndDateDiff.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndDateDiff.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System.Collections.Generic;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndDatePart.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndDatePart.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System.Collections.Generic;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndIsNull.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndIsNull.cs
@@ -1,7 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndMaximum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndMaximum.cs
@@ -1,8 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
-using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndMinimum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndMinimum.cs
@@ -1,9 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
-using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System;
+using HatTrick.DbEx.Sql;
 using System.Collections.Generic;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndPopulationStandardDeviation.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndPopulationStandardDeviation.cs
@@ -1,9 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
-using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndPopulationVariance.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndPopulationVariance.cs
@@ -1,7 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndStandardDeviation.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndStandardDeviation.cs
@@ -1,9 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
-using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndSum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndSum.cs
@@ -1,7 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndVariance.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CoalesceAndVariance.cs
@@ -1,9 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
-using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/ConcatAndCoalesce.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/ConcatAndCoalesce.cs
@@ -1,7 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CountAndDateAdd.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CountAndDateAdd.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CountAndDateDiff.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CountAndDateDiff.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CountAndDatePart.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/CountAndDatePart.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/DateAddAndDateDiff.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/DateAddAndDateDiff.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/DateAddAndDatePart.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/DateAddAndDatePart.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/DateAddAndMaximum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/DateAddAndMaximum.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/DateAddAndMinimum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/DateAddAndMinimum.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/DateDiffAndMaximum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/DateDiffAndMaximum.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using System.Data.SqlClient;
 using Xunit;
@@ -50,491 +50,472 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
         }
 
         //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_maximum_of_quantity_added_to_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 3)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Max(dbo.PurchaseLine.Quantity) + db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_maximum_of_credit_limit_added_to_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 20000)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Max(dbo.Person.CreditLimit) + db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_maximum_of_credit_limit_added_to_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 20000)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Max(dbo.Person.CreditLimit) + db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_maximum_of_quantity_added_to_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 3)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Max(dbo.PurchaseLine.Quantity) + db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_maximum_of_quantity_minus_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 3)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Max(dbo.PurchaseLine.Quantity) - db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_maximum_of_credit_limit_minus_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 20000)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Max(dbo.Person.CreditLimit) - db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_maximum_of_credit_limit_minus_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 20000)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Max(dbo.Person.CreditLimit) - db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_maximum_of_quantity_minus_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 3)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Max(dbo.PurchaseLine.Quantity) - db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_maximum_of_quantity_multiplied_by_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 0)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Max(dbo.PurchaseLine.Quantity) * db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_maximum_of_credit_limit_multiplied_by_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 0)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Max(dbo.Person.CreditLimit) * db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_maximum_of_credit_limit_multiplied_by_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 0)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Max(dbo.Person.CreditLimit) * db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_maximum_of_quantity_multiplied_by_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 0)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Max(dbo.PurchaseLine.Quantity) * db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_maximum_of_quantity_divided_by_datediff_of_purchase_date_and_ship_date_succeed(int version)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    static void _() => db.SelectOne(
-        //            db.fx.Max(dbo.PurchaseLine.Quantity) / db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value)
-        //        .Execute();
-
-        //    //when               
-        //    var result = Assert.ThrowsAny<Exception>(_);
-
-        //    //then
-        //    result.Should().BeOfType<SqlException>();
-        //    result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_maximum_of_credit_limit_divided_by_datediff_of_purchase_date_and_ship_date_succeed(int version)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    static void _() => db.SelectOne(
-        //            db.fx.Max(dbo.Person.CreditLimit) / db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value)
-        //        .Execute();
-
-        //    //when               
-        //    var result = Assert.ThrowsAny<Exception>(_);
-
-        //    //then
-        //    result.Should().BeOfType<SqlException>();
-        //    result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_maximum_of_credit_limit_divided_by_datediff_of_purchase_date_and_date_created_succeed(int version)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    static void _() => db.SelectOne(
-        //            db.fx.Max(dbo.Person.CreditLimit) / db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value)
-        //        .Execute();
-
-        //    //when               
-        //    var result = Assert.ThrowsAny<Exception>(_);
-
-        //    //then
-        //    result.Should().BeOfType<SqlException>();
-        //    result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_maximum_of_quantity_divided_by_datediff_of_purchase_date_and_date_created_succeed(int version)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    static void _() => db.SelectOne(
-        //            db.fx.Max(dbo.PurchaseLine.Quantity) / db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value)
-        //        .Execute();
-
-        //    //when               
-        //    var result = Assert.ThrowsAny<Exception>(_);
-
-        //    //then
-        //    result.Should().BeOfType<SqlException>();
-        //    result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_maximum_of_quantity_modulus_of_datediff_of_purchase_date_and_ship_date_succeed(int version)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    static void _() => db.SelectOne(
-        //            db.fx.Max(dbo.PurchaseLine.Quantity) % db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value)
-        //        .Execute();
-
-        //    //when               
-        //    var result = Assert.ThrowsAny<Exception>(_);
-
-        //    //then
-        //    result.Should().BeOfType<SqlException>();
-        //    result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_maximum_of_credit_limit_modulus_of_datediff_of_purchase_date_and_ship_date_succeed(int version)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    static void _() => db.SelectOne(
-        //            db.fx.Max(dbo.Person.CreditLimit) % db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value)
-        //        .Execute();
-
-        //    //when               
-        //    var result = Assert.ThrowsAny<Exception>(_);
-
-        //    //then
-        //    result.Should().BeOfType<SqlException>();
-        //    result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_maximum_of_credit_limit_modulus_of_datediff_of_purchase_date_and_date_created_succeed(int version)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    static void _() => db.SelectOne(
-        //            db.fx.Max(dbo.Person.CreditLimit) % db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value)
-        //        .Execute();
-
-        //    //when               
-        //    var result = Assert.ThrowsAny<Exception>(_);
-
-        //    //then
-        //    result.Should().BeOfType<SqlException>();
-        //    result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_maximum_of_quantity_modulus_of_datediff_of_purchase_date_and_date_created_succeed(int version)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    static void _() => db.SelectOne(
-        //            db.fx.Max(dbo.PurchaseLine.Quantity) % db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value)
-        //        .Execute();
-
-        //    //when               
-        //    var result = Assert.ThrowsAny<Exception>(_);
-
-        //    //then
-        //    result.Should().BeOfType<SqlException>();
-        //    result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
-        //}
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_maximum_of_quantity_added_to_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 3)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Max(dbo.PurchaseLine.Quantity) + db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_maximum_of_credit_limit_added_to_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 20000)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Max(dbo.Person.CreditLimit) + db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_maximum_of_credit_limit_added_to_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 20000)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Max(dbo.Person.CreditLimit) + db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_maximum_of_quantity_added_to_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 3)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Max(dbo.PurchaseLine.Quantity) + db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_maximum_of_quantity_minus_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 3)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Max(dbo.PurchaseLine.Quantity) - db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_maximum_of_credit_limit_minus_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 20000)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Max(dbo.Person.CreditLimit) - db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_maximum_of_credit_limit_minus_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 20000)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Max(dbo.Person.CreditLimit) - db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_maximum_of_quantity_minus_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 3)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Max(dbo.PurchaseLine.Quantity) - db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_maximum_of_quantity_multiplied_by_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 0)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Max(dbo.PurchaseLine.Quantity) * db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_maximum_of_credit_limit_multiplied_by_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 0)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Max(dbo.Person.CreditLimit) * db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_maximum_of_credit_limit_multiplied_by_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 0)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Max(dbo.Person.CreditLimit) * db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_maximum_of_quantity_multiplied_by_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 0)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Max(dbo.PurchaseLine.Quantity) * db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_maximum_of_quantity_divided_by_datediff_of_purchase_date_and_ship_date_throw_sql_exception_when_datediff_is_zero(int version)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            static void _() => db.SelectOne(
+                    db.fx.Max(dbo.PurchaseLine.Quantity) / db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value)
+                .Execute();
+
+            //when               
+            var result = Assert.ThrowsAny<Exception>(_);
+
+            //then
+            result.Should().BeOfType<SqlException>();
+            result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_maximum_of_credit_limit_divided_by_datediff_of_purchase_date_and_ship_date_throw_sql_exception_when_datediff_is_zero(int version)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            static void _() => db.SelectOne(
+                    db.fx.Max(dbo.Person.CreditLimit) / db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value)
+                .Execute();
+
+            //when               
+            var result = Assert.ThrowsAny<Exception>(_);
+
+            //then
+            result.Should().BeOfType<SqlException>();
+            result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_maximum_of_credit_limit_divided_by_datediff_of_purchase_date_and_date_created_throw_sql_exception_when_datediff_is_zero(int version)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            static void _() => db.SelectOne(
+                    db.fx.Max(dbo.Person.CreditLimit) / db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value)
+                .Execute();
+
+            //when               
+            var result = Assert.ThrowsAny<Exception>(_);
+
+            //then
+            result.Should().BeOfType<SqlException>();
+            result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_maximum_of_quantity_divided_by_datediff_of_purchase_date_and_date_created_throw_sql_exception_when_datediff_is_zero(int version)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            static void _() => db.SelectOne(
+                    db.fx.Max(dbo.PurchaseLine.Quantity) / db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value)
+                .Execute();
+
+            //when               
+            var result = Assert.ThrowsAny<Exception>(_);
+
+            //then
+            result.Should().BeOfType<SqlException>();
+            result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_maximum_of_quantity_modulus_of_datediff_of_purchase_date_and_ship_date_throw_sql_exception_when_datediff_is_zero(int version)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            static void _() => db.SelectOne(
+                    db.fx.Max(dbo.PurchaseLine.Quantity) % db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value)
+                .Execute();
+
+            //when               
+            var result = Assert.ThrowsAny<Exception>(_);
+
+            //then
+            result.Should().BeOfType<SqlException>();
+            result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_maximum_of_credit_limit_modulus_of_datediff_of_purchase_date_and_ship_date_throw_sql_exception_when_datediff_is_zero(int version)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            static void _() => db.SelectOne(
+                    db.fx.Max(dbo.Person.CreditLimit) % db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value)
+                .Execute();
+
+            //when               
+            var result = Assert.ThrowsAny<Exception>(_);
+
+            //then
+            result.Should().BeOfType<SqlException>();
+            result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_maximum_of_credit_limit_modulus_of_datediff_of_purchase_date_and_date_created_throw_sql_exception_when_datediff_is_zero(int version)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            static void _() => db.SelectOne(
+                    db.fx.Max(dbo.Person.CreditLimit) % db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value)
+                .Execute();
+
+            //when               
+            var result = Assert.ThrowsAny<Exception>(_);
+
+            //then
+            result.Should().BeOfType<SqlException>();
+            result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_maximum_of_quantity_modulus_of_datediff_of_purchase_date_and_date_created_throw_sql_exception_when_datediff_is_zero(int version)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            static void _() => db.SelectOne(
+                    db.fx.Max(dbo.PurchaseLine.Quantity) % db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value)
+                .Execute();
+
+            //when               
+            var result = Assert.ThrowsAny<Exception>(_);
+
+            //then
+            result.Should().BeOfType<SqlException>();
+            result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
+        }
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/DateDiffAndMinimum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/DateDiffAndMinimum.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using System.Data.SqlClient;
 using Xunit;
@@ -49,492 +49,472 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             result.Should().Be(expected);
         }
 
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_minimum_of_quantity_added_to_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 1)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Min(dbo.PurchaseLine.Quantity) + db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_minimum_of_credit_limit_added_to_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 10000)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Min(dbo.Person.CreditLimit) + db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_minimum_of_credit_limit_added_to_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 10000)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Min(dbo.Person.CreditLimit) + db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_minimum_of_quantity_added_to_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 1)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Min(dbo.PurchaseLine.Quantity) + db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_minimum_of_quantity_minus_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 1)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Min(dbo.PurchaseLine.Quantity) - db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_minimum_of_credit_limit_minus_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 10000)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Min(dbo.Person.CreditLimit) - db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_minimum_of_credit_limit_minus_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 10000)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Min(dbo.Person.CreditLimit) - db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_minimum_of_quantity_minus_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 1)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Min(dbo.PurchaseLine.Quantity) - db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_minimum_of_quantity_multiplied_by_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 0)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Min(dbo.PurchaseLine.Quantity) * db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_minimum_of_credit_limit_multiplied_by_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 0)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Min(dbo.Person.CreditLimit) * db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_minimum_of_credit_limit_multiplied_by_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 0)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Min(dbo.Person.CreditLimit) * db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_minimum_of_quantity_multiplied_by_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 0)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    var exp = db.SelectOne(
-        //            db.fx.Min(dbo.PurchaseLine.Quantity) * db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value);
-
-        //    //when               
-        //    int? result = exp.Execute();
-
-        //    //then
-        //    result.Should().NotBeNull();
-        //    result.Value.Should().Be(expected);
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_minimum_of_quantity_divided_by_datediff_of_purchase_date_and_ship_date_succeed(int version)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    static void _() => db.SelectOne(
-        //            db.fx.Min(dbo.PurchaseLine.Quantity) / db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value)
-        //        .Execute();
-
-        //    //when               
-        //    var result = Assert.ThrowsAny<Exception>(_);
-
-        //    //then
-        //    result.Should().BeOfType<SqlException>();
-        //    result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_minimum_of_credit_limit_divided_by_datediff_of_purchase_date_and_ship_date_succeed(int version)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    static void _() => db.SelectOne(
-        //            db.fx.Min(dbo.Person.CreditLimit) / db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value)
-        //        .Execute();
-
-        //    //when               
-        //    var result = Assert.ThrowsAny<Exception>(_);
-
-        //    //then
-        //    result.Should().BeOfType<SqlException>();
-        //    result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_minimum_of_credit_limit_divided_by_datediff_of_purchase_date_and_date_created_succeed(int version)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    static void _() => db.SelectOne(
-        //            db.fx.Min(dbo.Person.CreditLimit) / db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value)
-        //        .Execute();
-
-        //    //when               
-        //    var result = Assert.ThrowsAny<Exception>(_);
-
-        //    //then
-        //    result.Should().BeOfType<SqlException>();
-        //    result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_minimum_of_quantity_divided_by_datediff_of_purchase_date_and_date_created_succeed(int version)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    static void _() => db.SelectOne(
-        //            db.fx.Min(dbo.PurchaseLine.Quantity) / db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value)
-        //        .Execute();
-
-        //    //when               
-        //    var result = Assert.ThrowsAny<Exception>(_);
-
-        //    //then
-        //    result.Should().BeOfType<SqlException>();
-        //    result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_minimum_of_quantity_modulus_of_datediff_of_purchase_date_and_ship_date_succeed(int version)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    static void _() => db.SelectOne(
-        //            db.fx.Min(dbo.PurchaseLine.Quantity) % db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value)
-        //        .Execute();
-
-        //    //when               
-        //    var result = Assert.ThrowsAny<Exception>(_);
-
-        //    //then
-        //    result.Should().BeOfType<SqlException>();
-        //    result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_minimum_of_credit_limit_modulus_of_datediff_of_purchase_date_and_ship_date_succeed(int version)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    static void _() => db.SelectOne(
-        //            db.fx.Min(dbo.Person.CreditLimit) % db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value)
-        //        .Execute();
-
-        //    //when               
-        //    var result = Assert.ThrowsAny<Exception>(_);
-
-        //    //then
-        //    result.Should().BeOfType<SqlException>();
-        //    result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_minimum_of_credit_limit_modulus_of_datediff_of_purchase_date_and_date_created_succeed(int version)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    static void _() => db.SelectOne(
-        //            db.fx.Min(dbo.Person.CreditLimit) % db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value)
-        //        .Execute();
-
-        //    //when               
-        //    var result = Assert.ThrowsAny<Exception>(_);
-
-        //    //then
-        //    result.Should().BeOfType<SqlException>();
-        //    result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
-        //}
-
-        //MILESTONE: Function Arithmetic
-        //[Theory]
-        //[MsSqlVersions.AllVersions]
-        //[Trait("Operation", "GROUP BY")]
-        //public void Does_selecting_minimum_of_quantity_modulus_of_datediff_of_purchase_date_and_date_created_succeed(int version)
-        //{
-        //    //given
-        //    ConfigureForMsSqlVersion(version);
-
-        //    static void _() => db.SelectOne(
-        //            db.fx.Min(dbo.PurchaseLine.Quantity) % db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
-        //        ).From(dbo.Purchase)
-        //        .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
-        //        .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
-        //        .Where(dbo.Purchase.ShipDate != DBNull.Value)
-        //        .Execute();
-
-        //    //when               
-        //    var result = Assert.ThrowsAny<Exception>(_);
-
-        //    //then
-        //    result.Should().BeOfType<SqlException>();
-        //    result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
-        //}
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_minimum_of_quantity_added_to_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 1)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Min(dbo.PurchaseLine.Quantity) + db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_minimum_of_credit_limit_added_to_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 10000)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Min(dbo.Person.CreditLimit) + db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_minimum_of_credit_limit_added_to_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 10000)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Min(dbo.Person.CreditLimit) + db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_minimum_of_quantity_added_to_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 1)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Min(dbo.PurchaseLine.Quantity) + db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_minimum_of_quantity_minus_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 1)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Min(dbo.PurchaseLine.Quantity) - db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_minimum_of_credit_limit_minus_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 10000)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Min(dbo.Person.CreditLimit) - db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_minimum_of_credit_limit_minus_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 10000)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Min(dbo.Person.CreditLimit) - db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_minimum_of_quantity_minus_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 1)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Min(dbo.PurchaseLine.Quantity) - db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_minimum_of_quantity_multiplied_by_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 0)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Min(dbo.PurchaseLine.Quantity) * db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_minimum_of_credit_limit_multiplied_by_datediff_of_purchase_date_and_ship_date_succeed(int version, int expected = 0)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Min(dbo.Person.CreditLimit) * db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_minimum_of_credit_limit_multiplied_by_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 0)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Min(dbo.Person.CreditLimit) * db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_minimum_of_quantity_multiplied_by_datediff_of_purchase_date_and_date_created_succeed(int version, int expected = 0)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(
+                    db.fx.Min(dbo.PurchaseLine.Quantity) * db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value);
+
+            //when               
+            int? result = exp.Execute();
+
+            //then
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_minimum_of_quantity_divided_by_datediff_of_purchase_date_and_ship_date_succeed(int version)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            static void _() => db.SelectOne(
+                    db.fx.Min(dbo.PurchaseLine.Quantity) / db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value)
+                .Execute();
+
+            //when               
+            var result = Assert.ThrowsAny<Exception>(_);
+
+            //then
+            result.Should().BeOfType<SqlException>();
+            result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_minimum_of_credit_limit_divided_by_datediff_of_purchase_date_and_ship_date_succeed(int version)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            static void _() => db.SelectOne(
+                    db.fx.Min(dbo.Person.CreditLimit) / db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value)
+                .Execute();
+
+            //when               
+            var result = Assert.ThrowsAny<Exception>(_);
+
+            //then
+            result.Should().BeOfType<SqlException>();
+            result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_minimum_of_credit_limit_divided_by_datediff_of_purchase_date_and_date_created_succeed(int version)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            static void _() => db.SelectOne(
+                    db.fx.Min(dbo.Person.CreditLimit) / db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value)
+                .Execute();
+
+            //when               
+            var result = Assert.ThrowsAny<Exception>(_);
+
+            //then
+            result.Should().BeOfType<SqlException>();
+            result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_minimum_of_quantity_divided_by_datediff_of_purchase_date_and_date_created_succeed(int version)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            static void _() => db.SelectOne(
+                    db.fx.Min(dbo.PurchaseLine.Quantity) / db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value)
+                .Execute();
+
+            //when               
+            var result = Assert.ThrowsAny<Exception>(_);
+
+            //then
+            result.Should().BeOfType<SqlException>();
+            result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_minimum_of_quantity_modulus_of_datediff_of_purchase_date_and_ship_date_succeed(int version)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            static void _() => db.SelectOne(
+                    db.fx.Min(dbo.PurchaseLine.Quantity) % db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value)
+                .Execute();
+
+            //when               
+            var result = Assert.ThrowsAny<Exception>(_);
+
+            //then
+            result.Should().BeOfType<SqlException>();
+            result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_minimum_of_credit_limit_modulus_of_datediff_of_purchase_date_and_ship_date_succeed(int version)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            static void _() => db.SelectOne(
+                    db.fx.Min(dbo.Person.CreditLimit) % db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.ShipDate))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value)
+                .Execute();
+
+            //when               
+            var result = Assert.ThrowsAny<Exception>(_);
+
+            //then
+            result.Should().BeOfType<SqlException>();
+            result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_minimum_of_credit_limit_modulus_of_datediff_of_purchase_date_and_date_created_succeed(int version)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            static void _() => db.SelectOne(
+                    db.fx.Min(dbo.Person.CreditLimit) % db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.Person).On(dbo.Purchase.PersonId == dbo.Person.Id)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value)
+                .Execute();
+
+            //when               
+            var result = Assert.ThrowsAny<Exception>(_);
+
+            //then
+            result.Should().BeOfType<SqlException>();
+            result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public void Does_selecting_minimum_of_quantity_modulus_of_datediff_of_purchase_date_and_date_created_succeed(int version)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            static void _() => db.SelectOne(
+                    db.fx.Min(dbo.PurchaseLine.Quantity) % db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated)
+                ).From(dbo.Purchase)
+                .InnerJoin(dbo.PurchaseLine).On(dbo.Purchase.Id == dbo.PurchaseLine.PurchaseId)
+                .GroupBy(db.fx.DateDiff(DateParts.Year, dbo.Purchase.PurchaseDate, dbo.Purchase.DateCreated))
+                .Where(dbo.Purchase.ShipDate != DBNull.Value)
+                .Execute();
+
+            //when               
+            var result = Assert.ThrowsAny<Exception>(_);
+
+            //then
+            result.Should().BeOfType<SqlException>();
+            result.As<SqlException>().Message.Should().Be("Divide by zero error encountered.");
+        }
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/DatePartAndMaximum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/DatePartAndMaximum.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/DatePartAndMinimum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/DatePartAndMinimum.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndAverage.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndAverage.cs
@@ -1,8 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
-using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndCount.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndCount.cs
@@ -1,8 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
-using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndDateAdd.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndDateAdd.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndDateDiff.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndDateDiff.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System.Collections.Generic;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndDatePart.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndDatePart.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System.Collections.Generic;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndMaximum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndMaximum.cs
@@ -1,10 +1,8 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
-using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndMinimum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndMinimum.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndPopulationStandardDeviation.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndPopulationStandardDeviation.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndPopulationVariance.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndPopulationVariance.cs
@@ -1,7 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndStandardDeviation.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndStandardDeviation.cs
@@ -1,9 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
-using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndSum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndSum.cs
@@ -1,7 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndVariance.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/_Interactions/IsNullAndVariance.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Insert/Insert.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Insert/Insert.cs
@@ -3,7 +3,7 @@ using DbEx.Data.dbo;
 using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Select/SelectMany.InnerJoin.GroupBy.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Select/SelectMany.InnerJoin.GroupBy.cs
@@ -2,7 +2,7 @@
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Expression;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using System.Linq;
 using Xunit;

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Select/SelectMany.InnerJoin.Subquery.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Select/SelectMany.InnerJoin.Subquery.cs
@@ -1,8 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System.Data.SqlClient;
+using HatTrick.DbEx.Sql;
 using System.Linq;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Select/SelectMany.InnerJoin.Where.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Select/SelectMany.InnerJoin.Where.cs
@@ -2,7 +2,7 @@
 using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Select/SelectMany.InnerJoin.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Select/SelectMany.InnerJoin.cs
@@ -1,9 +1,7 @@
-﻿using DbEx.Data;
-using DbEx.DataService;
+﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
-using System.Linq;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Select/SelectMany.MultiSchema.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Select/SelectMany.MultiSchema.cs
@@ -1,7 +1,7 @@
 ﻿using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Select/SelectMany.Where.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Select/SelectMany.Where.cs
@@ -2,7 +2,7 @@
 using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using Xunit;
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Select/SelectMany.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Select/SelectMany.cs
@@ -2,7 +2,7 @@
 using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_SelectOne/SelectOne.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_SelectOne/SelectOne.cs
@@ -2,7 +2,7 @@
 using DbEx.DataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System;
 using System.Linq;
 using System.Threading.Tasks;

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Update/Update.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Update/Update.cs
@@ -1,5 +1,5 @@
 ﻿using DbEx.DataService;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using Xunit;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Random.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Random.cs
@@ -1,9 +1,7 @@
-﻿using DbEx.Data.dbo;
-using DbEx.DataService;
+﻿using DbEx.DataService;
 using FluentAssertions;
-using HatTrick.DbEx.MsSql.Test.Database.Executor;
 using HatTrick.DbEx.MsSql.Test.Executor;
-using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql;
 using System.Linq;
 using Xunit;
 


### PR DESCRIPTION
…an extra using statement to use DbExpression.  Included unit tests that were previously commented out.