### PR TITLE
ExpressionMediators -> FilterExpressions (via operator overloads), ExpressionMediators return new instances when aliasing

### DIFF
--- a/samples/mssql/ServerSideBlazorApp/Data/_Generated/EntityProvider.cs
+++ b/samples/mssql/ServerSideBlazorApp/Data/_Generated/EntityProvider.cs
@@ -9,7 +9,7 @@ namespace ServerSideBlazorApp.dboDataService
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
         #region internals
-        private static readonly dboSchemaExpression _schema = new dboSchemaExpression("MsSqlDbExTest.dbo");
+        private static readonly dboSchemaExpression _schema = new dboSchemaExpression("dbo");
         #endregion
 
         #region interface
@@ -41,7 +41,7 @@ namespace ServerSideBlazorApp.secDataService
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
         #region internals
-        private static readonly secSchemaExpression _schema = new secSchemaExpression("MsSqlDbExTest.sec");
+        private static readonly secSchemaExpression _schema = new secSchemaExpression("sec");
         #endregion
 
         #region interface

--- a/samples/mssql/ServerSideBlazorApp/Data/_Generated/Metadata.cs
+++ b/samples/mssql/ServerSideBlazorApp/Data/_Generated/Metadata.cs
@@ -7,7 +7,7 @@ namespace ServerSideBlazorApp.DataService
 
     public class CRMDatabase : RuntimeEnvironmentSqlDatabase
     {
-        public CRMDatabase() : base(new db(), new SqlDatabaseMetadataProvider(new CRMDatabaseSqlDatabaseMetadata("CRMDatabase", "CRMDatabase"))) 
+        public CRMDatabase() : base(new db(), new SqlDatabaseMetadataProvider(new CRMDatabaseSqlDatabaseMetadata("MsSqlDbExTest", "CRMDatabase"))) 
         { 
         
         }
@@ -15,11 +15,6 @@ namespace ServerSideBlazorApp.DataService
 
     public class CRMDatabaseSqlDatabaseMetadata : ISqlDatabaseMetadata
     {
-        #region internals
-        private static string _dboSchemaIdentifier;
-        private static string _secSchemaIdentifier;
-        #endregion
-
         #region interface
         public string Identifier { get; private set; }
         public string Name { get; private set; }
@@ -31,8 +26,8 @@ namespace ServerSideBlazorApp.DataService
         {
             Identifier = identifier;
             Name = name;
-            Schemas.Add(_dboSchemaIdentifier = $"{identifier}.dbo", new dboSchemaMetadata(this, _dboSchemaIdentifier, "dbo"));
-            Schemas.Add(_secSchemaIdentifier = $"{identifier}.sec", new secSchemaMetadata(this, _secSchemaIdentifier, "sec"));
+            Schemas.Add("dbo", new dboSchemaMetadata(this, "dbo", "dbo"));
+            Schemas.Add("sec", new secSchemaMetadata(this, "sec", "sec"));
         }
         #endregion
     }

--- a/samples/mssql/ServerSideBlazorApp/Models/CustomerSummaryModel.cs
+++ b/samples/mssql/ServerSideBlazorApp/Models/CustomerSummaryModel.cs
@@ -1,4 +1,6 @@
-﻿namespace ServerSideBlazorApp.Models
+﻿using System.Collections;
+
+namespace ServerSideBlazorApp.Models
 {
     public class CustomerSummaryModel
     {

--- a/samples/mssql/ServerSideBlazorApp/PageModel.cs
+++ b/samples/mssql/ServerSideBlazorApp/PageModel.cs
@@ -32,9 +32,13 @@ namespace ServerSideBlazorApp
     }
 
     public class PageResponseModel<T> : PageModel
-    { 
-        public IEnumerable<T> Page { get; set; }
+    {
+        public IEnumerable<T> Page { get; set; } = new List<T>();
         public int TotalCount { get; set; }
+
+        public PageResponseModel()
+        { 
+        }
 
         public PageResponseModel(int offset, int limit, string searchPhrase, IEnumerable<T> page, int totalCount) : base(offset, limit, searchPhrase)
         {

--- a/samples/mssql/ServerSideBlazorApp/Pages/Customers.cs
+++ b/samples/mssql/ServerSideBlazorApp/Pages/Customers.cs
@@ -1,0 +1,50 @@
+﻿using MatBlazor;
+using ServerSideBlazorApp.Models;
+using System;
+using System.Threading.Tasks;
+
+namespace ServerSideBlazorApp.Pages
+{
+    public partial class Customers
+    {
+        private int PageIndex { get; set; } = 0;
+        private int PageSize { get; set; } = 5;
+        private string SearchPhrase { get; set; }
+        private PageResponseModel<CustomerSummaryModel> CurrentPage { get; set; } = new PageResponseModel<CustomerSummaryModel>();
+
+        protected override async Task OnInitializedAsync() => await FetchCurrentPage();
+
+        private async Task FetchCurrentPage()
+        {
+            await ProgressBar.Show();
+
+            var model = new PageRequestModel { Limit = PageSize, Offset = PageIndex * PageSize, SearchPhrase = SearchPhrase };
+
+            try
+            {
+                CurrentPage = await service.GetSummaryPageAsync(model);
+            }
+            finally
+            {
+                await ProgressBar.Hide();
+            }
+
+            StateHasChanged();
+        }
+
+        private async Task OnPage(MatPaginatorPageEvent e)
+        {
+            PageSize = e.PageSize;
+            PageIndex = e.PageIndex;
+            await FetchCurrentPage();
+            StateHasChanged();
+        }
+
+        private async Task OnPage(int index)
+        {
+            PageIndex = index;
+            await FetchCurrentPage();
+            StateHasChanged();
+        }
+    }
+}

--- a/samples/mssql/ServerSideBlazorApp/Pages/Customers.razor
+++ b/samples/mssql/ServerSideBlazorApp/Pages/Customers.razor
@@ -2,11 +2,11 @@
 @inject GlobalProgressBar ProgressBar
 @inject CustomerService service
 
-<h3>PeopleList</h3>
+<h3>Customers</h3>
 
 <div>
     <GridLoading RecordCount="@(CurrentPage?.TotalCount)"></GridLoading>
-    @if (CurrentPage is object && CurrentPage.Page.Any())
+    @if (CurrentPage.Page.Any())
     {
         <MatCard>
             <MatCardContent Class="m-4">
@@ -38,46 +38,5 @@
 
 
 @code {
-    private int PageIndex { get; set; } = 0;
-    private int PageSize { get; set; } = 5;
-    private string SearchPhrase { get; set; }
-    private PageResponseModel<dynamic> CurrentPage { get; set; }
-
-    protected override async Task OnInitializedAsync() => await FetchCurrentPage();
-
-    private async Task FetchCurrentPage()
-    {
-        await ProgressBar.Show();
-        var model = new PageRequestModel { Limit = PageSize, Offset = PageIndex * PageSize, SearchPhrase = SearchPhrase };
-
-        try
-        {
-            CurrentPage = await service.GetSummaryPageAsync(model);
-        }
-        catch (Exception e)
-        {
-
-        }
-        finally
-        {
-            await ProgressBar.Hide();
-        }
-
-        StateHasChanged();
-    }
-
-    private async Task OnPage(MatPaginatorPageEvent e)
-    {
-        PageSize = e.PageSize;
-        PageIndex = e.PageIndex;
-        await FetchCurrentPage();
-        StateHasChanged();
-    }
-
-    private async Task OnPage(int index)
-    {
-        PageIndex = index;
-        await FetchCurrentPage();
-        StateHasChanged();
-    }
+    
 }

--- a/src/HatTrick.DbEx.Sql/Expression/ArithmeticExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/ArithmeticExpression.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using HatTrick.DbEx.Sql.Attribute;
+using System;
 
 namespace HatTrick.DbEx.Sql.Expression
 {
@@ -22,7 +23,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region to string
-        public override string ToString() => $"({LeftArg} {ExpressionOperator} {RightArg})";
+        public override string ToString() => $"({LeftArg} {ExpressionOperator.GetArithmeticOperator()} {RightArg})";
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/DatePartsExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/DatePartsExpression.cs
@@ -16,6 +16,10 @@ namespace HatTrick.DbEx.Sql.Expression
         }
         #endregion
 
+        #region to string
+        public override string ToString() => Expression.ToString() ?? string.Empty;
+        #endregion
+
         #region equals
         public bool Equals(DatePartsExpression obj)
         {

--- a/src/HatTrick.DbEx.Sql/Expression/LiteralExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/LiteralExpression.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 namespace HatTrick.DbEx.Sql.Expression
 {
@@ -20,7 +21,19 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region tostring
-        public override string ToString() => Expression?.ToString() ?? "null";
+        public override string ToString()
+        {
+            if (Expression is null)
+                return "null";
+
+            if (!(Expression is string))
+                return Expression.ToString();
+
+            string exp = Expression as string;
+            if (exp.All(char.IsWhiteSpace)) return $"'{Expression}'";
+
+            return Expression.ToString();
+        }
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/BooleanExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/BooleanExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public BooleanExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected BooleanExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new BooleanExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new BooleanExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/BooleanExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/BooleanExpressionMediator.generated.cs
@@ -17,5 +17,49 @@ namespace HatTrick.DbEx.Sql.Expression
         #region mediator
         #endregion
         #endregion
+
+        #region filter operators
+        public static FilterExpression<bool> operator ==(BooleanExpressionMediator a, bool b) => new FilterExpression<bool>(a, new BooleanExpressionMediator(new LiteralExpression<bool>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(BooleanExpressionMediator a, bool b) => new FilterExpression<bool>(a, new BooleanExpressionMediator(new LiteralExpression<bool>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(BooleanExpressionMediator a, bool b) => new FilterExpression<bool>(a, new BooleanExpressionMediator(new LiteralExpression<bool>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(BooleanExpressionMediator a, bool b) => new FilterExpression<bool>(a, new BooleanExpressionMediator(new LiteralExpression<bool>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(BooleanExpressionMediator a, bool b) => new FilterExpression<bool>(a, new BooleanExpressionMediator(new LiteralExpression<bool>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(BooleanExpressionMediator a, bool b) => new FilterExpression<bool>(a, new BooleanExpressionMediator(new LiteralExpression<bool>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(bool a, BooleanExpressionMediator b) => new FilterExpression<bool>(new BooleanExpressionMediator(new LiteralExpression<bool>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(bool a, BooleanExpressionMediator b) => new FilterExpression<bool>(new BooleanExpressionMediator(new LiteralExpression<bool>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(bool a, BooleanExpressionMediator b) => new FilterExpression<bool>(new BooleanExpressionMediator(new LiteralExpression<bool>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(bool a, BooleanExpressionMediator b) => new FilterExpression<bool>(new BooleanExpressionMediator(new LiteralExpression<bool>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(bool a, BooleanExpressionMediator b) => new FilterExpression<bool>(new BooleanExpressionMediator(new LiteralExpression<bool>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(bool a, BooleanExpressionMediator b) => new FilterExpression<bool>(new BooleanExpressionMediator(new LiteralExpression<bool>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(BooleanExpressionMediator a, bool? b) => new FilterExpression<bool>(a, new BooleanExpressionMediator(new LiteralExpression<bool?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(BooleanExpressionMediator a, bool? b) => new FilterExpression<bool>(a, new BooleanExpressionMediator(new LiteralExpression<bool?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(BooleanExpressionMediator a, bool? b) => new FilterExpression<bool>(a, new BooleanExpressionMediator(new LiteralExpression<bool?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(BooleanExpressionMediator a, bool? b) => new FilterExpression<bool>(a, new BooleanExpressionMediator(new LiteralExpression<bool?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(BooleanExpressionMediator a, bool? b) => new FilterExpression<bool>(a, new BooleanExpressionMediator(new LiteralExpression<bool?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(BooleanExpressionMediator a, bool? b) => new FilterExpression<bool>(a, new BooleanExpressionMediator(new LiteralExpression<bool?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(bool? a, BooleanExpressionMediator b) => new FilterExpression<bool>(new BooleanExpressionMediator(new LiteralExpression<bool?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(bool? a, BooleanExpressionMediator b) => new FilterExpression<bool>(new BooleanExpressionMediator(new LiteralExpression<bool?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(bool? a, BooleanExpressionMediator b) => new FilterExpression<bool>(new BooleanExpressionMediator(new LiteralExpression<bool?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(bool? a, BooleanExpressionMediator b) => new FilterExpression<bool>(new BooleanExpressionMediator(new LiteralExpression<bool?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(bool? a, BooleanExpressionMediator b) => new FilterExpression<bool>(new BooleanExpressionMediator(new LiteralExpression<bool?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(bool? a, BooleanExpressionMediator b) => new FilterExpression<bool>(new BooleanExpressionMediator(new LiteralExpression<bool?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(BooleanExpressionMediator a, BooleanExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(BooleanExpressionMediator a, BooleanExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(BooleanExpressionMediator a, BooleanExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(BooleanExpressionMediator a, BooleanExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(BooleanExpressionMediator a, BooleanExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(BooleanExpressionMediator a, BooleanExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(BooleanExpressionMediator a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(BooleanExpressionMediator a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(BooleanExpressionMediator a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(BooleanExpressionMediator a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(BooleanExpressionMediator a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(BooleanExpressionMediator a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/ByteExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/ByteExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public ByteExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected ByteExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new ByteExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new ByteExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/ByteExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/ByteExpressionMediator.generated.cs
@@ -384,5 +384,49 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #endregion
         #endregion
+
+        #region filter operators
+        public static FilterExpression<bool> operator ==(ByteExpressionMediator a, byte b) => new FilterExpression<bool>(a, new ByteExpressionMediator(new LiteralExpression<byte>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(ByteExpressionMediator a, byte b) => new FilterExpression<bool>(a, new ByteExpressionMediator(new LiteralExpression<byte>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(ByteExpressionMediator a, byte b) => new FilterExpression<bool>(a, new ByteExpressionMediator(new LiteralExpression<byte>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(ByteExpressionMediator a, byte b) => new FilterExpression<bool>(a, new ByteExpressionMediator(new LiteralExpression<byte>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(ByteExpressionMediator a, byte b) => new FilterExpression<bool>(a, new ByteExpressionMediator(new LiteralExpression<byte>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(ByteExpressionMediator a, byte b) => new FilterExpression<bool>(a, new ByteExpressionMediator(new LiteralExpression<byte>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(byte a, ByteExpressionMediator b) => new FilterExpression<bool>(new ByteExpressionMediator(new LiteralExpression<byte>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(byte a, ByteExpressionMediator b) => new FilterExpression<bool>(new ByteExpressionMediator(new LiteralExpression<byte>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(byte a, ByteExpressionMediator b) => new FilterExpression<bool>(new ByteExpressionMediator(new LiteralExpression<byte>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(byte a, ByteExpressionMediator b) => new FilterExpression<bool>(new ByteExpressionMediator(new LiteralExpression<byte>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(byte a, ByteExpressionMediator b) => new FilterExpression<bool>(new ByteExpressionMediator(new LiteralExpression<byte>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(byte a, ByteExpressionMediator b) => new FilterExpression<bool>(new ByteExpressionMediator(new LiteralExpression<byte>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(ByteExpressionMediator a, byte? b) => new FilterExpression<bool>(a, new ByteExpressionMediator(new LiteralExpression<byte?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(ByteExpressionMediator a, byte? b) => new FilterExpression<bool>(a, new ByteExpressionMediator(new LiteralExpression<byte?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(ByteExpressionMediator a, byte? b) => new FilterExpression<bool>(a, new ByteExpressionMediator(new LiteralExpression<byte?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(ByteExpressionMediator a, byte? b) => new FilterExpression<bool>(a, new ByteExpressionMediator(new LiteralExpression<byte?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(ByteExpressionMediator a, byte? b) => new FilterExpression<bool>(a, new ByteExpressionMediator(new LiteralExpression<byte?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(ByteExpressionMediator a, byte? b) => new FilterExpression<bool>(a, new ByteExpressionMediator(new LiteralExpression<byte?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(byte? a, ByteExpressionMediator b) => new FilterExpression<bool>(new ByteExpressionMediator(new LiteralExpression<byte?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(byte? a, ByteExpressionMediator b) => new FilterExpression<bool>(new ByteExpressionMediator(new LiteralExpression<byte?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(byte? a, ByteExpressionMediator b) => new FilterExpression<bool>(new ByteExpressionMediator(new LiteralExpression<byte?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(byte? a, ByteExpressionMediator b) => new FilterExpression<bool>(new ByteExpressionMediator(new LiteralExpression<byte?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(byte? a, ByteExpressionMediator b) => new FilterExpression<bool>(new ByteExpressionMediator(new LiteralExpression<byte?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(byte? a, ByteExpressionMediator b) => new FilterExpression<bool>(new ByteExpressionMediator(new LiteralExpression<byte?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(ByteExpressionMediator a, ByteExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(ByteExpressionMediator a, ByteExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(ByteExpressionMediator a, ByteExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(ByteExpressionMediator a, ByteExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(ByteExpressionMediator a, ByteExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(ByteExpressionMediator a, ByteExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(ByteExpressionMediator a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(ByteExpressionMediator a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(ByteExpressionMediator a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(ByteExpressionMediator a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(ByteExpressionMediator a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(ByteExpressionMediator a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/DateTimeExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/DateTimeExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public DateTimeExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected DateTimeExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new DateTimeExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new DateTimeExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/DateTimeExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/DateTimeExpressionMediator.generated.cs
@@ -224,5 +224,49 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #endregion
         #endregion
+
+        #region filter operators
+        public static FilterExpression<bool> operator ==(DateTimeExpressionMediator a, DateTime b) => new FilterExpression<bool>(a, new DateTimeExpressionMediator(new LiteralExpression<DateTime>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(DateTimeExpressionMediator a, DateTime b) => new FilterExpression<bool>(a, new DateTimeExpressionMediator(new LiteralExpression<DateTime>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(DateTimeExpressionMediator a, DateTime b) => new FilterExpression<bool>(a, new DateTimeExpressionMediator(new LiteralExpression<DateTime>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(DateTimeExpressionMediator a, DateTime b) => new FilterExpression<bool>(a, new DateTimeExpressionMediator(new LiteralExpression<DateTime>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(DateTimeExpressionMediator a, DateTime b) => new FilterExpression<bool>(a, new DateTimeExpressionMediator(new LiteralExpression<DateTime>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(DateTimeExpressionMediator a, DateTime b) => new FilterExpression<bool>(a, new DateTimeExpressionMediator(new LiteralExpression<DateTime>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(DateTime a, DateTimeExpressionMediator b) => new FilterExpression<bool>(new DateTimeExpressionMediator(new LiteralExpression<DateTime>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(DateTime a, DateTimeExpressionMediator b) => new FilterExpression<bool>(new DateTimeExpressionMediator(new LiteralExpression<DateTime>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(DateTime a, DateTimeExpressionMediator b) => new FilterExpression<bool>(new DateTimeExpressionMediator(new LiteralExpression<DateTime>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(DateTime a, DateTimeExpressionMediator b) => new FilterExpression<bool>(new DateTimeExpressionMediator(new LiteralExpression<DateTime>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(DateTime a, DateTimeExpressionMediator b) => new FilterExpression<bool>(new DateTimeExpressionMediator(new LiteralExpression<DateTime>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(DateTime a, DateTimeExpressionMediator b) => new FilterExpression<bool>(new DateTimeExpressionMediator(new LiteralExpression<DateTime>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(DateTimeExpressionMediator a, DateTime? b) => new FilterExpression<bool>(a, new DateTimeExpressionMediator(new LiteralExpression<DateTime?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(DateTimeExpressionMediator a, DateTime? b) => new FilterExpression<bool>(a, new DateTimeExpressionMediator(new LiteralExpression<DateTime?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(DateTimeExpressionMediator a, DateTime? b) => new FilterExpression<bool>(a, new DateTimeExpressionMediator(new LiteralExpression<DateTime?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(DateTimeExpressionMediator a, DateTime? b) => new FilterExpression<bool>(a, new DateTimeExpressionMediator(new LiteralExpression<DateTime?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(DateTimeExpressionMediator a, DateTime? b) => new FilterExpression<bool>(a, new DateTimeExpressionMediator(new LiteralExpression<DateTime?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(DateTimeExpressionMediator a, DateTime? b) => new FilterExpression<bool>(a, new DateTimeExpressionMediator(new LiteralExpression<DateTime?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(DateTime? a, DateTimeExpressionMediator b) => new FilterExpression<bool>(new DateTimeExpressionMediator(new LiteralExpression<DateTime?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(DateTime? a, DateTimeExpressionMediator b) => new FilterExpression<bool>(new DateTimeExpressionMediator(new LiteralExpression<DateTime?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(DateTime? a, DateTimeExpressionMediator b) => new FilterExpression<bool>(new DateTimeExpressionMediator(new LiteralExpression<DateTime?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(DateTime? a, DateTimeExpressionMediator b) => new FilterExpression<bool>(new DateTimeExpressionMediator(new LiteralExpression<DateTime?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(DateTime? a, DateTimeExpressionMediator b) => new FilterExpression<bool>(new DateTimeExpressionMediator(new LiteralExpression<DateTime?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(DateTime? a, DateTimeExpressionMediator b) => new FilterExpression<bool>(new DateTimeExpressionMediator(new LiteralExpression<DateTime?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(DateTimeExpressionMediator a, DateTimeExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(DateTimeExpressionMediator a, DateTimeExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(DateTimeExpressionMediator a, DateTimeExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(DateTimeExpressionMediator a, DateTimeExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(DateTimeExpressionMediator a, DateTimeExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(DateTimeExpressionMediator a, DateTimeExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(DateTimeExpressionMediator a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(DateTimeExpressionMediator a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(DateTimeExpressionMediator a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(DateTimeExpressionMediator a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(DateTimeExpressionMediator a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(DateTimeExpressionMediator a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/DateTimeOffsetExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/DateTimeOffsetExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public DateTimeOffsetExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected DateTimeOffsetExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new DateTimeOffsetExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new DateTimeOffsetExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/DateTimeOffsetExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/DateTimeOffsetExpressionMediator.generated.cs
@@ -224,5 +224,49 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #endregion
         #endregion
+
+        #region filter operators
+        public static FilterExpression<bool> operator ==(DateTimeOffsetExpressionMediator a, DateTimeOffset b) => new FilterExpression<bool>(a, new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(DateTimeOffsetExpressionMediator a, DateTimeOffset b) => new FilterExpression<bool>(a, new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(DateTimeOffsetExpressionMediator a, DateTimeOffset b) => new FilterExpression<bool>(a, new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(DateTimeOffsetExpressionMediator a, DateTimeOffset b) => new FilterExpression<bool>(a, new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(DateTimeOffsetExpressionMediator a, DateTimeOffset b) => new FilterExpression<bool>(a, new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(DateTimeOffsetExpressionMediator a, DateTimeOffset b) => new FilterExpression<bool>(a, new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(DateTimeOffset a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool>(new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(DateTimeOffset a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool>(new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(DateTimeOffset a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool>(new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(DateTimeOffset a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool>(new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(DateTimeOffset a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool>(new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(DateTimeOffset a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool>(new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(DateTimeOffsetExpressionMediator a, DateTimeOffset? b) => new FilterExpression<bool>(a, new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(DateTimeOffsetExpressionMediator a, DateTimeOffset? b) => new FilterExpression<bool>(a, new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(DateTimeOffsetExpressionMediator a, DateTimeOffset? b) => new FilterExpression<bool>(a, new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(DateTimeOffsetExpressionMediator a, DateTimeOffset? b) => new FilterExpression<bool>(a, new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(DateTimeOffsetExpressionMediator a, DateTimeOffset? b) => new FilterExpression<bool>(a, new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(DateTimeOffsetExpressionMediator a, DateTimeOffset? b) => new FilterExpression<bool>(a, new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(DateTimeOffset? a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool>(new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(DateTimeOffset? a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool>(new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(DateTimeOffset? a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool>(new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(DateTimeOffset? a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool>(new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(DateTimeOffset? a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool>(new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(DateTimeOffset? a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool>(new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(DateTimeOffsetExpressionMediator a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(DateTimeOffsetExpressionMediator a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(DateTimeOffsetExpressionMediator a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(DateTimeOffsetExpressionMediator a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(DateTimeOffsetExpressionMediator a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(DateTimeOffsetExpressionMediator a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(DateTimeOffsetExpressionMediator a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(DateTimeOffsetExpressionMediator a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(DateTimeOffsetExpressionMediator a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(DateTimeOffsetExpressionMediator a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(DateTimeOffsetExpressionMediator a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(DateTimeOffsetExpressionMediator a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/DecimalExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/DecimalExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public DecimalExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected DecimalExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new DecimalExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new DecimalExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/DecimalExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/DecimalExpressionMediator.generated.cs
@@ -384,5 +384,49 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #endregion
         #endregion
+
+        #region filter operators
+        public static FilterExpression<bool> operator ==(DecimalExpressionMediator a, decimal b) => new FilterExpression<bool>(a, new DecimalExpressionMediator(new LiteralExpression<decimal>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(DecimalExpressionMediator a, decimal b) => new FilterExpression<bool>(a, new DecimalExpressionMediator(new LiteralExpression<decimal>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(DecimalExpressionMediator a, decimal b) => new FilterExpression<bool>(a, new DecimalExpressionMediator(new LiteralExpression<decimal>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(DecimalExpressionMediator a, decimal b) => new FilterExpression<bool>(a, new DecimalExpressionMediator(new LiteralExpression<decimal>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(DecimalExpressionMediator a, decimal b) => new FilterExpression<bool>(a, new DecimalExpressionMediator(new LiteralExpression<decimal>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(DecimalExpressionMediator a, decimal b) => new FilterExpression<bool>(a, new DecimalExpressionMediator(new LiteralExpression<decimal>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(decimal a, DecimalExpressionMediator b) => new FilterExpression<bool>(new DecimalExpressionMediator(new LiteralExpression<decimal>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(decimal a, DecimalExpressionMediator b) => new FilterExpression<bool>(new DecimalExpressionMediator(new LiteralExpression<decimal>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(decimal a, DecimalExpressionMediator b) => new FilterExpression<bool>(new DecimalExpressionMediator(new LiteralExpression<decimal>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(decimal a, DecimalExpressionMediator b) => new FilterExpression<bool>(new DecimalExpressionMediator(new LiteralExpression<decimal>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(decimal a, DecimalExpressionMediator b) => new FilterExpression<bool>(new DecimalExpressionMediator(new LiteralExpression<decimal>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(decimal a, DecimalExpressionMediator b) => new FilterExpression<bool>(new DecimalExpressionMediator(new LiteralExpression<decimal>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(DecimalExpressionMediator a, decimal? b) => new FilterExpression<bool>(a, new DecimalExpressionMediator(new LiteralExpression<decimal?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(DecimalExpressionMediator a, decimal? b) => new FilterExpression<bool>(a, new DecimalExpressionMediator(new LiteralExpression<decimal?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(DecimalExpressionMediator a, decimal? b) => new FilterExpression<bool>(a, new DecimalExpressionMediator(new LiteralExpression<decimal?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(DecimalExpressionMediator a, decimal? b) => new FilterExpression<bool>(a, new DecimalExpressionMediator(new LiteralExpression<decimal?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(DecimalExpressionMediator a, decimal? b) => new FilterExpression<bool>(a, new DecimalExpressionMediator(new LiteralExpression<decimal?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(DecimalExpressionMediator a, decimal? b) => new FilterExpression<bool>(a, new DecimalExpressionMediator(new LiteralExpression<decimal?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(decimal? a, DecimalExpressionMediator b) => new FilterExpression<bool>(new DecimalExpressionMediator(new LiteralExpression<decimal?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(decimal? a, DecimalExpressionMediator b) => new FilterExpression<bool>(new DecimalExpressionMediator(new LiteralExpression<decimal?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(decimal? a, DecimalExpressionMediator b) => new FilterExpression<bool>(new DecimalExpressionMediator(new LiteralExpression<decimal?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(decimal? a, DecimalExpressionMediator b) => new FilterExpression<bool>(new DecimalExpressionMediator(new LiteralExpression<decimal?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(decimal? a, DecimalExpressionMediator b) => new FilterExpression<bool>(new DecimalExpressionMediator(new LiteralExpression<decimal?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(decimal? a, DecimalExpressionMediator b) => new FilterExpression<bool>(new DecimalExpressionMediator(new LiteralExpression<decimal?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(DecimalExpressionMediator a, DecimalExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(DecimalExpressionMediator a, DecimalExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(DecimalExpressionMediator a, DecimalExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(DecimalExpressionMediator a, DecimalExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(DecimalExpressionMediator a, DecimalExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(DecimalExpressionMediator a, DecimalExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(DecimalExpressionMediator a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(DecimalExpressionMediator a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(DecimalExpressionMediator a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(DecimalExpressionMediator a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(DecimalExpressionMediator a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(DecimalExpressionMediator a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/DoubleExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/DoubleExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public DoubleExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected DoubleExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new DoubleExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new DoubleExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/DoubleExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/DoubleExpressionMediator.generated.cs
@@ -384,5 +384,49 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #endregion
         #endregion
+
+        #region filter operators
+        public static FilterExpression<bool> operator ==(DoubleExpressionMediator a, double b) => new FilterExpression<bool>(a, new DoubleExpressionMediator(new LiteralExpression<double>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(DoubleExpressionMediator a, double b) => new FilterExpression<bool>(a, new DoubleExpressionMediator(new LiteralExpression<double>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(DoubleExpressionMediator a, double b) => new FilterExpression<bool>(a, new DoubleExpressionMediator(new LiteralExpression<double>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(DoubleExpressionMediator a, double b) => new FilterExpression<bool>(a, new DoubleExpressionMediator(new LiteralExpression<double>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(DoubleExpressionMediator a, double b) => new FilterExpression<bool>(a, new DoubleExpressionMediator(new LiteralExpression<double>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(DoubleExpressionMediator a, double b) => new FilterExpression<bool>(a, new DoubleExpressionMediator(new LiteralExpression<double>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(double a, DoubleExpressionMediator b) => new FilterExpression<bool>(new DoubleExpressionMediator(new LiteralExpression<double>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(double a, DoubleExpressionMediator b) => new FilterExpression<bool>(new DoubleExpressionMediator(new LiteralExpression<double>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(double a, DoubleExpressionMediator b) => new FilterExpression<bool>(new DoubleExpressionMediator(new LiteralExpression<double>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(double a, DoubleExpressionMediator b) => new FilterExpression<bool>(new DoubleExpressionMediator(new LiteralExpression<double>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(double a, DoubleExpressionMediator b) => new FilterExpression<bool>(new DoubleExpressionMediator(new LiteralExpression<double>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(double a, DoubleExpressionMediator b) => new FilterExpression<bool>(new DoubleExpressionMediator(new LiteralExpression<double>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(DoubleExpressionMediator a, double? b) => new FilterExpression<bool>(a, new DoubleExpressionMediator(new LiteralExpression<double?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(DoubleExpressionMediator a, double? b) => new FilterExpression<bool>(a, new DoubleExpressionMediator(new LiteralExpression<double?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(DoubleExpressionMediator a, double? b) => new FilterExpression<bool>(a, new DoubleExpressionMediator(new LiteralExpression<double?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(DoubleExpressionMediator a, double? b) => new FilterExpression<bool>(a, new DoubleExpressionMediator(new LiteralExpression<double?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(DoubleExpressionMediator a, double? b) => new FilterExpression<bool>(a, new DoubleExpressionMediator(new LiteralExpression<double?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(DoubleExpressionMediator a, double? b) => new FilterExpression<bool>(a, new DoubleExpressionMediator(new LiteralExpression<double?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(double? a, DoubleExpressionMediator b) => new FilterExpression<bool>(new DoubleExpressionMediator(new LiteralExpression<double?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(double? a, DoubleExpressionMediator b) => new FilterExpression<bool>(new DoubleExpressionMediator(new LiteralExpression<double?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(double? a, DoubleExpressionMediator b) => new FilterExpression<bool>(new DoubleExpressionMediator(new LiteralExpression<double?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(double? a, DoubleExpressionMediator b) => new FilterExpression<bool>(new DoubleExpressionMediator(new LiteralExpression<double?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(double? a, DoubleExpressionMediator b) => new FilterExpression<bool>(new DoubleExpressionMediator(new LiteralExpression<double?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(double? a, DoubleExpressionMediator b) => new FilterExpression<bool>(new DoubleExpressionMediator(new LiteralExpression<double?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(DoubleExpressionMediator a, DoubleExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(DoubleExpressionMediator a, DoubleExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(DoubleExpressionMediator a, DoubleExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(DoubleExpressionMediator a, DoubleExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(DoubleExpressionMediator a, DoubleExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(DoubleExpressionMediator a, DoubleExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(DoubleExpressionMediator a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(DoubleExpressionMediator a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(DoubleExpressionMediator a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(DoubleExpressionMediator a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(DoubleExpressionMediator a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(DoubleExpressionMediator a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/EnumExpressionMediator{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/EnumExpressionMediator{T}.cs
@@ -15,14 +15,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public EnumExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected EnumExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new EnumExpressionMediator<TEnum> As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new EnumExpressionMediator<TEnum>(this.Expression, alias);
         #endregion
 
         #region order

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/ExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/ExpressionMediator.cs
@@ -2,7 +2,7 @@
 
 namespace HatTrick.DbEx.Sql.Expression
 {
-    public class ExpressionMediator : 
+    public abstract class ExpressionMediator : 
         IExpression,
         IExpressionAliasProvider,
         IEquatable<ExpressionMediator>
@@ -21,20 +21,21 @@ namespace HatTrick.DbEx.Sql.Expression
         {
         }
 
-        public ExpressionMediator(IExpression expression)
+        protected ExpressionMediator(IExpression expression) : this(expression, null)
         {
             Expression = expression ?? throw new ArgumentNullException($"{nameof(expression)} is required.");
+        }
+
+        protected ExpressionMediator(IExpression expression, string alias)
+        {
+            Expression = expression ?? throw new ArgumentNullException($"{nameof(expression)} is required.");
+            Alias = string.IsNullOrWhiteSpace(alias) ? null : alias;
         }
         #endregion
 
         #region as
-        public ExpressionMediator As(string alias)
-        {
-            Alias = alias;
-            return this;
-        }
+        public abstract ExpressionMediator As(string alias);
         #endregion
-
 
         #region order
         public virtual OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
@@ -42,7 +43,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region tostring
-        public override string ToString() => $"Mediator({Expression})";
+        public override string ToString() => Expression?.ToString();
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/ExpressionMediator{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/ExpressionMediator{T}.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace HatTrick.DbEx.Sql.Expression
 {
@@ -11,9 +9,17 @@ namespace HatTrick.DbEx.Sql.Expression
         {
         }
 
-        public ExpressionMediator(IExpression expression) : base(expression)
+        protected ExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected ExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
+        #endregion
+
+        #region as
+        public override ExpressionMediator As(string alias) => throw new NotImplementedException("Expected concrete type to override the As method.");
         #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/GuidExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/GuidExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public GuidExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected GuidExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new GuidExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new GuidExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/GuidExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/GuidExpressionMediator.generated.cs
@@ -17,5 +17,49 @@ namespace HatTrick.DbEx.Sql.Expression
         #region mediator
         #endregion
         #endregion
+
+        #region filter operators
+        public static FilterExpression<bool> operator ==(GuidExpressionMediator a, Guid b) => new FilterExpression<bool>(a, new GuidExpressionMediator(new LiteralExpression<Guid>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(GuidExpressionMediator a, Guid b) => new FilterExpression<bool>(a, new GuidExpressionMediator(new LiteralExpression<Guid>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(GuidExpressionMediator a, Guid b) => new FilterExpression<bool>(a, new GuidExpressionMediator(new LiteralExpression<Guid>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(GuidExpressionMediator a, Guid b) => new FilterExpression<bool>(a, new GuidExpressionMediator(new LiteralExpression<Guid>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(GuidExpressionMediator a, Guid b) => new FilterExpression<bool>(a, new GuidExpressionMediator(new LiteralExpression<Guid>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(GuidExpressionMediator a, Guid b) => new FilterExpression<bool>(a, new GuidExpressionMediator(new LiteralExpression<Guid>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(Guid a, GuidExpressionMediator b) => new FilterExpression<bool>(new GuidExpressionMediator(new LiteralExpression<Guid>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(Guid a, GuidExpressionMediator b) => new FilterExpression<bool>(new GuidExpressionMediator(new LiteralExpression<Guid>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(Guid a, GuidExpressionMediator b) => new FilterExpression<bool>(new GuidExpressionMediator(new LiteralExpression<Guid>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(Guid a, GuidExpressionMediator b) => new FilterExpression<bool>(new GuidExpressionMediator(new LiteralExpression<Guid>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(Guid a, GuidExpressionMediator b) => new FilterExpression<bool>(new GuidExpressionMediator(new LiteralExpression<Guid>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(Guid a, GuidExpressionMediator b) => new FilterExpression<bool>(new GuidExpressionMediator(new LiteralExpression<Guid>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(GuidExpressionMediator a, Guid? b) => new FilterExpression<bool>(a, new GuidExpressionMediator(new LiteralExpression<Guid?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(GuidExpressionMediator a, Guid? b) => new FilterExpression<bool>(a, new GuidExpressionMediator(new LiteralExpression<Guid?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(GuidExpressionMediator a, Guid? b) => new FilterExpression<bool>(a, new GuidExpressionMediator(new LiteralExpression<Guid?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(GuidExpressionMediator a, Guid? b) => new FilterExpression<bool>(a, new GuidExpressionMediator(new LiteralExpression<Guid?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(GuidExpressionMediator a, Guid? b) => new FilterExpression<bool>(a, new GuidExpressionMediator(new LiteralExpression<Guid?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(GuidExpressionMediator a, Guid? b) => new FilterExpression<bool>(a, new GuidExpressionMediator(new LiteralExpression<Guid?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(Guid? a, GuidExpressionMediator b) => new FilterExpression<bool>(new GuidExpressionMediator(new LiteralExpression<Guid?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(Guid? a, GuidExpressionMediator b) => new FilterExpression<bool>(new GuidExpressionMediator(new LiteralExpression<Guid?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(Guid? a, GuidExpressionMediator b) => new FilterExpression<bool>(new GuidExpressionMediator(new LiteralExpression<Guid?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(Guid? a, GuidExpressionMediator b) => new FilterExpression<bool>(new GuidExpressionMediator(new LiteralExpression<Guid?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(Guid? a, GuidExpressionMediator b) => new FilterExpression<bool>(new GuidExpressionMediator(new LiteralExpression<Guid?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(Guid? a, GuidExpressionMediator b) => new FilterExpression<bool>(new GuidExpressionMediator(new LiteralExpression<Guid?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(GuidExpressionMediator a, GuidExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(GuidExpressionMediator a, GuidExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(GuidExpressionMediator a, GuidExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(GuidExpressionMediator a, GuidExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(GuidExpressionMediator a, GuidExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(GuidExpressionMediator a, GuidExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(GuidExpressionMediator a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(GuidExpressionMediator a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(GuidExpressionMediator a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(GuidExpressionMediator a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(GuidExpressionMediator a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(GuidExpressionMediator a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int16ExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int16ExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public Int16ExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected Int16ExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new Int16ExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new Int16ExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int16ExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int16ExpressionMediator.generated.cs
@@ -384,5 +384,49 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #endregion
         #endregion
+
+        #region filter operators
+        public static FilterExpression<bool> operator ==(Int16ExpressionMediator a, short b) => new FilterExpression<bool>(a, new Int16ExpressionMediator(new LiteralExpression<short>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(Int16ExpressionMediator a, short b) => new FilterExpression<bool>(a, new Int16ExpressionMediator(new LiteralExpression<short>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(Int16ExpressionMediator a, short b) => new FilterExpression<bool>(a, new Int16ExpressionMediator(new LiteralExpression<short>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(Int16ExpressionMediator a, short b) => new FilterExpression<bool>(a, new Int16ExpressionMediator(new LiteralExpression<short>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(Int16ExpressionMediator a, short b) => new FilterExpression<bool>(a, new Int16ExpressionMediator(new LiteralExpression<short>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(Int16ExpressionMediator a, short b) => new FilterExpression<bool>(a, new Int16ExpressionMediator(new LiteralExpression<short>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(short a, Int16ExpressionMediator b) => new FilterExpression<bool>(new Int16ExpressionMediator(new LiteralExpression<short>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(short a, Int16ExpressionMediator b) => new FilterExpression<bool>(new Int16ExpressionMediator(new LiteralExpression<short>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(short a, Int16ExpressionMediator b) => new FilterExpression<bool>(new Int16ExpressionMediator(new LiteralExpression<short>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(short a, Int16ExpressionMediator b) => new FilterExpression<bool>(new Int16ExpressionMediator(new LiteralExpression<short>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(short a, Int16ExpressionMediator b) => new FilterExpression<bool>(new Int16ExpressionMediator(new LiteralExpression<short>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(short a, Int16ExpressionMediator b) => new FilterExpression<bool>(new Int16ExpressionMediator(new LiteralExpression<short>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(Int16ExpressionMediator a, short? b) => new FilterExpression<bool>(a, new Int16ExpressionMediator(new LiteralExpression<short?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(Int16ExpressionMediator a, short? b) => new FilterExpression<bool>(a, new Int16ExpressionMediator(new LiteralExpression<short?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(Int16ExpressionMediator a, short? b) => new FilterExpression<bool>(a, new Int16ExpressionMediator(new LiteralExpression<short?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(Int16ExpressionMediator a, short? b) => new FilterExpression<bool>(a, new Int16ExpressionMediator(new LiteralExpression<short?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(Int16ExpressionMediator a, short? b) => new FilterExpression<bool>(a, new Int16ExpressionMediator(new LiteralExpression<short?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(Int16ExpressionMediator a, short? b) => new FilterExpression<bool>(a, new Int16ExpressionMediator(new LiteralExpression<short?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(short? a, Int16ExpressionMediator b) => new FilterExpression<bool>(new Int16ExpressionMediator(new LiteralExpression<short?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(short? a, Int16ExpressionMediator b) => new FilterExpression<bool>(new Int16ExpressionMediator(new LiteralExpression<short?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(short? a, Int16ExpressionMediator b) => new FilterExpression<bool>(new Int16ExpressionMediator(new LiteralExpression<short?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(short? a, Int16ExpressionMediator b) => new FilterExpression<bool>(new Int16ExpressionMediator(new LiteralExpression<short?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(short? a, Int16ExpressionMediator b) => new FilterExpression<bool>(new Int16ExpressionMediator(new LiteralExpression<short?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(short? a, Int16ExpressionMediator b) => new FilterExpression<bool>(new Int16ExpressionMediator(new LiteralExpression<short?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(Int16ExpressionMediator a, Int16ExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(Int16ExpressionMediator a, Int16ExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(Int16ExpressionMediator a, Int16ExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(Int16ExpressionMediator a, Int16ExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(Int16ExpressionMediator a, Int16ExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(Int16ExpressionMediator a, Int16ExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(Int16ExpressionMediator a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(Int16ExpressionMediator a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(Int16ExpressionMediator a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(Int16ExpressionMediator a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(Int16ExpressionMediator a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(Int16ExpressionMediator a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int32ExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int32ExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public Int32ExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected Int32ExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new Int32ExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new Int32ExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int32ExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int32ExpressionMediator.generated.cs
@@ -384,5 +384,49 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #endregion
         #endregion
+
+        #region filter operators
+        public static FilterExpression<bool> operator ==(Int32ExpressionMediator a, int b) => new FilterExpression<bool>(a, new Int32ExpressionMediator(new LiteralExpression<int>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(Int32ExpressionMediator a, int b) => new FilterExpression<bool>(a, new Int32ExpressionMediator(new LiteralExpression<int>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(Int32ExpressionMediator a, int b) => new FilterExpression<bool>(a, new Int32ExpressionMediator(new LiteralExpression<int>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(Int32ExpressionMediator a, int b) => new FilterExpression<bool>(a, new Int32ExpressionMediator(new LiteralExpression<int>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(Int32ExpressionMediator a, int b) => new FilterExpression<bool>(a, new Int32ExpressionMediator(new LiteralExpression<int>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(Int32ExpressionMediator a, int b) => new FilterExpression<bool>(a, new Int32ExpressionMediator(new LiteralExpression<int>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(int a, Int32ExpressionMediator b) => new FilterExpression<bool>(new Int32ExpressionMediator(new LiteralExpression<int>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(int a, Int32ExpressionMediator b) => new FilterExpression<bool>(new Int32ExpressionMediator(new LiteralExpression<int>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(int a, Int32ExpressionMediator b) => new FilterExpression<bool>(new Int32ExpressionMediator(new LiteralExpression<int>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(int a, Int32ExpressionMediator b) => new FilterExpression<bool>(new Int32ExpressionMediator(new LiteralExpression<int>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(int a, Int32ExpressionMediator b) => new FilterExpression<bool>(new Int32ExpressionMediator(new LiteralExpression<int>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(int a, Int32ExpressionMediator b) => new FilterExpression<bool>(new Int32ExpressionMediator(new LiteralExpression<int>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(Int32ExpressionMediator a, int? b) => new FilterExpression<bool>(a, new Int32ExpressionMediator(new LiteralExpression<int?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(Int32ExpressionMediator a, int? b) => new FilterExpression<bool>(a, new Int32ExpressionMediator(new LiteralExpression<int?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(Int32ExpressionMediator a, int? b) => new FilterExpression<bool>(a, new Int32ExpressionMediator(new LiteralExpression<int?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(Int32ExpressionMediator a, int? b) => new FilterExpression<bool>(a, new Int32ExpressionMediator(new LiteralExpression<int?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(Int32ExpressionMediator a, int? b) => new FilterExpression<bool>(a, new Int32ExpressionMediator(new LiteralExpression<int?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(Int32ExpressionMediator a, int? b) => new FilterExpression<bool>(a, new Int32ExpressionMediator(new LiteralExpression<int?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(int? a, Int32ExpressionMediator b) => new FilterExpression<bool>(new Int32ExpressionMediator(new LiteralExpression<int?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(int? a, Int32ExpressionMediator b) => new FilterExpression<bool>(new Int32ExpressionMediator(new LiteralExpression<int?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(int? a, Int32ExpressionMediator b) => new FilterExpression<bool>(new Int32ExpressionMediator(new LiteralExpression<int?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(int? a, Int32ExpressionMediator b) => new FilterExpression<bool>(new Int32ExpressionMediator(new LiteralExpression<int?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(int? a, Int32ExpressionMediator b) => new FilterExpression<bool>(new Int32ExpressionMediator(new LiteralExpression<int?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(int? a, Int32ExpressionMediator b) => new FilterExpression<bool>(new Int32ExpressionMediator(new LiteralExpression<int?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(Int32ExpressionMediator a, Int32ExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(Int32ExpressionMediator a, Int32ExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(Int32ExpressionMediator a, Int32ExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(Int32ExpressionMediator a, Int32ExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(Int32ExpressionMediator a, Int32ExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(Int32ExpressionMediator a, Int32ExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(Int32ExpressionMediator a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(Int32ExpressionMediator a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(Int32ExpressionMediator a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(Int32ExpressionMediator a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(Int32ExpressionMediator a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(Int32ExpressionMediator a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int64ExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int64ExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public Int64ExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected Int64ExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new Int64ExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new Int64ExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int64ExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int64ExpressionMediator.generated.cs
@@ -384,5 +384,49 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #endregion
         #endregion
+
+        #region filter operators
+        public static FilterExpression<bool> operator ==(Int64ExpressionMediator a, long b) => new FilterExpression<bool>(a, new Int64ExpressionMediator(new LiteralExpression<long>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(Int64ExpressionMediator a, long b) => new FilterExpression<bool>(a, new Int64ExpressionMediator(new LiteralExpression<long>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(Int64ExpressionMediator a, long b) => new FilterExpression<bool>(a, new Int64ExpressionMediator(new LiteralExpression<long>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(Int64ExpressionMediator a, long b) => new FilterExpression<bool>(a, new Int64ExpressionMediator(new LiteralExpression<long>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(Int64ExpressionMediator a, long b) => new FilterExpression<bool>(a, new Int64ExpressionMediator(new LiteralExpression<long>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(Int64ExpressionMediator a, long b) => new FilterExpression<bool>(a, new Int64ExpressionMediator(new LiteralExpression<long>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(long a, Int64ExpressionMediator b) => new FilterExpression<bool>(new Int64ExpressionMediator(new LiteralExpression<long>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(long a, Int64ExpressionMediator b) => new FilterExpression<bool>(new Int64ExpressionMediator(new LiteralExpression<long>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(long a, Int64ExpressionMediator b) => new FilterExpression<bool>(new Int64ExpressionMediator(new LiteralExpression<long>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(long a, Int64ExpressionMediator b) => new FilterExpression<bool>(new Int64ExpressionMediator(new LiteralExpression<long>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(long a, Int64ExpressionMediator b) => new FilterExpression<bool>(new Int64ExpressionMediator(new LiteralExpression<long>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(long a, Int64ExpressionMediator b) => new FilterExpression<bool>(new Int64ExpressionMediator(new LiteralExpression<long>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(Int64ExpressionMediator a, long? b) => new FilterExpression<bool>(a, new Int64ExpressionMediator(new LiteralExpression<long?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(Int64ExpressionMediator a, long? b) => new FilterExpression<bool>(a, new Int64ExpressionMediator(new LiteralExpression<long?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(Int64ExpressionMediator a, long? b) => new FilterExpression<bool>(a, new Int64ExpressionMediator(new LiteralExpression<long?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(Int64ExpressionMediator a, long? b) => new FilterExpression<bool>(a, new Int64ExpressionMediator(new LiteralExpression<long?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(Int64ExpressionMediator a, long? b) => new FilterExpression<bool>(a, new Int64ExpressionMediator(new LiteralExpression<long?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(Int64ExpressionMediator a, long? b) => new FilterExpression<bool>(a, new Int64ExpressionMediator(new LiteralExpression<long?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(long? a, Int64ExpressionMediator b) => new FilterExpression<bool>(new Int64ExpressionMediator(new LiteralExpression<long?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(long? a, Int64ExpressionMediator b) => new FilterExpression<bool>(new Int64ExpressionMediator(new LiteralExpression<long?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(long? a, Int64ExpressionMediator b) => new FilterExpression<bool>(new Int64ExpressionMediator(new LiteralExpression<long?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(long? a, Int64ExpressionMediator b) => new FilterExpression<bool>(new Int64ExpressionMediator(new LiteralExpression<long?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(long? a, Int64ExpressionMediator b) => new FilterExpression<bool>(new Int64ExpressionMediator(new LiteralExpression<long?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(long? a, Int64ExpressionMediator b) => new FilterExpression<bool>(new Int64ExpressionMediator(new LiteralExpression<long?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(Int64ExpressionMediator a, Int64ExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(Int64ExpressionMediator a, Int64ExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(Int64ExpressionMediator a, Int64ExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(Int64ExpressionMediator a, Int64ExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(Int64ExpressionMediator a, Int64ExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(Int64ExpressionMediator a, Int64ExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(Int64ExpressionMediator a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(Int64ExpressionMediator a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(Int64ExpressionMediator a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(Int64ExpressionMediator a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(Int64ExpressionMediator a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(Int64ExpressionMediator a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableBooleanExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableBooleanExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public NullableBooleanExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected NullableBooleanExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new NullableBooleanExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new NullableBooleanExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableBooleanExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableBooleanExpressionMediator.generated.cs
@@ -17,5 +17,53 @@ namespace HatTrick.DbEx.Sql.Expression
         #region mediator
         #endregion
         #endregion
+
+        #region filter operators
+        #region bool
+        public static FilterExpression<bool?> operator ==(NullableBooleanExpressionMediator a, bool b) => new FilterExpression<bool?>(a, new BooleanExpressionMediator(new LiteralExpression<bool>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableBooleanExpressionMediator a, bool b) => new FilterExpression<bool?>(a, new BooleanExpressionMediator(new LiteralExpression<bool>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableBooleanExpressionMediator a, bool b) => new FilterExpression<bool?>(a, new BooleanExpressionMediator(new LiteralExpression<bool>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableBooleanExpressionMediator a, bool b) => new FilterExpression<bool?>(a, new BooleanExpressionMediator(new LiteralExpression<bool>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableBooleanExpressionMediator a, bool b) => new FilterExpression<bool?>(a, new BooleanExpressionMediator(new LiteralExpression<bool>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableBooleanExpressionMediator a, bool b) => new FilterExpression<bool?>(a, new BooleanExpressionMediator(new LiteralExpression<bool>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(bool a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(new BooleanExpressionMediator(new LiteralExpression<bool>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(bool a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(new BooleanExpressionMediator(new LiteralExpression<bool>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(bool a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(new BooleanExpressionMediator(new LiteralExpression<bool>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(bool a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(new BooleanExpressionMediator(new LiteralExpression<bool>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(bool a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(new BooleanExpressionMediator(new LiteralExpression<bool>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(bool a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(new BooleanExpressionMediator(new LiteralExpression<bool>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableBooleanExpressionMediator a, bool? b) => new FilterExpression<bool?>(a, new NullableBooleanExpressionMediator(new LiteralExpression<bool?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableBooleanExpressionMediator a, bool? b) => new FilterExpression<bool?>(a, new NullableBooleanExpressionMediator(new LiteralExpression<bool?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableBooleanExpressionMediator a, bool? b) => new FilterExpression<bool?>(a, new NullableBooleanExpressionMediator(new LiteralExpression<bool?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableBooleanExpressionMediator a, bool? b) => new FilterExpression<bool?>(a, new NullableBooleanExpressionMediator(new LiteralExpression<bool?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableBooleanExpressionMediator a, bool? b) => new FilterExpression<bool?>(a, new NullableBooleanExpressionMediator(new LiteralExpression<bool?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableBooleanExpressionMediator a, bool? b) => new FilterExpression<bool?>(a, new NullableBooleanExpressionMediator(new LiteralExpression<bool?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(bool? a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(new NullableBooleanExpressionMediator(new LiteralExpression<bool?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(bool? a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(new NullableBooleanExpressionMediator(new LiteralExpression<bool?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(bool? a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(new NullableBooleanExpressionMediator(new LiteralExpression<bool?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(bool? a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(new NullableBooleanExpressionMediator(new LiteralExpression<bool?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(bool? a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(new NullableBooleanExpressionMediator(new LiteralExpression<bool?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(bool? a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(new NullableBooleanExpressionMediator(new LiteralExpression<bool?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        
+        #region mediator
+        public static FilterExpression<bool?> operator ==(NullableBooleanExpressionMediator a, BooleanExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableBooleanExpressionMediator a, BooleanExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableBooleanExpressionMediator a, BooleanExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableBooleanExpressionMediator a, BooleanExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableBooleanExpressionMediator a, BooleanExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableBooleanExpressionMediator a, BooleanExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableBooleanExpressionMediator a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(new BooleanExpressionMediator(a), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableBooleanExpressionMediator a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(new BooleanExpressionMediator(a), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableBooleanExpressionMediator a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(new BooleanExpressionMediator(a), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableBooleanExpressionMediator a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(new BooleanExpressionMediator(a), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableBooleanExpressionMediator a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(new BooleanExpressionMediator(a), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableBooleanExpressionMediator a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(new BooleanExpressionMediator(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableByteExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableByteExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public NullableByteExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected NullableByteExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new NullableByteExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new NullableByteExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableByteExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableByteExpressionMediator.generated.cs
@@ -379,5 +379,53 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #endregion
         #endregion
+
+        #region filter operators
+        #region byte
+        public static FilterExpression<bool?> operator ==(NullableByteExpressionMediator a, byte b) => new FilterExpression<bool?>(a, new ByteExpressionMediator(new LiteralExpression<byte>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableByteExpressionMediator a, byte b) => new FilterExpression<bool?>(a, new ByteExpressionMediator(new LiteralExpression<byte>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableByteExpressionMediator a, byte b) => new FilterExpression<bool?>(a, new ByteExpressionMediator(new LiteralExpression<byte>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableByteExpressionMediator a, byte b) => new FilterExpression<bool?>(a, new ByteExpressionMediator(new LiteralExpression<byte>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableByteExpressionMediator a, byte b) => new FilterExpression<bool?>(a, new ByteExpressionMediator(new LiteralExpression<byte>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableByteExpressionMediator a, byte b) => new FilterExpression<bool?>(a, new ByteExpressionMediator(new LiteralExpression<byte>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(byte a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new ByteExpressionMediator(new LiteralExpression<byte>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(byte a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new ByteExpressionMediator(new LiteralExpression<byte>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(byte a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new ByteExpressionMediator(new LiteralExpression<byte>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(byte a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new ByteExpressionMediator(new LiteralExpression<byte>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(byte a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new ByteExpressionMediator(new LiteralExpression<byte>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(byte a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new ByteExpressionMediator(new LiteralExpression<byte>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableByteExpressionMediator a, byte? b) => new FilterExpression<bool?>(a, new NullableByteExpressionMediator(new LiteralExpression<byte?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableByteExpressionMediator a, byte? b) => new FilterExpression<bool?>(a, new NullableByteExpressionMediator(new LiteralExpression<byte?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableByteExpressionMediator a, byte? b) => new FilterExpression<bool?>(a, new NullableByteExpressionMediator(new LiteralExpression<byte?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableByteExpressionMediator a, byte? b) => new FilterExpression<bool?>(a, new NullableByteExpressionMediator(new LiteralExpression<byte?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableByteExpressionMediator a, byte? b) => new FilterExpression<bool?>(a, new NullableByteExpressionMediator(new LiteralExpression<byte?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableByteExpressionMediator a, byte? b) => new FilterExpression<bool?>(a, new NullableByteExpressionMediator(new LiteralExpression<byte?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(byte? a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new NullableByteExpressionMediator(new LiteralExpression<byte?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(byte? a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new NullableByteExpressionMediator(new LiteralExpression<byte?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(byte? a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new NullableByteExpressionMediator(new LiteralExpression<byte?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(byte? a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new NullableByteExpressionMediator(new LiteralExpression<byte?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(byte? a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new NullableByteExpressionMediator(new LiteralExpression<byte?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(byte? a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new NullableByteExpressionMediator(new LiteralExpression<byte?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        
+        #region mediator
+        public static FilterExpression<bool?> operator ==(NullableByteExpressionMediator a, ByteExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableByteExpressionMediator a, ByteExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableByteExpressionMediator a, ByteExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableByteExpressionMediator a, ByteExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableByteExpressionMediator a, ByteExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableByteExpressionMediator a, ByteExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableByteExpressionMediator a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new ByteExpressionMediator(a), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableByteExpressionMediator a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new ByteExpressionMediator(a), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableByteExpressionMediator a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new ByteExpressionMediator(a), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableByteExpressionMediator a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new ByteExpressionMediator(a), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableByteExpressionMediator a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new ByteExpressionMediator(a), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableByteExpressionMediator a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new ByteExpressionMediator(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDateTimeExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDateTimeExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public NullableDateTimeExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected NullableDateTimeExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new NullableDateTimeExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new NullableDateTimeExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDateTimeExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDateTimeExpressionMediator.generated.cs
@@ -217,5 +217,53 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #endregion
         #endregion
+
+        #region filter operators
+        #region DateTime
+        public static FilterExpression<bool?> operator ==(NullableDateTimeExpressionMediator a, DateTime b) => new FilterExpression<bool?>(a, new DateTimeExpressionMediator(new LiteralExpression<DateTime>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableDateTimeExpressionMediator a, DateTime b) => new FilterExpression<bool?>(a, new DateTimeExpressionMediator(new LiteralExpression<DateTime>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableDateTimeExpressionMediator a, DateTime b) => new FilterExpression<bool?>(a, new DateTimeExpressionMediator(new LiteralExpression<DateTime>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableDateTimeExpressionMediator a, DateTime b) => new FilterExpression<bool?>(a, new DateTimeExpressionMediator(new LiteralExpression<DateTime>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableDateTimeExpressionMediator a, DateTime b) => new FilterExpression<bool?>(a, new DateTimeExpressionMediator(new LiteralExpression<DateTime>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableDateTimeExpressionMediator a, DateTime b) => new FilterExpression<bool?>(a, new DateTimeExpressionMediator(new LiteralExpression<DateTime>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(DateTime a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new DateTimeExpressionMediator(new LiteralExpression<DateTime>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(DateTime a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new DateTimeExpressionMediator(new LiteralExpression<DateTime>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(DateTime a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new DateTimeExpressionMediator(new LiteralExpression<DateTime>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(DateTime a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new DateTimeExpressionMediator(new LiteralExpression<DateTime>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(DateTime a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new DateTimeExpressionMediator(new LiteralExpression<DateTime>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(DateTime a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new DateTimeExpressionMediator(new LiteralExpression<DateTime>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableDateTimeExpressionMediator a, DateTime? b) => new FilterExpression<bool?>(a, new NullableDateTimeExpressionMediator(new LiteralExpression<DateTime?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableDateTimeExpressionMediator a, DateTime? b) => new FilterExpression<bool?>(a, new NullableDateTimeExpressionMediator(new LiteralExpression<DateTime?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableDateTimeExpressionMediator a, DateTime? b) => new FilterExpression<bool?>(a, new NullableDateTimeExpressionMediator(new LiteralExpression<DateTime?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableDateTimeExpressionMediator a, DateTime? b) => new FilterExpression<bool?>(a, new NullableDateTimeExpressionMediator(new LiteralExpression<DateTime?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableDateTimeExpressionMediator a, DateTime? b) => new FilterExpression<bool?>(a, new NullableDateTimeExpressionMediator(new LiteralExpression<DateTime?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableDateTimeExpressionMediator a, DateTime? b) => new FilterExpression<bool?>(a, new NullableDateTimeExpressionMediator(new LiteralExpression<DateTime?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(DateTime? a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new NullableDateTimeExpressionMediator(new LiteralExpression<DateTime?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(DateTime? a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new NullableDateTimeExpressionMediator(new LiteralExpression<DateTime?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(DateTime? a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new NullableDateTimeExpressionMediator(new LiteralExpression<DateTime?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(DateTime? a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new NullableDateTimeExpressionMediator(new LiteralExpression<DateTime?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(DateTime? a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new NullableDateTimeExpressionMediator(new LiteralExpression<DateTime?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(DateTime? a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new NullableDateTimeExpressionMediator(new LiteralExpression<DateTime?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        
+        #region mediator
+        public static FilterExpression<bool?> operator ==(NullableDateTimeExpressionMediator a, DateTimeExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableDateTimeExpressionMediator a, DateTimeExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableDateTimeExpressionMediator a, DateTimeExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableDateTimeExpressionMediator a, DateTimeExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableDateTimeExpressionMediator a, DateTimeExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableDateTimeExpressionMediator a, DateTimeExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableDateTimeExpressionMediator a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new DateTimeExpressionMediator(a), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableDateTimeExpressionMediator a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new DateTimeExpressionMediator(a), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableDateTimeExpressionMediator a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new DateTimeExpressionMediator(a), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableDateTimeExpressionMediator a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new DateTimeExpressionMediator(a), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableDateTimeExpressionMediator a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new DateTimeExpressionMediator(a), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableDateTimeExpressionMediator a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new DateTimeExpressionMediator(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDateTimeOffsetExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDateTimeOffsetExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public NullableDateTimeOffsetExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected NullableDateTimeOffsetExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new NullableDateTimeOffsetExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new NullableDateTimeOffsetExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDateTimeOffsetExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDateTimeOffsetExpressionMediator.generated.cs
@@ -217,5 +217,53 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #endregion
         #endregion
+
+        #region filter operators
+        #region DateTimeOffset
+        public static FilterExpression<bool?> operator ==(NullableDateTimeOffsetExpressionMediator a, DateTimeOffset b) => new FilterExpression<bool?>(a, new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableDateTimeOffsetExpressionMediator a, DateTimeOffset b) => new FilterExpression<bool?>(a, new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableDateTimeOffsetExpressionMediator a, DateTimeOffset b) => new FilterExpression<bool?>(a, new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableDateTimeOffsetExpressionMediator a, DateTimeOffset b) => new FilterExpression<bool?>(a, new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableDateTimeOffsetExpressionMediator a, DateTimeOffset b) => new FilterExpression<bool?>(a, new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableDateTimeOffsetExpressionMediator a, DateTimeOffset b) => new FilterExpression<bool?>(a, new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(DateTimeOffset a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(DateTimeOffset a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(DateTimeOffset a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(DateTimeOffset a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(DateTimeOffset a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(DateTimeOffset a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new DateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableDateTimeOffsetExpressionMediator a, DateTimeOffset? b) => new FilterExpression<bool?>(a, new NullableDateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableDateTimeOffsetExpressionMediator a, DateTimeOffset? b) => new FilterExpression<bool?>(a, new NullableDateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableDateTimeOffsetExpressionMediator a, DateTimeOffset? b) => new FilterExpression<bool?>(a, new NullableDateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableDateTimeOffsetExpressionMediator a, DateTimeOffset? b) => new FilterExpression<bool?>(a, new NullableDateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableDateTimeOffsetExpressionMediator a, DateTimeOffset? b) => new FilterExpression<bool?>(a, new NullableDateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableDateTimeOffsetExpressionMediator a, DateTimeOffset? b) => new FilterExpression<bool?>(a, new NullableDateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(DateTimeOffset? a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new NullableDateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(DateTimeOffset? a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new NullableDateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(DateTimeOffset? a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new NullableDateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(DateTimeOffset? a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new NullableDateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(DateTimeOffset? a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new NullableDateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(DateTimeOffset? a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new NullableDateTimeOffsetExpressionMediator(new LiteralExpression<DateTimeOffset?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        
+        #region mediator
+        public static FilterExpression<bool?> operator ==(NullableDateTimeOffsetExpressionMediator a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableDateTimeOffsetExpressionMediator a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableDateTimeOffsetExpressionMediator a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableDateTimeOffsetExpressionMediator a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableDateTimeOffsetExpressionMediator a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableDateTimeOffsetExpressionMediator a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableDateTimeOffsetExpressionMediator a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new DateTimeOffsetExpressionMediator(a), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableDateTimeOffsetExpressionMediator a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new DateTimeOffsetExpressionMediator(a), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableDateTimeOffsetExpressionMediator a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new DateTimeOffsetExpressionMediator(a), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableDateTimeOffsetExpressionMediator a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new DateTimeOffsetExpressionMediator(a), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableDateTimeOffsetExpressionMediator a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new DateTimeOffsetExpressionMediator(a), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableDateTimeOffsetExpressionMediator a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new DateTimeOffsetExpressionMediator(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDecimalExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDecimalExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public NullableDecimalExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected NullableDecimalExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new NullableDecimalExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new NullableDecimalExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDecimalExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDecimalExpressionMediator.generated.cs
@@ -379,5 +379,53 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #endregion
         #endregion
+
+        #region filter operators
+        #region decimal
+        public static FilterExpression<bool?> operator ==(NullableDecimalExpressionMediator a, decimal b) => new FilterExpression<bool?>(a, new DecimalExpressionMediator(new LiteralExpression<decimal>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableDecimalExpressionMediator a, decimal b) => new FilterExpression<bool?>(a, new DecimalExpressionMediator(new LiteralExpression<decimal>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableDecimalExpressionMediator a, decimal b) => new FilterExpression<bool?>(a, new DecimalExpressionMediator(new LiteralExpression<decimal>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableDecimalExpressionMediator a, decimal b) => new FilterExpression<bool?>(a, new DecimalExpressionMediator(new LiteralExpression<decimal>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableDecimalExpressionMediator a, decimal b) => new FilterExpression<bool?>(a, new DecimalExpressionMediator(new LiteralExpression<decimal>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableDecimalExpressionMediator a, decimal b) => new FilterExpression<bool?>(a, new DecimalExpressionMediator(new LiteralExpression<decimal>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(decimal a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new DecimalExpressionMediator(new LiteralExpression<decimal>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(decimal a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new DecimalExpressionMediator(new LiteralExpression<decimal>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(decimal a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new DecimalExpressionMediator(new LiteralExpression<decimal>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(decimal a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new DecimalExpressionMediator(new LiteralExpression<decimal>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(decimal a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new DecimalExpressionMediator(new LiteralExpression<decimal>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(decimal a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new DecimalExpressionMediator(new LiteralExpression<decimal>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableDecimalExpressionMediator a, decimal? b) => new FilterExpression<bool?>(a, new NullableDecimalExpressionMediator(new LiteralExpression<decimal?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableDecimalExpressionMediator a, decimal? b) => new FilterExpression<bool?>(a, new NullableDecimalExpressionMediator(new LiteralExpression<decimal?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableDecimalExpressionMediator a, decimal? b) => new FilterExpression<bool?>(a, new NullableDecimalExpressionMediator(new LiteralExpression<decimal?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableDecimalExpressionMediator a, decimal? b) => new FilterExpression<bool?>(a, new NullableDecimalExpressionMediator(new LiteralExpression<decimal?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableDecimalExpressionMediator a, decimal? b) => new FilterExpression<bool?>(a, new NullableDecimalExpressionMediator(new LiteralExpression<decimal?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableDecimalExpressionMediator a, decimal? b) => new FilterExpression<bool?>(a, new NullableDecimalExpressionMediator(new LiteralExpression<decimal?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(decimal? a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new NullableDecimalExpressionMediator(new LiteralExpression<decimal?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(decimal? a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new NullableDecimalExpressionMediator(new LiteralExpression<decimal?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(decimal? a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new NullableDecimalExpressionMediator(new LiteralExpression<decimal?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(decimal? a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new NullableDecimalExpressionMediator(new LiteralExpression<decimal?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(decimal? a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new NullableDecimalExpressionMediator(new LiteralExpression<decimal?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(decimal? a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new NullableDecimalExpressionMediator(new LiteralExpression<decimal?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        
+        #region mediator
+        public static FilterExpression<bool?> operator ==(NullableDecimalExpressionMediator a, DecimalExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableDecimalExpressionMediator a, DecimalExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableDecimalExpressionMediator a, DecimalExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableDecimalExpressionMediator a, DecimalExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableDecimalExpressionMediator a, DecimalExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableDecimalExpressionMediator a, DecimalExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableDecimalExpressionMediator a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new DecimalExpressionMediator(a), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableDecimalExpressionMediator a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new DecimalExpressionMediator(a), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableDecimalExpressionMediator a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new DecimalExpressionMediator(a), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableDecimalExpressionMediator a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new DecimalExpressionMediator(a), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableDecimalExpressionMediator a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new DecimalExpressionMediator(a), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableDecimalExpressionMediator a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new DecimalExpressionMediator(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDoubleExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDoubleExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public NullableDoubleExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected NullableDoubleExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new NullableDoubleExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new NullableDoubleExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDoubleExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDoubleExpressionMediator.generated.cs
@@ -379,5 +379,53 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #endregion
         #endregion
+
+        #region filter operators
+        #region double
+        public static FilterExpression<bool?> operator ==(NullableDoubleExpressionMediator a, double b) => new FilterExpression<bool?>(a, new DoubleExpressionMediator(new LiteralExpression<double>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableDoubleExpressionMediator a, double b) => new FilterExpression<bool?>(a, new DoubleExpressionMediator(new LiteralExpression<double>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableDoubleExpressionMediator a, double b) => new FilterExpression<bool?>(a, new DoubleExpressionMediator(new LiteralExpression<double>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableDoubleExpressionMediator a, double b) => new FilterExpression<bool?>(a, new DoubleExpressionMediator(new LiteralExpression<double>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableDoubleExpressionMediator a, double b) => new FilterExpression<bool?>(a, new DoubleExpressionMediator(new LiteralExpression<double>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableDoubleExpressionMediator a, double b) => new FilterExpression<bool?>(a, new DoubleExpressionMediator(new LiteralExpression<double>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(double a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new DoubleExpressionMediator(new LiteralExpression<double>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(double a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new DoubleExpressionMediator(new LiteralExpression<double>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(double a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new DoubleExpressionMediator(new LiteralExpression<double>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(double a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new DoubleExpressionMediator(new LiteralExpression<double>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(double a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new DoubleExpressionMediator(new LiteralExpression<double>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(double a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new DoubleExpressionMediator(new LiteralExpression<double>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableDoubleExpressionMediator a, double? b) => new FilterExpression<bool?>(a, new NullableDoubleExpressionMediator(new LiteralExpression<double?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableDoubleExpressionMediator a, double? b) => new FilterExpression<bool?>(a, new NullableDoubleExpressionMediator(new LiteralExpression<double?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableDoubleExpressionMediator a, double? b) => new FilterExpression<bool?>(a, new NullableDoubleExpressionMediator(new LiteralExpression<double?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableDoubleExpressionMediator a, double? b) => new FilterExpression<bool?>(a, new NullableDoubleExpressionMediator(new LiteralExpression<double?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableDoubleExpressionMediator a, double? b) => new FilterExpression<bool?>(a, new NullableDoubleExpressionMediator(new LiteralExpression<double?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableDoubleExpressionMediator a, double? b) => new FilterExpression<bool?>(a, new NullableDoubleExpressionMediator(new LiteralExpression<double?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(double? a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new NullableDoubleExpressionMediator(new LiteralExpression<double?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(double? a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new NullableDoubleExpressionMediator(new LiteralExpression<double?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(double? a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new NullableDoubleExpressionMediator(new LiteralExpression<double?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(double? a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new NullableDoubleExpressionMediator(new LiteralExpression<double?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(double? a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new NullableDoubleExpressionMediator(new LiteralExpression<double?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(double? a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new NullableDoubleExpressionMediator(new LiteralExpression<double?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        
+        #region mediator
+        public static FilterExpression<bool?> operator ==(NullableDoubleExpressionMediator a, DoubleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableDoubleExpressionMediator a, DoubleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableDoubleExpressionMediator a, DoubleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableDoubleExpressionMediator a, DoubleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableDoubleExpressionMediator a, DoubleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableDoubleExpressionMediator a, DoubleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableDoubleExpressionMediator a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new DoubleExpressionMediator(a), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableDoubleExpressionMediator a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new DoubleExpressionMediator(a), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableDoubleExpressionMediator a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new DoubleExpressionMediator(a), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableDoubleExpressionMediator a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new DoubleExpressionMediator(a), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableDoubleExpressionMediator a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new DoubleExpressionMediator(a), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableDoubleExpressionMediator a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new DoubleExpressionMediator(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableEnumExpressionMediator{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableEnumExpressionMediator{T}.cs
@@ -16,14 +16,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public NullableEnumExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected NullableEnumExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new NullableEnumExpressionMediator<TEnum> As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new NullableEnumExpressionMediator<TEnum>(this.Expression, alias);
         #endregion
 
         #region order

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableExpressionMediator{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableExpressionMediator{T}.cs
@@ -4,10 +4,14 @@
     {
         #region constructors
         protected NullableExpressionMediator()
-        { }
+        { 
+        }
 
-        protected NullableExpressionMediator(IExpression expression)
-            : base(expression)
+        protected NullableExpressionMediator(IExpression expression) : base(expression)
+        {
+        }
+
+        protected NullableExpressionMediator(IExpression expression, string alias) : base(expression, alias)
         {
         }
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableGuidExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableGuidExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public NullableGuidExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected NullableGuidExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new NullableGuidExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new NullableGuidExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableGuidExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableGuidExpressionMediator.generated.cs
@@ -17,5 +17,53 @@ namespace HatTrick.DbEx.Sql.Expression
         #region mediator
         #endregion
         #endregion
+
+        #region filter operators
+        #region Guid
+        public static FilterExpression<bool?> operator ==(NullableGuidExpressionMediator a, Guid b) => new FilterExpression<bool?>(a, new GuidExpressionMediator(new LiteralExpression<Guid>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableGuidExpressionMediator a, Guid b) => new FilterExpression<bool?>(a, new GuidExpressionMediator(new LiteralExpression<Guid>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableGuidExpressionMediator a, Guid b) => new FilterExpression<bool?>(a, new GuidExpressionMediator(new LiteralExpression<Guid>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableGuidExpressionMediator a, Guid b) => new FilterExpression<bool?>(a, new GuidExpressionMediator(new LiteralExpression<Guid>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableGuidExpressionMediator a, Guid b) => new FilterExpression<bool?>(a, new GuidExpressionMediator(new LiteralExpression<Guid>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableGuidExpressionMediator a, Guid b) => new FilterExpression<bool?>(a, new GuidExpressionMediator(new LiteralExpression<Guid>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(Guid a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(new GuidExpressionMediator(new LiteralExpression<Guid>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(Guid a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(new GuidExpressionMediator(new LiteralExpression<Guid>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(Guid a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(new GuidExpressionMediator(new LiteralExpression<Guid>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(Guid a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(new GuidExpressionMediator(new LiteralExpression<Guid>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(Guid a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(new GuidExpressionMediator(new LiteralExpression<Guid>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(Guid a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(new GuidExpressionMediator(new LiteralExpression<Guid>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableGuidExpressionMediator a, Guid? b) => new FilterExpression<bool?>(a, new NullableGuidExpressionMediator(new LiteralExpression<Guid?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableGuidExpressionMediator a, Guid? b) => new FilterExpression<bool?>(a, new NullableGuidExpressionMediator(new LiteralExpression<Guid?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableGuidExpressionMediator a, Guid? b) => new FilterExpression<bool?>(a, new NullableGuidExpressionMediator(new LiteralExpression<Guid?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableGuidExpressionMediator a, Guid? b) => new FilterExpression<bool?>(a, new NullableGuidExpressionMediator(new LiteralExpression<Guid?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableGuidExpressionMediator a, Guid? b) => new FilterExpression<bool?>(a, new NullableGuidExpressionMediator(new LiteralExpression<Guid?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableGuidExpressionMediator a, Guid? b) => new FilterExpression<bool?>(a, new NullableGuidExpressionMediator(new LiteralExpression<Guid?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(Guid? a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(new NullableGuidExpressionMediator(new LiteralExpression<Guid?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(Guid? a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(new NullableGuidExpressionMediator(new LiteralExpression<Guid?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(Guid? a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(new NullableGuidExpressionMediator(new LiteralExpression<Guid?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(Guid? a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(new NullableGuidExpressionMediator(new LiteralExpression<Guid?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(Guid? a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(new NullableGuidExpressionMediator(new LiteralExpression<Guid?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(Guid? a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(new NullableGuidExpressionMediator(new LiteralExpression<Guid?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        
+        #region mediator
+        public static FilterExpression<bool?> operator ==(NullableGuidExpressionMediator a, GuidExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableGuidExpressionMediator a, GuidExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableGuidExpressionMediator a, GuidExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableGuidExpressionMediator a, GuidExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableGuidExpressionMediator a, GuidExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableGuidExpressionMediator a, GuidExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableGuidExpressionMediator a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(new GuidExpressionMediator(a), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableGuidExpressionMediator a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(new GuidExpressionMediator(a), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableGuidExpressionMediator a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(new GuidExpressionMediator(a), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableGuidExpressionMediator a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(new GuidExpressionMediator(a), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableGuidExpressionMediator a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(new GuidExpressionMediator(a), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableGuidExpressionMediator a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(new GuidExpressionMediator(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt16ExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt16ExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public NullableInt16ExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected NullableInt16ExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new NullableInt16ExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new NullableInt16ExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt16ExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt16ExpressionMediator.generated.cs
@@ -379,5 +379,53 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #endregion
         #endregion
+
+        #region filter operators
+        #region short
+        public static FilterExpression<bool?> operator ==(NullableInt16ExpressionMediator a, short b) => new FilterExpression<bool?>(a, new Int16ExpressionMediator(new LiteralExpression<short>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableInt16ExpressionMediator a, short b) => new FilterExpression<bool?>(a, new Int16ExpressionMediator(new LiteralExpression<short>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableInt16ExpressionMediator a, short b) => new FilterExpression<bool?>(a, new Int16ExpressionMediator(new LiteralExpression<short>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableInt16ExpressionMediator a, short b) => new FilterExpression<bool?>(a, new Int16ExpressionMediator(new LiteralExpression<short>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableInt16ExpressionMediator a, short b) => new FilterExpression<bool?>(a, new Int16ExpressionMediator(new LiteralExpression<short>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableInt16ExpressionMediator a, short b) => new FilterExpression<bool?>(a, new Int16ExpressionMediator(new LiteralExpression<short>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(short a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new Int16ExpressionMediator(new LiteralExpression<short>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(short a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new Int16ExpressionMediator(new LiteralExpression<short>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(short a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new Int16ExpressionMediator(new LiteralExpression<short>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(short a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new Int16ExpressionMediator(new LiteralExpression<short>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(short a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new Int16ExpressionMediator(new LiteralExpression<short>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(short a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new Int16ExpressionMediator(new LiteralExpression<short>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableInt16ExpressionMediator a, short? b) => new FilterExpression<bool?>(a, new NullableInt16ExpressionMediator(new LiteralExpression<short?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableInt16ExpressionMediator a, short? b) => new FilterExpression<bool?>(a, new NullableInt16ExpressionMediator(new LiteralExpression<short?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableInt16ExpressionMediator a, short? b) => new FilterExpression<bool?>(a, new NullableInt16ExpressionMediator(new LiteralExpression<short?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableInt16ExpressionMediator a, short? b) => new FilterExpression<bool?>(a, new NullableInt16ExpressionMediator(new LiteralExpression<short?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableInt16ExpressionMediator a, short? b) => new FilterExpression<bool?>(a, new NullableInt16ExpressionMediator(new LiteralExpression<short?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableInt16ExpressionMediator a, short? b) => new FilterExpression<bool?>(a, new NullableInt16ExpressionMediator(new LiteralExpression<short?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(short? a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new NullableInt16ExpressionMediator(new LiteralExpression<short?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(short? a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new NullableInt16ExpressionMediator(new LiteralExpression<short?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(short? a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new NullableInt16ExpressionMediator(new LiteralExpression<short?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(short? a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new NullableInt16ExpressionMediator(new LiteralExpression<short?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(short? a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new NullableInt16ExpressionMediator(new LiteralExpression<short?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(short? a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new NullableInt16ExpressionMediator(new LiteralExpression<short?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        
+        #region mediator
+        public static FilterExpression<bool?> operator ==(NullableInt16ExpressionMediator a, Int16ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableInt16ExpressionMediator a, Int16ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableInt16ExpressionMediator a, Int16ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableInt16ExpressionMediator a, Int16ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableInt16ExpressionMediator a, Int16ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableInt16ExpressionMediator a, Int16ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableInt16ExpressionMediator a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new Int16ExpressionMediator(a), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableInt16ExpressionMediator a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new Int16ExpressionMediator(a), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableInt16ExpressionMediator a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new Int16ExpressionMediator(a), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableInt16ExpressionMediator a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new Int16ExpressionMediator(a), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableInt16ExpressionMediator a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new Int16ExpressionMediator(a), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableInt16ExpressionMediator a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new Int16ExpressionMediator(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt32ExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt32ExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public NullableInt32ExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected NullableInt32ExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new NullableInt32ExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new NullableInt32ExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt32ExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt32ExpressionMediator.generated.cs
@@ -379,5 +379,53 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #endregion
         #endregion
+
+        #region filter operators
+        #region int
+        public static FilterExpression<bool?> operator ==(NullableInt32ExpressionMediator a, int b) => new FilterExpression<bool?>(a, new Int32ExpressionMediator(new LiteralExpression<int>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableInt32ExpressionMediator a, int b) => new FilterExpression<bool?>(a, new Int32ExpressionMediator(new LiteralExpression<int>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableInt32ExpressionMediator a, int b) => new FilterExpression<bool?>(a, new Int32ExpressionMediator(new LiteralExpression<int>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableInt32ExpressionMediator a, int b) => new FilterExpression<bool?>(a, new Int32ExpressionMediator(new LiteralExpression<int>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableInt32ExpressionMediator a, int b) => new FilterExpression<bool?>(a, new Int32ExpressionMediator(new LiteralExpression<int>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableInt32ExpressionMediator a, int b) => new FilterExpression<bool?>(a, new Int32ExpressionMediator(new LiteralExpression<int>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(int a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new Int32ExpressionMediator(new LiteralExpression<int>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(int a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new Int32ExpressionMediator(new LiteralExpression<int>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(int a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new Int32ExpressionMediator(new LiteralExpression<int>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(int a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new Int32ExpressionMediator(new LiteralExpression<int>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(int a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new Int32ExpressionMediator(new LiteralExpression<int>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(int a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new Int32ExpressionMediator(new LiteralExpression<int>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableInt32ExpressionMediator a, int? b) => new FilterExpression<bool?>(a, new NullableInt32ExpressionMediator(new LiteralExpression<int?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableInt32ExpressionMediator a, int? b) => new FilterExpression<bool?>(a, new NullableInt32ExpressionMediator(new LiteralExpression<int?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableInt32ExpressionMediator a, int? b) => new FilterExpression<bool?>(a, new NullableInt32ExpressionMediator(new LiteralExpression<int?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableInt32ExpressionMediator a, int? b) => new FilterExpression<bool?>(a, new NullableInt32ExpressionMediator(new LiteralExpression<int?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableInt32ExpressionMediator a, int? b) => new FilterExpression<bool?>(a, new NullableInt32ExpressionMediator(new LiteralExpression<int?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableInt32ExpressionMediator a, int? b) => new FilterExpression<bool?>(a, new NullableInt32ExpressionMediator(new LiteralExpression<int?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(int? a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new NullableInt32ExpressionMediator(new LiteralExpression<int?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(int? a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new NullableInt32ExpressionMediator(new LiteralExpression<int?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(int? a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new NullableInt32ExpressionMediator(new LiteralExpression<int?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(int? a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new NullableInt32ExpressionMediator(new LiteralExpression<int?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(int? a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new NullableInt32ExpressionMediator(new LiteralExpression<int?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(int? a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new NullableInt32ExpressionMediator(new LiteralExpression<int?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        
+        #region mediator
+        public static FilterExpression<bool?> operator ==(NullableInt32ExpressionMediator a, Int32ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableInt32ExpressionMediator a, Int32ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableInt32ExpressionMediator a, Int32ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableInt32ExpressionMediator a, Int32ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableInt32ExpressionMediator a, Int32ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableInt32ExpressionMediator a, Int32ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableInt32ExpressionMediator a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new Int32ExpressionMediator(a), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableInt32ExpressionMediator a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new Int32ExpressionMediator(a), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableInt32ExpressionMediator a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new Int32ExpressionMediator(a), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableInt32ExpressionMediator a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new Int32ExpressionMediator(a), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableInt32ExpressionMediator a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new Int32ExpressionMediator(a), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableInt32ExpressionMediator a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new Int32ExpressionMediator(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt64ExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt64ExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public NullableInt64ExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected NullableInt64ExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new NullableInt64ExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new NullableInt64ExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt64ExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt64ExpressionMediator.generated.cs
@@ -379,5 +379,53 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #endregion
         #endregion
+
+        #region filter operators
+        #region long
+        public static FilterExpression<bool?> operator ==(NullableInt64ExpressionMediator a, long b) => new FilterExpression<bool?>(a, new Int64ExpressionMediator(new LiteralExpression<long>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableInt64ExpressionMediator a, long b) => new FilterExpression<bool?>(a, new Int64ExpressionMediator(new LiteralExpression<long>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableInt64ExpressionMediator a, long b) => new FilterExpression<bool?>(a, new Int64ExpressionMediator(new LiteralExpression<long>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableInt64ExpressionMediator a, long b) => new FilterExpression<bool?>(a, new Int64ExpressionMediator(new LiteralExpression<long>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableInt64ExpressionMediator a, long b) => new FilterExpression<bool?>(a, new Int64ExpressionMediator(new LiteralExpression<long>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableInt64ExpressionMediator a, long b) => new FilterExpression<bool?>(a, new Int64ExpressionMediator(new LiteralExpression<long>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(long a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new Int64ExpressionMediator(new LiteralExpression<long>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(long a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new Int64ExpressionMediator(new LiteralExpression<long>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(long a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new Int64ExpressionMediator(new LiteralExpression<long>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(long a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new Int64ExpressionMediator(new LiteralExpression<long>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(long a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new Int64ExpressionMediator(new LiteralExpression<long>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(long a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new Int64ExpressionMediator(new LiteralExpression<long>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableInt64ExpressionMediator a, long? b) => new FilterExpression<bool?>(a, new NullableInt64ExpressionMediator(new LiteralExpression<long?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableInt64ExpressionMediator a, long? b) => new FilterExpression<bool?>(a, new NullableInt64ExpressionMediator(new LiteralExpression<long?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableInt64ExpressionMediator a, long? b) => new FilterExpression<bool?>(a, new NullableInt64ExpressionMediator(new LiteralExpression<long?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableInt64ExpressionMediator a, long? b) => new FilterExpression<bool?>(a, new NullableInt64ExpressionMediator(new LiteralExpression<long?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableInt64ExpressionMediator a, long? b) => new FilterExpression<bool?>(a, new NullableInt64ExpressionMediator(new LiteralExpression<long?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableInt64ExpressionMediator a, long? b) => new FilterExpression<bool?>(a, new NullableInt64ExpressionMediator(new LiteralExpression<long?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(long? a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new NullableInt64ExpressionMediator(new LiteralExpression<long?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(long? a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new NullableInt64ExpressionMediator(new LiteralExpression<long?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(long? a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new NullableInt64ExpressionMediator(new LiteralExpression<long?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(long? a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new NullableInt64ExpressionMediator(new LiteralExpression<long?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(long? a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new NullableInt64ExpressionMediator(new LiteralExpression<long?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(long? a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new NullableInt64ExpressionMediator(new LiteralExpression<long?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        
+        #region mediator
+        public static FilterExpression<bool?> operator ==(NullableInt64ExpressionMediator a, Int64ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableInt64ExpressionMediator a, Int64ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableInt64ExpressionMediator a, Int64ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableInt64ExpressionMediator a, Int64ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableInt64ExpressionMediator a, Int64ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableInt64ExpressionMediator a, Int64ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableInt64ExpressionMediator a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new Int64ExpressionMediator(a), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableInt64ExpressionMediator a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new Int64ExpressionMediator(a), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableInt64ExpressionMediator a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new Int64ExpressionMediator(a), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableInt64ExpressionMediator a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new Int64ExpressionMediator(a), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableInt64ExpressionMediator a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new Int64ExpressionMediator(a), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableInt64ExpressionMediator a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new Int64ExpressionMediator(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableSingleExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableSingleExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public NullableSingleExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected NullableSingleExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new NullableSingleExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new NullableSingleExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableSingleExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableSingleExpressionMediator.generated.cs
@@ -379,5 +379,53 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #endregion
         #endregion
+
+        #region filter operators
+        #region float
+        public static FilterExpression<bool?> operator ==(NullableSingleExpressionMediator a, float b) => new FilterExpression<bool?>(a, new SingleExpressionMediator(new LiteralExpression<float>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableSingleExpressionMediator a, float b) => new FilterExpression<bool?>(a, new SingleExpressionMediator(new LiteralExpression<float>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableSingleExpressionMediator a, float b) => new FilterExpression<bool?>(a, new SingleExpressionMediator(new LiteralExpression<float>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableSingleExpressionMediator a, float b) => new FilterExpression<bool?>(a, new SingleExpressionMediator(new LiteralExpression<float>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableSingleExpressionMediator a, float b) => new FilterExpression<bool?>(a, new SingleExpressionMediator(new LiteralExpression<float>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableSingleExpressionMediator a, float b) => new FilterExpression<bool?>(a, new SingleExpressionMediator(new LiteralExpression<float>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(float a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new SingleExpressionMediator(new LiteralExpression<float>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(float a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new SingleExpressionMediator(new LiteralExpression<float>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(float a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new SingleExpressionMediator(new LiteralExpression<float>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(float a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new SingleExpressionMediator(new LiteralExpression<float>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(float a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new SingleExpressionMediator(new LiteralExpression<float>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(float a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new SingleExpressionMediator(new LiteralExpression<float>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableSingleExpressionMediator a, float? b) => new FilterExpression<bool?>(a, new NullableSingleExpressionMediator(new LiteralExpression<float?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableSingleExpressionMediator a, float? b) => new FilterExpression<bool?>(a, new NullableSingleExpressionMediator(new LiteralExpression<float?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableSingleExpressionMediator a, float? b) => new FilterExpression<bool?>(a, new NullableSingleExpressionMediator(new LiteralExpression<float?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableSingleExpressionMediator a, float? b) => new FilterExpression<bool?>(a, new NullableSingleExpressionMediator(new LiteralExpression<float?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableSingleExpressionMediator a, float? b) => new FilterExpression<bool?>(a, new NullableSingleExpressionMediator(new LiteralExpression<float?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableSingleExpressionMediator a, float? b) => new FilterExpression<bool?>(a, new NullableSingleExpressionMediator(new LiteralExpression<float?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(float? a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new NullableSingleExpressionMediator(new LiteralExpression<float?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(float? a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new NullableSingleExpressionMediator(new LiteralExpression<float?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(float? a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new NullableSingleExpressionMediator(new LiteralExpression<float?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(float? a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new NullableSingleExpressionMediator(new LiteralExpression<float?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(float? a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new NullableSingleExpressionMediator(new LiteralExpression<float?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(float? a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new NullableSingleExpressionMediator(new LiteralExpression<float?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        
+        #region mediator
+        public static FilterExpression<bool?> operator ==(NullableSingleExpressionMediator a, SingleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableSingleExpressionMediator a, SingleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableSingleExpressionMediator a, SingleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableSingleExpressionMediator a, SingleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableSingleExpressionMediator a, SingleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableSingleExpressionMediator a, SingleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableSingleExpressionMediator a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new SingleExpressionMediator(a), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(NullableSingleExpressionMediator a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new SingleExpressionMediator(a), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(NullableSingleExpressionMediator a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new SingleExpressionMediator(a), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(NullableSingleExpressionMediator a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new SingleExpressionMediator(a), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(NullableSingleExpressionMediator a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new SingleExpressionMediator(a), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(NullableSingleExpressionMediator a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new SingleExpressionMediator(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/SingleExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/SingleExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public SingleExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected SingleExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new SingleExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new SingleExpressionMediator(this.Expression, alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/SingleExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/SingleExpressionMediator.generated.cs
@@ -384,5 +384,49 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #endregion
         #endregion
+
+        #region filter operators
+        public static FilterExpression<bool> operator ==(SingleExpressionMediator a, float b) => new FilterExpression<bool>(a, new SingleExpressionMediator(new LiteralExpression<float>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(SingleExpressionMediator a, float b) => new FilterExpression<bool>(a, new SingleExpressionMediator(new LiteralExpression<float>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(SingleExpressionMediator a, float b) => new FilterExpression<bool>(a, new SingleExpressionMediator(new LiteralExpression<float>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(SingleExpressionMediator a, float b) => new FilterExpression<bool>(a, new SingleExpressionMediator(new LiteralExpression<float>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(SingleExpressionMediator a, float b) => new FilterExpression<bool>(a, new SingleExpressionMediator(new LiteralExpression<float>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(SingleExpressionMediator a, float b) => new FilterExpression<bool>(a, new SingleExpressionMediator(new LiteralExpression<float>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(float a, SingleExpressionMediator b) => new FilterExpression<bool>(new SingleExpressionMediator(new LiteralExpression<float>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(float a, SingleExpressionMediator b) => new FilterExpression<bool>(new SingleExpressionMediator(new LiteralExpression<float>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(float a, SingleExpressionMediator b) => new FilterExpression<bool>(new SingleExpressionMediator(new LiteralExpression<float>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(float a, SingleExpressionMediator b) => new FilterExpression<bool>(new SingleExpressionMediator(new LiteralExpression<float>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(float a, SingleExpressionMediator b) => new FilterExpression<bool>(new SingleExpressionMediator(new LiteralExpression<float>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(float a, SingleExpressionMediator b) => new FilterExpression<bool>(new SingleExpressionMediator(new LiteralExpression<float>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(SingleExpressionMediator a, float? b) => new FilterExpression<bool>(a, new SingleExpressionMediator(new LiteralExpression<float?>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(SingleExpressionMediator a, float? b) => new FilterExpression<bool>(a, new SingleExpressionMediator(new LiteralExpression<float?>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(SingleExpressionMediator a, float? b) => new FilterExpression<bool>(a, new SingleExpressionMediator(new LiteralExpression<float?>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(SingleExpressionMediator a, float? b) => new FilterExpression<bool>(a, new SingleExpressionMediator(new LiteralExpression<float?>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(SingleExpressionMediator a, float? b) => new FilterExpression<bool>(a, new SingleExpressionMediator(new LiteralExpression<float?>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(SingleExpressionMediator a, float? b) => new FilterExpression<bool>(a, new SingleExpressionMediator(new LiteralExpression<float?>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(float? a, SingleExpressionMediator b) => new FilterExpression<bool>(new SingleExpressionMediator(new LiteralExpression<float?>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(float? a, SingleExpressionMediator b) => new FilterExpression<bool>(new SingleExpressionMediator(new LiteralExpression<float?>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(float? a, SingleExpressionMediator b) => new FilterExpression<bool>(new SingleExpressionMediator(new LiteralExpression<float?>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(float? a, SingleExpressionMediator b) => new FilterExpression<bool>(new SingleExpressionMediator(new LiteralExpression<float?>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(float? a, SingleExpressionMediator b) => new FilterExpression<bool>(new SingleExpressionMediator(new LiteralExpression<float?>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(float? a, SingleExpressionMediator b) => new FilterExpression<bool>(new SingleExpressionMediator(new LiteralExpression<float?>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(SingleExpressionMediator a, SingleExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(SingleExpressionMediator a, SingleExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(SingleExpressionMediator a, SingleExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(SingleExpressionMediator a, SingleExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(SingleExpressionMediator a, SingleExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(SingleExpressionMediator a, SingleExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool?> operator ==(SingleExpressionMediator a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool?> operator !=(SingleExpressionMediator a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool?> operator <(SingleExpressionMediator a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool?> operator <=(SingleExpressionMediator a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool?> operator >(SingleExpressionMediator a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool?> operator >=(SingleExpressionMediator a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/StringExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/StringExpressionMediator.cs
@@ -14,14 +14,15 @@ namespace HatTrick.DbEx.Sql.Expression
         public StringExpressionMediator(IExpression expression) : base(expression)
         {
         }
+
+        protected StringExpressionMediator(IExpression expression, string alias) : base(expression, alias)
+        {
+        }
         #endregion
 
         #region as
         public new StringExpressionMediator As(string alias)
-        {
-            base.As(alias);
-            return this;
-        }
+            => new StringExpressionMediator(this.Expression, alias);
         #endregion
 
         #region like

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/StringExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/StringExpressionMediator.generated.cs
@@ -270,5 +270,30 @@ namespace HatTrick.DbEx.Sql.Expression
         #region mediator
         #endregion
         #endregion
+
+        #region filter operators
+        public static FilterExpression<bool> operator ==(StringExpressionMediator a, string b) => new FilterExpression<bool>(a, new StringExpressionMediator(new LiteralExpression<string>(b)), FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(StringExpressionMediator a, string b) => new FilterExpression<bool>(a, new StringExpressionMediator(new LiteralExpression<string>(b)), FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(StringExpressionMediator a, string b) => new FilterExpression<bool>(a, new StringExpressionMediator(new LiteralExpression<string>(b)), FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(StringExpressionMediator a, string b) => new FilterExpression<bool>(a, new StringExpressionMediator(new LiteralExpression<string>(b)), FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(StringExpressionMediator a, string b) => new FilterExpression<bool>(a, new StringExpressionMediator(new LiteralExpression<string>(b)), FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(StringExpressionMediator a, string b) => new FilterExpression<bool>(a, new StringExpressionMediator(new LiteralExpression<string>(b)), FilterExpressionOperator.GreaterThanOrEqual);
+
+        public static FilterExpression<bool> operator ==(string a, StringExpressionMediator b) => new FilterExpression<bool>(new StringExpressionMediator(new LiteralExpression<string>(a)), b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(string a, StringExpressionMediator b) => new FilterExpression<bool>(new StringExpressionMediator(new LiteralExpression<string>(a)), b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(string a, StringExpressionMediator b) => new FilterExpression<bool>(new StringExpressionMediator(new LiteralExpression<string>(a)), b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(string a, StringExpressionMediator b) => new FilterExpression<bool>(new StringExpressionMediator(new LiteralExpression<string>(a)), b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(string a, StringExpressionMediator b) => new FilterExpression<bool>(new StringExpressionMediator(new LiteralExpression<string>(a)), b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(string a, StringExpressionMediator b) => new FilterExpression<bool>(new StringExpressionMediator(new LiteralExpression<string>(a)), b, FilterExpressionOperator.GreaterThanOrEqual);
+
+
+        public static FilterExpression<bool> operator ==(StringExpressionMediator a, StringExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.Equal);
+        public static FilterExpression<bool> operator !=(StringExpressionMediator a, StringExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.NotEqual);
+        public static FilterExpression<bool> operator <(StringExpressionMediator a, StringExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThan);
+        public static FilterExpression<bool> operator <=(StringExpressionMediator a, StringExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.LessThanOrEqual);
+        public static FilterExpression<bool> operator >(StringExpressionMediator a, StringExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThan);
+        public static FilterExpression<bool> operator >=(StringExpressionMediator a, StringExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.GreaterThanOrEqual);
+
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/_Extensions/Attribute/ConditionalExpressionOperatorAttributeExtensions.cs
+++ b/src/HatTrick.DbEx.Sql/_Extensions/Attribute/ConditionalExpressionOperatorAttributeExtensions.cs
@@ -30,7 +30,7 @@ namespace HatTrick.DbEx.Sql.Attribute
         public static ConditionalExpressionOperator GetConditionalOperator(this string value)
         {
             if (string.IsNullOrWhiteSpace(value))
-                return default(ConditionalExpressionOperator);
+                return default;
 
             var values = Enum.GetValues(typeof(ConditionalExpressionOperator));
             var fi = typeof(ConditionalExpressionOperator).GetFields();
@@ -48,13 +48,13 @@ namespace HatTrick.DbEx.Sql.Attribute
             if (Enum.TryParse(value, true, out ConditionalExpressionOperator parsedValue))
                 return parsedValue;
 
-            return default(ConditionalExpressionOperator);
+            return default;
         }
 
         public static SortedDictionary<ConditionalExpressionOperator, string> GetValuesAndConditionalOperators(this Type type)
         {
             if (type != typeof(ConditionalExpressionOperator))
-                throw new InvalidOperationException("Type must be DBConditionalExpressionOperator");
+                throw new InvalidOperationException($"Type must be {nameof(ConditionalExpressionOperator)}");
 
             var sortedDictionary = new SortedDictionary<ConditionalExpressionOperator, string>();
             foreach (var value in Enum.GetValues(type))

--- a/src/HatTrick.DbEx.Sql/_Extensions/Attribute/FilterExpressionOperatorAttributeExtensions.cs
+++ b/src/HatTrick.DbEx.Sql/_Extensions/Attribute/FilterExpressionOperatorAttributeExtensions.cs
@@ -30,7 +30,7 @@ namespace HatTrick.DbEx.Sql.Attribute
         public static FilterExpressionOperator GetFilterOperator(this string value)
         {
             if (string.IsNullOrWhiteSpace(value))
-                return default(FilterExpressionOperator);
+                return default;
 
             var values = Enum.GetValues(typeof(FilterExpressionOperator));
             var fi = typeof(FilterExpressionOperator).GetFields();
@@ -48,13 +48,13 @@ namespace HatTrick.DbEx.Sql.Attribute
             if (Enum.TryParse(value, true, out FilterExpressionOperator parsedValue))
                 return parsedValue;
 
-            return default(FilterExpressionOperator);
+            return default;
         }
 
         public static SortedDictionary<FilterExpressionOperator, string> GetValuesAndFilterOperators(this Type type)
         {
             if (type != typeof(FilterExpressionOperator))
-                throw new InvalidOperationException("Type must be DBFilterExpressionOperator");
+                throw new InvalidOperationException($"Type must be {nameof(FilterExpressionOperator)}");
 
             var sortedDictionary = new SortedDictionary<FilterExpressionOperator, string>();
             foreach (var value in Enum.GetValues(type))

--- a/test/HatTrick.DbEx.MsSql.Test.Code/MetadataProviderTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Code/MetadataProviderTests.cs
@@ -9,7 +9,7 @@ namespace HatTrick.DbEx.MsSql.Test.Code
     {
         [Theory]
         [MsSqlVersions.AllVersions]
-        public void Can_resolve_metadata_for_a_schema(int version, string identifier = "MsSqlDbExTest.dbo")
+        public void Can_resolve_metadata_for_a_schema(int version, string identifier = "dbo")
         {
             //given
             var config = ConfigureForMsSqlVersion(version);
@@ -22,7 +22,7 @@ namespace HatTrick.DbEx.MsSql.Test.Code
 
         [Theory]
         [MsSqlVersions.AllVersions]
-        public void Can_resolve_metadata_for_an_entity(int version, string identifier = "MsSqlDbExTest.dbo.Address")
+        public void Can_resolve_metadata_for_an_entity(int version, string identifier = "dbo.Address")
         {
             //given
             var config = ConfigureForMsSqlVersion(version);
@@ -35,7 +35,7 @@ namespace HatTrick.DbEx.MsSql.Test.Code
 
         [Theory]
         [MsSqlVersions.AllVersions]
-        public void Can_resolve_metadata_for_an_entity_that_was_generated_with_name_override(int version, string identifier = "MsSqlDbExTest.dbo.Person_Address")
+        public void Can_resolve_metadata_for_an_entity_that_was_generated_with_name_override(int version, string identifier = "dbo.Person_Address")
         {
             //given
             var config = ConfigureForMsSqlVersion(version);
@@ -48,7 +48,7 @@ namespace HatTrick.DbEx.MsSql.Test.Code
 
         [Theory]
         [MsSqlVersions.AllVersions]
-        public void Can_resolve_metadata_for_a_field(int version, string identifier = "MsSqlDbExTest.dbo.Address.Id")
+        public void Can_resolve_metadata_for_a_field(int version, string identifier = "dbo.Address.Id")
         {
             //given
             var config = ConfigureForMsSqlVersion(version);

--- a/test/HatTrick.DbEx.MsSql.Test/Generated/EntityProvider.cs
+++ b/test/HatTrick.DbEx.MsSql.Test/Generated/EntityProvider.cs
@@ -9,7 +9,7 @@ namespace DbEx.dboDataService
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
         #region internals
-        private static readonly dboSchemaExpression _schema = new dboSchemaExpression("MsSqlDbExTest.dbo");
+        private static readonly dboSchemaExpression _schema = new dboSchemaExpression("dbo");
         #endregion
 
         #region interface
@@ -41,7 +41,7 @@ namespace DbEx.secDataService
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
         #region internals
-        private static readonly secSchemaExpression _schema = new secSchemaExpression("MsSqlDbExTest.sec");
+        private static readonly secSchemaExpression _schema = new secSchemaExpression("sec");
         #endregion
 
         #region interface

--- a/test/HatTrick.DbEx.MsSql.Test/Generated/Metadata.cs
+++ b/test/HatTrick.DbEx.MsSql.Test/Generated/Metadata.cs
@@ -15,11 +15,6 @@ namespace DbEx.DataService
 
     public class MsSqlDbExTestSqlDatabaseMetadata : ISqlDatabaseMetadata
     {
-        #region internals
-        private static string _dboSchemaIdentifier;
-        private static string _secSchemaIdentifier;
-        #endregion
-
         #region interface
         public string Identifier { get; private set; }
         public string Name { get; private set; }
@@ -31,8 +26,8 @@ namespace DbEx.DataService
         {
             Identifier = identifier;
             Name = name;
-            Schemas.Add(_dboSchemaIdentifier = $"{identifier}.dbo", new dboSchemaMetadata(this, _dboSchemaIdentifier, "dbo"));
-            Schemas.Add(_secSchemaIdentifier = $"{identifier}.sec", new secSchemaMetadata(this, _secSchemaIdentifier, "sec"));
+            Schemas.Add("dbo", new dboSchemaMetadata(this, "dbo", "dbo"));
+            Schemas.Add("sec", new secSchemaMetadata(this, "sec", "sec"));
         }
         #endregion
     }

--- a/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Mediator/TypedExpressionMediator.txt
+++ b/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Mediator/TypedExpressionMediator.txt
@@ -57,5 +57,35 @@ namespace {Namespace}
         {/each}
         #endregion
         #endregion
+
+        #region filter operators
+        {#each FilterOperations}
+        public static FilterExpression<bool> operator {$.FilterOperatorSymbol}({..\$.Type.Name}ExpressionMediator a, {..\$.Type.Alias} b) => new FilterExpression<bool>(a, new {..\$.Type.Name}ExpressionMediator(new LiteralExpression<{..\$.Type.Alias}>(b)), FilterExpressionOperator.{$.FilterOperatorName});
+        {/each}
+
+        {#each FilterOperations}
+        public static FilterExpression<bool> operator {$.FilterOperatorSymbol}({..\$.Type.Alias} a, {..\$.Type.Name}ExpressionMediator b) => new FilterExpression<bool>(new {..\$.Type.Name}ExpressionMediator(new LiteralExpression<{..\$.Type.Alias}>(a)), b, FilterExpressionOperator.{$.FilterOperatorName});
+        {/each}
+
+        {#if Type.IsNullable}
+        {#each FilterOperations}
+        public static FilterExpression<bool> operator {$.FilterOperatorSymbol}({..\$.Type.Name}ExpressionMediator a, {..\$.Type.Alias}? b) => new FilterExpression<bool>(a, new {..\$.Type.Name}ExpressionMediator(new LiteralExpression<{..\$.Type.Alias}?>(b)), FilterExpressionOperator.{$.FilterOperatorName});
+        {/each}
+
+        {#each FilterOperations}
+        public static FilterExpression<bool> operator {$.FilterOperatorSymbol}({..\$.Type.Alias}? a, {..\$.Type.Name}ExpressionMediator b) => new FilterExpression<bool>(new {..\$.Type.Name}ExpressionMediator(new LiteralExpression<{..\$.Type.Alias}?>(a)), b, FilterExpressionOperator.{$.FilterOperatorName});
+        {/each}
+        {/if}
+
+        {#each FilterOperations}
+        public static FilterExpression<bool> operator {$.FilterOperatorSymbol}({..\$.Type.Name}ExpressionMediator a, {..\$.Type.Name}ExpressionMediator b) => new FilterExpression<bool>(a, b, FilterExpressionOperator.{$.FilterOperatorName});
+        {/each}
+
+        {#if Type.IsNullable}
+        {#each FilterOperations}
+        public static FilterExpression<bool?> operator {$.FilterOperatorSymbol}({..\$.Type.Name}ExpressionMediator a, Nullable{..\$.Type.Name}ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.{$.FilterOperatorName});
+        {/each}
+        {/if}
+        #endregion
     }}
 }}

--- a/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Mediator/TypedNullableExpressionMediator.txt
+++ b/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Mediator/TypedNullableExpressionMediator.txt
@@ -57,5 +57,39 @@ namespace {Namespace}
         {/each}
         #endregion
         #endregion
+
+        #region filter operators
+        #region {Type.Alias}
+        {#each FilterOperations}
+        public static FilterExpression<bool?> operator {$.FilterOperatorSymbol}(Nullable{..\$.Type.Name}ExpressionMediator a, {..\$.Type.Alias} b) => new FilterExpression<bool?>(a, new {..\$.Type.Name}ExpressionMediator(new LiteralExpression<{..\$.Type.Alias}>(b)), FilterExpressionOperator.{$.FilterOperatorName});
+        {/each}
+
+        {#each FilterOperations}
+        public static FilterExpression<bool?> operator {$.FilterOperatorSymbol}({..\$.Type.Alias} a, Nullable{..\$.Type.Name}ExpressionMediator b) => new FilterExpression<bool?>(new {..\$.Type.Name}ExpressionMediator(new LiteralExpression<{..\$.Type.Alias}>(a)), b, FilterExpressionOperator.{$.FilterOperatorName});
+        {/each}
+
+        {#if Type.IsNullable}
+        {#each FilterOperations}
+        public static FilterExpression<bool?> operator {$.FilterOperatorSymbol}(Nullable{..\$.Type.Name}ExpressionMediator a, {..\$.Type.Alias}? b) => new FilterExpression<bool?>(a, new Nullable{..\$.Type.Name}ExpressionMediator(new LiteralExpression<{..\$.Type.Alias}?>(b)), FilterExpressionOperator.{$.FilterOperatorName});
+        {/each}
+
+        {#each FilterOperations}
+        public static FilterExpression<bool?> operator {$.FilterOperatorSymbol}({..\$.Type.Alias}? a, Nullable{..\$.Type.Name}ExpressionMediator b) => new FilterExpression<bool?>(new Nullable{..\$.Type.Name}ExpressionMediator(new LiteralExpression<{..\$.Type.Alias}?>(a)), b, FilterExpressionOperator.{$.FilterOperatorName});
+        {/each}
+        {/if}
+        #endregion
+        
+        #region mediator
+        {#each FilterOperations}
+        public static FilterExpression<bool?> operator {$.FilterOperatorSymbol}(Nullable{..\$.Type.Name}ExpressionMediator a, {..\$.Type.Name}ExpressionMediator b) => new FilterExpression<bool?>(a, b, FilterExpressionOperator.{$.FilterOperatorName});
+        {/each}
+
+        {#if Type.IsNullable}
+        {#each FilterOperations}
+        public static FilterExpression<bool?> operator {$.FilterOperatorSymbol}(Nullable{..\$.Type.Name}ExpressionMediator a, Nullable{..\$.Type.Name}ExpressionMediator b) => new FilterExpression<bool?>(new {..\$.Type.Name}ExpressionMediator(a), b, FilterExpressionOperator.{$.FilterOperatorName});
+        {/each}
+        {/if}
+        #endregion
+        #endregion
     }}
 }}

--- a/tools/HatTrick.DbEx.Tools/Resources/Templates/EntityProvider.Template.txt
+++ b/tools/HatTrick.DbEx.Tools/Resources/Templates/EntityProvider.Template.txt
@@ -10,7 +10,7 @@ namespace {() => ResolveRootNamespace}{($) => ResolveName}DataService
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {{
         #region internals
-        private static readonly {($) => ResolveName}SchemaExpression _schema = new {($) => ResolveName}SchemaExpression("{..\$.Name}.{$.Name}");
+        private static readonly {($) => ResolveName}SchemaExpression _schema = new {($) => ResolveName}SchemaExpression("{$.Name}");
         #endregion
 
         #region interface

--- a/tools/HatTrick.DbEx.Tools/Resources/Templates/Metadata.Template.txt
+++ b/tools/HatTrick.DbEx.Tools/Resources/Templates/Metadata.Template.txt
@@ -10,7 +10,7 @@ namespace {() => ResolveRootNamespace}DataService
 
     public class {($) => ResolveName} : RuntimeEnvironmentSqlDatabase
     {{
-        public {($) => ResolveName}() : base(new db(), new SqlDatabaseMetadataProvider(new {($) => ResolveName}SqlDatabaseMetadata("{($) => ResolveName}", "{($) => ResolveName}"))) 
+        public {($) => ResolveName}() : base(new db(), new SqlDatabaseMetadataProvider(new {($) => ResolveName}SqlDatabaseMetadata("{$.Name}", "{($) => ResolveName}"))) 
         {{ 
         
         }}
@@ -18,14 +18,6 @@ namespace {() => ResolveRootNamespace}DataService
 
     public class {($) => ResolveName}SqlDatabaseMetadata : ISqlDatabaseMetadata
     {{
-        #region internals
-		{#each Schemas}
-		{#if !($) => IsIgnored}
-        private static string _{($) => ToCamelCase}SchemaIdentifier;
-		{/if}
-		{/each}
-        #endregion
-
         #region interface
         public string Identifier {{ get; private set; }}
         public string Name {{ get; private set; }}
@@ -39,7 +31,7 @@ namespace {() => ResolveRootNamespace}DataService
             Name = name;
 			{#each Schemas}
 			{#if !($) => IsIgnored}
-            Schemas.Add(_{($) => ToCamelCase}SchemaIdentifier = $"{{identifier}}.{$.Name}", new {($) => ResolveName}SchemaMetadata(this, _{($) => ToCamelCase}SchemaIdentifier, "{$.Name}"));
+            Schemas.Add("{$.Name}", new {($) => ResolveName}SchemaMetadata(this, "{$.Name}", "{$.Name}"));
 			{/if}
 			{/each}
         }}


### PR DESCRIPTION
- Added generated code to support filter expression operator overloads for expression mediators
- Reworked "As" methods for expression mediators to build a new instance of the mediator instead of aliasing the same instance (shared instances all had aliases when a single instance was aliased)
- Removed database name from identifiers for field, entity, and schema expressions and field, entity, and schema metadata