### PR TITLE
Used branch name in version when suffix not supplied (and not master)…

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ stages:
         displayName: 'Build and Package Solution'
         inputs:
           filePath: '$(Build.SourcesDirectory)/build.ps1'
-          arguments: '-Configuration $(buildConfiguration) -BranchName $(Build.SourceBranchName) -CommitSHA $(Build.SourceVersion) -BuildIdentifier $(Build.BuildNumber)'
+          arguments: '-Configuration $(buildConfiguration) -BranchName $(Build.SourceBranchName) -CommitSHA $(Build.SourceVersion) -BuildIdentifier $(Build.BuildNumber) -UseBranchNameAsVersionSuffixWhenNotSupplied'
           workingDirectory: $(Build.SourcesDirectory)
           pwsh: true
         

--- a/build.props.json
+++ b/build.props.json
@@ -40,7 +40,7 @@
 			major: 1,
 			minor: 0,
 			nuGet: {
-				patch: 12,
+				patch: 0,
 				id: "HatTrick.DbEx.MsSql",
 				title: "DbExpression for Microsoft Sql Server",
 				authors: "jerrod.eiman, gwgrubbs",

--- a/build/HatTrick/AssemblyVersion/AssemblyVersion.psm1
+++ b/build/HatTrick/AssemblyVersion/AssemblyVersion.psm1
@@ -11,7 +11,7 @@ class AssemblyVersion
     [DateTime]$CurrentUtcDate
 
     [string]$AssemblyVersion
-
+    [string]$AssemblyInformationalVersion
 
     AssemblyVersion(
         [string]$Major,
@@ -34,6 +34,20 @@ class AssemblyVersion
         $this.Revision = [int]((New-TimeSpan -Start (New-Object "System.DateTime" -ArgumentList $this.CurrentUtcDate.Year, $this.CurrentUtcDate.Month, $this.CurrentUtcDate.Day) -End $this.CurrentUtcDate).TotalSeconds / 2)
 
         $this.AssemblyVersion = "{0}.{1}.{2}.{3}" -f $this.Major, $this.Minor, $this.Build, $this.Revision
+        
+        if ([string]::IsNullOrEmpty($this.Patch))
+        {
+            $this.AssemblyInformationalVersion = $this.AssemblyVersion
+        }
+        else
+        {
+            $version = "{0}.{1}.{2}" -f $this.Major, $this.Minor, $this.Patch
+            if (![string]::IsNullOrEmpty($this.Suffix))
+            {
+                $version = "{0}-{1}" -f $version, $this.Suffix
+            }      
+            $this.AssemblyInformationalVersion = $version
+       }
     }
 
     [string] ToAssemblyVersionAttribute()

--- a/build/HatTrick/Project/Project.psm1
+++ b/build/HatTrick/Project/Project.psm1
@@ -248,7 +248,9 @@ function New-BuildPropsFile()
         [Parameter(ValueFromPipelineByPropertyName)]
         [Project]$Project,
         [Parameter(ValueFromPipelineByPropertyName)]
-        [string]$CompanyName
+        [string]$CompanyName,
+        [Parameter(ValueFromPipelineByPropertyName)]
+        [AssemblyVersion]$AssemblyVersion
     )
 
     $dependencies = $Project.GetProjectDependencies()    
@@ -280,6 +282,7 @@ function New-BuildPropsFile()
 
         $props.WriteElementString("Id", $Project.Id)
         $props.WriteElementString("Title", $Project.Title)
+        $props.WriteElementString("Version", $AssemblyVersion.AssemblyInformationalVersion)
         $props.WriteElementString("Authors", $Project.Authors)
         $props.WriteElementString("RequireLicenseAcceptance", $Project.RequireLicenseAcceptance ? "true" : "false")    
         $props.WriteElementString("PackageLicenseExpression", $Project.LicenseType)


### PR DESCRIPTION
….  Fixed nuget package version that was pulling wrong version (moved to Directory.build.props)