### PR TITLE
Shared parameters and fixing issues with aliasing

### DIFF
--- a/src/HatTrick.DbEx.MsSql/Assembler/MsSqlParameterBuilderFactory.cs
+++ b/src/HatTrick.DbEx.MsSql/Assembler/MsSqlParameterBuilderFactory.cs
@@ -1,18 +1,18 @@
-﻿using HatTrick.DbEx.Sql.Assembler;
+﻿using HatTrick.DbEx.MsSql.Types;
+using HatTrick.DbEx.Sql.Assembler;
 using System;
-using System.Data;
 
 namespace HatTrick.DbEx.MsSql.Assembler
 {
     public class MsSqlParameterBuilderFactory : ISqlParameterBuilderFactory
     {
-        private readonly Func<Type, SqlDbType> typeMap;
+        private readonly MsSqlTypeMaps typeMaps;
 
-        public MsSqlParameterBuilderFactory(Func<Type, SqlDbType> typeMap)
+        public MsSqlParameterBuilderFactory(MsSqlTypeMaps typeMaps)
         {
-            this.typeMap = typeMap ?? throw new ArgumentNullException($"{nameof(typeMap)} is required.");
+            this.typeMaps = typeMaps ?? throw new ArgumentNullException($"{nameof(typeMaps)} is required.");
         }
 
-        public ISqlParameterBuilder CreateSqlParameterBuilder() => new MsSqlParameterBuilder(typeMap);
+        public ISqlParameterBuilder CreateSqlParameterBuilder() => new MsSqlParameterBuilder(typeMaps);
     }
 }

--- a/src/HatTrick.DbEx.MsSql/Types/MsSqlTypeMap.cs
+++ b/src/HatTrick.DbEx.MsSql/Types/MsSqlTypeMap.cs
@@ -1,407 +1,70 @@
-﻿using System;
+﻿using HatTrick.DbEx.Sql.Types;
+using System;
 using System.Collections.Generic;
 using System.Data;
-using HatTrick.DbEx.Sql;
+using System.Linq;
 
 namespace HatTrick.DbEx.MsSql.Types
 {
-    public static class MsSqlTypeMap
+    public class MsSqlTypeMaps : DbTypeMaps<SqlDbType>
     {
         #region internals
-        private static Dictionary<Type, SqlDbType> sqlTypeMap = new Dictionary<Type, SqlDbType>()
+        private static readonly HashSet<DbTypeMap<SqlDbType>> typeMaps = new HashSet<DbTypeMap<SqlDbType>>()
         {
-            { typeof(string), SqlDbType.VarChar }, //TODO: JRod, how varchar/nvarchar (sqlserver isnt picky...sqlce is ?)
-            { typeof(int), SqlDbType.Int },
-            { typeof(decimal), SqlDbType.Decimal },
-            { typeof(DateTime), SqlDbType.DateTime },
-            { typeof(bool), SqlDbType.Bit },
-            { typeof(byte), SqlDbType.TinyInt },
-            { typeof(long), SqlDbType.BigInt },
-            { typeof(object), SqlDbType.Binary },
-            { typeof(double), SqlDbType.Float },
-            { typeof(float), SqlDbType.Real },
-            { typeof(short), SqlDbType.SmallInt },
-            { typeof(Guid), SqlDbType.UniqueIdentifier },
-            { typeof(byte[]), SqlDbType.VarBinary },
-            { typeof(ushort), SqlDbType.SmallInt },
-            { typeof(sbyte), SqlDbType.TinyInt },
-            { typeof(uint), SqlDbType.Int },
-            { typeof(TimeSpan), SqlDbType.Time },
-            
-            { typeof(int?), SqlDbType.Int },
-            { typeof(bool?), SqlDbType.Bit },
-            { typeof(DateTime?), SqlDbType.DateTime },
-            { typeof(decimal?), SqlDbType.Decimal },
-            { typeof(long?), SqlDbType.BigInt },
-            { typeof(ulong?), SqlDbType.BigInt },
-            { typeof(double?), SqlDbType.Float },
-            { typeof(float?), SqlDbType.Real },
-            { typeof(short?), SqlDbType.SmallInt },
-            { typeof(ushort?), SqlDbType.SmallInt },
-            { typeof(byte?), SqlDbType.TinyInt },
-            { typeof(sbyte?), SqlDbType.TinyInt },
-            { typeof(uint?), SqlDbType.Int }
+            //reference: https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/sql-server-data-type-mappings
+            new DbTypeMap<SqlDbType>(typeof(string), DbType.AnsiString, SqlDbType.VarChar),
+            new DbTypeMap<SqlDbType>(typeof(char), DbType.AnsiString, SqlDbType.Char),
+            new DbTypeMap<SqlDbType>(typeof(char[]), DbType.AnsiString, SqlDbType.VarChar),
+            new DbTypeMap<SqlDbType>(typeof(int), DbType.Int32, SqlDbType.Int),
+            new DbTypeMap<SqlDbType>(typeof(decimal), DbType.Decimal, SqlDbType.Decimal),
+            new DbTypeMap<SqlDbType>(typeof(DateTime), DbType.DateTime, SqlDbType.DateTime),
+            new DbTypeMap<SqlDbType>(typeof(DateTimeOffset), DbType.DateTimeOffset, SqlDbType.DateTimeOffset),
+            new DbTypeMap<SqlDbType>(typeof(bool), DbType.Boolean, SqlDbType.Bit),
+            new DbTypeMap<SqlDbType>(typeof(byte), DbType.Byte, SqlDbType.TinyInt),
+            new DbTypeMap<SqlDbType>(typeof(long), DbType.Int64, SqlDbType.BigInt),
+            new DbTypeMap<SqlDbType>(typeof(double), DbType.Double, SqlDbType.Float),
+            new DbTypeMap<SqlDbType>(typeof(float), DbType.Single, SqlDbType.Real),
+            new DbTypeMap<SqlDbType>(typeof(short), DbType.Int16, SqlDbType.SmallInt),
+            new DbTypeMap<SqlDbType>(typeof(Guid), DbType.Guid, SqlDbType.UniqueIdentifier),
+            new DbTypeMap<SqlDbType>(typeof(byte[]), DbType.Binary, SqlDbType.VarBinary),
+            new DbTypeMap<SqlDbType>(typeof(ushort), DbType.Int16, SqlDbType.SmallInt),
+            new DbTypeMap<SqlDbType>(typeof(sbyte), DbType.Byte, SqlDbType.TinyInt),
+            new DbTypeMap<SqlDbType>(typeof(uint), DbType.Int32, SqlDbType.Int),
+            new DbTypeMap<SqlDbType>(typeof(TimeSpan), DbType.Time, SqlDbType.Time),
+
+            new DbTypeMap<SqlDbType>(typeof(int?), DbType.Int32, SqlDbType.Int),
+            new DbTypeMap<SqlDbType>(typeof(bool?), DbType.Boolean, SqlDbType.Bit),
+            new DbTypeMap<SqlDbType>(typeof(DateTime?), DbType.DateTime, SqlDbType.DateTime),
+            new DbTypeMap<SqlDbType>(typeof(decimal?), DbType.Decimal, SqlDbType.Decimal),
+            new DbTypeMap<SqlDbType>(typeof(long?), DbType.Int64, SqlDbType.BigInt),
+            new DbTypeMap<SqlDbType>(typeof(ulong?), DbType.Int64, SqlDbType.BigInt),
+            new DbTypeMap<SqlDbType>(typeof(double?), DbType.Double, SqlDbType.Float),
+            new DbTypeMap<SqlDbType>(typeof(float?), DbType.Single, SqlDbType.Real),
+            new DbTypeMap<SqlDbType>(typeof(short?), DbType.Int16, SqlDbType.SmallInt),
+            new DbTypeMap<SqlDbType>(typeof(ushort?), DbType.Int16, SqlDbType.SmallInt),
+            new DbTypeMap<SqlDbType>(typeof(byte?), DbType.Byte, SqlDbType.TinyInt),
+            new DbTypeMap<SqlDbType>(typeof(sbyte?), DbType.Byte, SqlDbType.TinyInt),
+            new DbTypeMap<SqlDbType>(typeof(uint?), DbType.Int32, SqlDbType.Int),
         };
         #endregion
 
-        #region get sql type text
-        public static string GetSqlTypeText(Type t, int? maxLength, int? precision, int? scale)
+        #region methods
+        public override DbTypeMap<SqlDbType> FindByDbType(DbType dbType)
+            => typeMaps.FirstOrDefault(x => x.DbType == dbType);
+
+        public override DbTypeMap<SqlDbType> FindByPlatformType(SqlDbType dbType)
+            => typeMaps.FirstOrDefault(x => x.PlatformType == dbType);
+
+        public override DbTypeMap<SqlDbType> FindByClrType(Type clrType)
         {
-            string sqlBase;
-            if (IsSqlTypeKnown(t))
-            {
-                sqlBase = GetSqlType(t).ToString().ToLower();
-                if (maxLength.HasValue)
-                {
-                    if (maxLength.Value == -1)
-                    {
-                        return $"{sqlBase}(max)";
-                    }
-                    else
-                    {
-                        return $"{sqlBase}({maxLength.Value})";
-                    }
-                }
-                else if (precision.HasValue)
-                {
-                    sqlBase = $"{sqlBase}({precision.Value})";
-                    if (scale.HasValue)
-                    {
-                        return $"{sqlBase},{scale.Value})";
-                    }
-                    else
-                    {
-                        return $"{sqlBase},0)";
-                    }
-                }
-                else
-                {
-                    return sqlBase;
-                }
-            }
-            else
-            {
-                return null;
-            }
-        }
-        #endregion
+            var existing = typeMaps.FirstOrDefault(x => x.ClrType == clrType);
+            if (existing is object)
+                return existing;
 
-        #region get assembly type
-        public static Type GetAssemblyType(SqlDbType dbType, bool allowNull)
-        {
-            Type t = null;
-            switch (dbType)
-            {
-                case SqlDbType.BigInt:
-                    t = (allowNull) ? typeof(long?) : typeof(long);
-                    break;
-                case SqlDbType.Binary:
-                    t = typeof(byte[]);
-                    break;
-                case SqlDbType.Bit:
-                    t = (allowNull) ? typeof(bool?) : typeof(bool);
-                    break;
-                case SqlDbType.Char:
-                    t = typeof(string);
-                    break;
-                case SqlDbType.Date:
-                    t = (allowNull) ? typeof(DateTime?) : typeof(DateTime);
-                    break;
-                case SqlDbType.DateTime:
-                    t = (allowNull) ? typeof(DateTime?) : typeof(DateTime);
-                    break;
-                case SqlDbType.DateTime2:
-                    t = (allowNull) ? typeof(DateTime?) : typeof(DateTime);
-                    break;
-                case SqlDbType.DateTimeOffset:
-                    t = (allowNull) ? typeof(DateTime?) : typeof(DateTime); //TODO: JRod, this may be timespan
-                    break;
-                case SqlDbType.Decimal:
-                    t = (allowNull) ? typeof(decimal?) : typeof(decimal);
-                    break;
-                case SqlDbType.Float:
-                    t = (allowNull) ? typeof(double?) : typeof(double);  //TODO: JRod, this may be single...
-                    break;
-                case SqlDbType.Image:
-                    t = typeof(byte[]);
-                    break;
-                case SqlDbType.Int:
-                    t = (allowNull) ? typeof(int?) : typeof(int);
-                    break;
-                case SqlDbType.Money:
-                    t = (allowNull) ? typeof(decimal?) : typeof(decimal);
-                    break;
-                case SqlDbType.NChar:
-                    t = typeof(string);
-                    break;
-                case SqlDbType.NText:
-                    t = typeof(string);
-                    break;
-                case SqlDbType.NVarChar:
-                    t = typeof(string);
-                    break;
-                case SqlDbType.Real:
-                    t = (allowNull) ? typeof(float?) : typeof(float); //TODO: JRod, this may be double/single???
-                    break;
-                case SqlDbType.SmallDateTime:
-                    t = (allowNull) ? typeof(DateTime?) : typeof(DateTime);
-                    break;
-                case SqlDbType.SmallInt:
-                    t = (allowNull) ? typeof(Int16?) : typeof(Int16);
-                    break;
-                case SqlDbType.SmallMoney:
-                    t = (allowNull) ? typeof(decimal?) : typeof(decimal);
-                    break;
-                case SqlDbType.Structured:
-                    throw new ArgumentException("Structured??? Seriously???  --> JROD E.");
-                case SqlDbType.Text:
-                    t = typeof(string);
-                    break;
-                case SqlDbType.Time:
-                    t = (allowNull) ? typeof(DateTime?) : typeof(DateTime); //?????
-                    break;
-                case SqlDbType.Timestamp:
-                    t = typeof(byte[]); //?????
-                    break;
-                case SqlDbType.TinyInt:
-                    t = (allowNull) ? typeof(byte?) : typeof(byte);
-                    break;
-                case SqlDbType.Udt:
-                    t = typeof(byte[]); //?????
-                    break;
-                case SqlDbType.UniqueIdentifier:
-                    t = typeof(Guid);
-                    break;
-                case SqlDbType.VarBinary:
-                    t = typeof(byte[]);
-                    break;
-                case SqlDbType.VarChar:
-                    t = typeof(string);
-                    break;
-                case SqlDbType.Variant:
-                    t = typeof(object);
-                    break;
-                case SqlDbType.Xml:
-                    t = typeof(string);
-                    break;
-                default:
-                    throw new ArgumentException("Encountered unknown SqlDbType.");
-            }
-            return t;
-        }
-        #endregion
+            if (clrType.IsEnum)
+                return typeMaps.FirstOrDefault(x => x.ClrType == typeof(long));
 
-        #region get sql type
-        public static SqlDbType GetSqlType(Type t)
-        {
-            if (t is null) { throw new ArgumentNullException("t", "Cannot resolve type 'null'"); }
-
-            Type underlyingType;
-            if (t.IsEnum)
-            {
-                underlyingType = t.GetUnderlyingEnumType();
-            }
-            else
-            {
-                underlyingType = t.EnsureUnderlyingType();
-            }
-
-            if (sqlTypeMap.ContainsKey(underlyingType))
-            {
-                return sqlTypeMap[underlyingType];
-            }
-            else
-            {
-                throw new ArgumentException($"Input type could not be resolved to a valid SqlDbType.  param value: {t}", "t");
-            }
-        }
-        #endregion
-
-        #region get sql db type from declaration
-        public static SqlDbType? GetSqlDBTypeFromDeclaration(string sqlTypeDeclaration)
-        {
-            if (string.IsNullOrEmpty(sqlTypeDeclaration)) { return null; }
-            int idx = sqlTypeDeclaration.IndexOf('(');
-            if (idx > 0)
-            {
-                sqlTypeDeclaration = sqlTypeDeclaration.Substring(0, idx);
-            }
-            sqlTypeDeclaration = sqlTypeDeclaration.Replace(" ", string.Empty).ToLower();
-            try
-            {
-                SqlDbType sqlT = (SqlDbType)Enum.Parse(typeof(SqlDbType), sqlTypeDeclaration, true);
-                return sqlT;
-            }
-            catch
-            {
-                return null;
-            }
-        }
-        #endregion
-
-        #region sql type allows precision and scale
-        public static bool SqlTypeAllowsPrecisionAndScale(SqlDbType sqlDbType)
-        {
-            return sqlDbType == SqlDbType.Decimal;
-        }
-        #endregion
-
-        #region parse precision and scale from sql type text
-        public static void ParsePrecisionAndScaleFromSqlTypeText(string sqlTypeText, out int? precision, out int? scale)
-        {
-            precision = null;
-            scale = null;
-
-            SqlDbType? sqlT = GetSqlDBTypeFromDeclaration(sqlTypeText);
-
-            if (sqlT is object && SqlTypeAllowsPrecisionAndScale(sqlT.Value))
-            {
-                sqlTypeText = sqlTypeText.Replace(" ", string.Empty);
-                int openIdx = sqlTypeText.IndexOf('(');
-                int closeIdx = sqlTypeText.IndexOf(')');
-                string val = sqlTypeText.Substring(openIdx, (sqlTypeText.Length - closeIdx));
-                string[] vals = val.Split(',');
-
-                if (vals.Length == 2)
-                {
-                    if (int.TryParse(vals[0], out int p))
-                    {
-                        precision = p;
-                    }
-                    if (int.TryParse(vals[1], out int s))
-                    {
-                        scale = s;
-                    }
-                }
-            }
-
-        }
-        #endregion
-
-        #region sql db type allows length declaration
-        public static bool SqlDbTypeAllowsLengthDeclaration(SqlDbType sqlDbType)
-        {
-            return sqlDbType == SqlDbType.VarChar
-                   || sqlDbType == SqlDbType.NVarChar
-                   || sqlDbType == SqlDbType.VarBinary
-                   || sqlDbType == SqlDbType.Binary
-                   || sqlDbType == SqlDbType.Char
-                   || sqlDbType == SqlDbType.NChar;
-        }
-        #endregion
-
-        #region parse length delcaration from sql type text
-        public static int? ParseLengthDeclarationFromSqlTypeText(string sqlTypeText)
-        {
-            sqlTypeText = sqlTypeText.Replace(" ", string.Empty);
-            int openIdx = sqlTypeText.IndexOf('(');
-            int closeIdx = sqlTypeText.IndexOf(')');
-
-            if (openIdx > 0 && closeIdx > 0)
-            {
-                string length = sqlTypeText.Substring(openIdx, (sqlTypeText.Length - closeIdx));
-                if (length.ToLower() == "max")
-                {
-                    return -1;
-                }
-                else
-                {
-                    int l;
-                    if (int.TryParse(length, out l))
-                    {
-                        return l;
-                    }
-                    else
-                    {
-                        return null;
-                    }
-                }
-            }
             return null;
-        }
-        #endregion
-
-        #region is compatible type
-        public static bool IsCompatibleType(string sqlTypeDeclaration, Type assemblyType)
-        {
-            if (sqlTypeDeclaration is null)
-            {
-                throw new ArgumentNullException("sqlTypeDeclaration");
-            }
-            if (sqlTypeDeclaration == string.Empty)
-            {
-                return false;
-            }
-            if (!IsSqlTypeKnown(assemblyType))
-            {
-                throw new ArgumentException("The assembly type supplied is not a known type.", "assemblyType");
-            }
-            int idx = sqlTypeDeclaration.IndexOf('(');
-            if (idx > 0)
-            {
-                sqlTypeDeclaration = sqlTypeDeclaration.Substring(0, idx);
-            }
-            sqlTypeDeclaration = sqlTypeDeclaration.Replace(" ", string.Empty).ToLower();
-            try
-            {
-                SqlDbType sqlT = (SqlDbType)Enum.Parse(typeof(SqlDbType), sqlTypeDeclaration, true);
-                return (GetAssemblyType(sqlT, false) == assemblyType.EnsureUnderlyingType());
-            }
-            catch
-            {
-                return false;
-            }
-        }
-        #endregion
-
-        #region is compatible type
-        public static bool IsCompatibleType(SqlDbType sqlType, Type assemblyType)
-        {
-            if (!IsSqlTypeKnown(assemblyType))
-            {
-                throw new ArgumentException("The assembly type supplied is not a known type.", "assemblyType");
-            }
-            return GetAssemblyType(sqlType, false) == assemblyType.EnsureUnderlyingType();
-        }
-        #endregion
-
-        #region is sql type known
-        public static bool IsSqlTypeKnown(Type t)
-        {
-            if (t is null) { return false; }
-            Type underlyingType;
-            if (t.IsEnum)
-            {
-                underlyingType = t.GetUnderlyingEnumType();
-            }
-            else
-            {
-                underlyingType = t.EnsureUnderlyingType();
-            }
-
-            return sqlTypeMap.ContainsKey(underlyingType);
-        }
-        #endregion
-
-        #region is known sql type delcaration
-        public static bool IsKnownSqlTypeDeclaration(string sqlTypeDeclaration)
-        {
-            if (string.IsNullOrEmpty(sqlTypeDeclaration)) { return false; }
-            int idx = sqlTypeDeclaration.IndexOf('(');
-            if (idx > 0)
-            {
-                sqlTypeDeclaration = sqlTypeDeclaration.Substring(0, idx);
-            }
-            sqlTypeDeclaration = sqlTypeDeclaration.Replace(" ", string.Empty).ToLower();
-            try
-            {
-                SqlDbType sqlT = (SqlDbType)Enum.Parse(typeof(SqlDbType), sqlTypeDeclaration, true);
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
         }
         #endregion
     }

--- a/src/HatTrick.DbEx.MsSql/_Extensions/Configuration/DatabaseConfigurationBuilderExtensions_Configure.cs
+++ b/src/HatTrick.DbEx.MsSql/_Extensions/Configuration/DatabaseConfigurationBuilderExtensions_Configure.cs
@@ -52,7 +52,7 @@ namespace HatTrick.DbEx.MsSql.Configuration
             builder.UseValueConverterFactory<ValueConverterFactory>();
             builder.UseMapperFactory<MapperFactory>();
             builder.UseExecutionPipelineFactory<ExecutionPipelineFactory>();
-            builder.UseParameterBuilderFactory(new MsSqlParameterBuilderFactory(t => MsSqlTypeMap.GetSqlType(t)));
+            builder.UseParameterBuilderFactory(new MsSqlParameterBuilderFactory(new MsSqlTypeMaps()));
 
             var appenderFactory = new MsSqlAssemblyPartAppenderFactory();
             appenderFactory.RegisterDefaultPartAppenders();

--- a/src/HatTrick.DbEx.Sql/Assembler/AssemblyContext.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/AssemblyContext.cs
@@ -1,5 +1,6 @@
 ﻿using HatTrick.DbEx.Sql.Configuration;
 using HatTrick.DbEx.Sql.Expression;
+using System;
 using System.Collections.Generic;
 
 namespace HatTrick.DbEx.Sql.Assembler
@@ -19,11 +20,12 @@ namespace HatTrick.DbEx.Sql.Assembler
         #endregion
 
         #region constructors
-        public AssemblyContext()
+        public AssemblyContext(SqlStatementAssemblerConfiguration configuration)
         {
             //set default styles
             fieldStyles.Push(FieldExpressionAppendStyle.None);
             entityStyles.Push(EntityExpressionAppendStyle.None);
+            Configuration = configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.");
         }
         #endregion
 

--- a/src/HatTrick.DbEx.Sql/Assembler/ParameterizedFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/ParameterizedFieldExpression.cs
@@ -1,16 +1,19 @@
 ﻿using HatTrick.DbEx.Sql.Expression;
+using System;
 using System.Data.Common;
 
 namespace HatTrick.DbEx.Sql.Assembler
 {
     public class ParameterizedFieldExpression
     {
+        public Type DeclaredType { get; private set; }
         public DbParameter Parameter { get; private set; }
         public FieldExpression Field { get; private set; }
         public ISqlFieldMetadata Metadata { get; private set; }
 
-        public ParameterizedFieldExpression(DbParameter parameter, FieldExpression expression, ISqlFieldMetadata metadata)
+        public ParameterizedFieldExpression(Type declaredType, DbParameter parameter, FieldExpression expression, ISqlFieldMetadata metadata)
         {
+            DeclaredType = declaredType;
             Parameter = parameter;
             Field = expression;
             Metadata = metadata;

--- a/src/HatTrick.DbEx.Sql/Assembler/SelectSqlStatementAssembler.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/SelectSqlStatementAssembler.cs
@@ -74,7 +74,9 @@ namespace HatTrick.DbEx.Sql.Assembler
             builder.Appender.Indent().Write("GROUP BY").LineBreak()
                 .Indentation++;
 
+            context.PushAppendStyles(EntityExpressionAppendStyle.Alias, FieldExpressionAppendStyle.None);
             builder.AppendPart(expression.GroupBy, context);
+            context.PopAppendStyles();
 
             builder.Appender
                 .Indentation--;
@@ -88,7 +90,9 @@ namespace HatTrick.DbEx.Sql.Assembler
             builder.Appender.Indent().Write("HAVING").LineBreak()
                 .Indentation++;
 
+            context.PushAppendStyles(EntityExpressionAppendStyle.Alias, FieldExpressionAppendStyle.None);
             builder.AppendPart(expression.Having, context);
+            context.PopAppendStyles();
 
             builder.Appender.LineBreak()
                 .Indentation--;
@@ -102,7 +106,9 @@ namespace HatTrick.DbEx.Sql.Assembler
             builder.Appender.Indent().Write("ORDER BY").LineBreak()
                 .Indentation++;
 
+            context.PushAppendStyles(EntityExpressionAppendStyle.Alias, FieldExpressionAppendStyle.None);
             builder.AppendPart(expression.OrderBy, context);
+            context.PopAppendStyles();
 
             builder.Appender
                 .Indentation--;

--- a/src/HatTrick.DbEx.Sql/Assembler/SqlParameterBuilder.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/SqlParameterBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using HatTrick.DbEx.Sql.Expression;
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Data.Common;
 
 namespace HatTrick.DbEx.Sql.Assembler
@@ -15,5 +16,33 @@ namespace HatTrick.DbEx.Sql.Assembler
         public abstract DbParameter Add(object value, Type valueType);
         public abstract ParameterizedFieldExpression AddOutput(FieldExpression expression, ISqlFieldMetadata meta);
         #endregion
+
+        protected virtual ParameterizedFieldExpression FindExistingParameter<T>(T value, Type declaredType, DbType dbType, ParameterDirection direction, int? size, byte? precision, byte? scale)
+        {
+            foreach (var parameter in Parameters)
+            {
+                if (parameter.Parameter.Direction != direction)
+                    continue;
+
+                if (size.HasValue && !(parameter.Parameter.Size == size.Value))
+                    continue;
+                if (precision.HasValue && !(parameter.Parameter.Precision == precision.Value))
+                    continue;
+                if (scale.HasValue && !(parameter.Parameter.Scale == scale.Value))
+                    continue;
+
+                if (parameter.DeclaredType != declaredType)
+                    continue;
+
+                if (parameter.Parameter.DbType != dbType)
+                    continue;                
+                
+                if (!Convert.ChangeType(parameter.Parameter.Value, parameter.DeclaredType).Equals(Convert.ChangeType(value, declaredType)))
+                    continue;
+
+                return parameter;
+            }
+            return null;
+        }
     }
 }

--- a/src/HatTrick.DbEx.Sql/Assembler/SqlStatementBuilder.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/SqlStatementBuilder.cs
@@ -44,10 +44,7 @@ namespace HatTrick.DbEx.Sql.Assembler
             if (_sqlStatement is object)
                 return _sqlStatement;
 
-            var context = new AssemblyContext
-            {
-                Configuration = AssemblerConfiguration,
-            };
+            var context = new AssemblyContext(AssemblerConfiguration);
 
             var assembler = AssemblerFactory(Query)
                 ?? throw new DbExpressionConfigurationException($"Could not resolve an assembler for statement execution type '{Query}', please ensure an assembler has been registered during startup initialization of DbExpression.");

--- a/src/HatTrick.DbEx.Sql/Assembler/_Appenders/FilterExpressionPartAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/_Appenders/FilterExpressionPartAppender.cs
@@ -14,13 +14,13 @@ namespace HatTrick.DbEx.Sql.Assembler
 
         #region methods
         public override void AppendPart(FilterExpression expression, ISqlStatementBuilder builder, AssemblyContext context)
-            => AppendFilterExpressionUsingExpressionAppendStyles(expression, builder, context, EntityExpressionAppendStyle.Alias, FieldExpressionAppendStyle.Alias);
+            => AppendFilterExpressionUsingExpressionAppendStyles(expression, builder, context, EntityExpressionAppendStyle.Alias, FieldExpressionAppendStyle.None);
 
-        private void AppendFilterExpressionUsingExpressionAppendStyles(FilterExpression expression, ISqlStatementBuilder builder, AssemblyContext context, EntityExpressionAppendStyle entityAppendStyle, FieldExpressionAppendStyle fieldEAppendStyle)
+        private void AppendFilterExpressionUsingExpressionAppendStyles(FilterExpression expression, ISqlStatementBuilder builder, AssemblyContext context, EntityExpressionAppendStyle entityAppendStyle, FieldExpressionAppendStyle fieldAppendStyle)
         {
             try
             {
-                context.PushAppendStyles(entityAppendStyle, fieldEAppendStyle);
+                context.PushAppendStyles(entityAppendStyle, fieldAppendStyle);
                 AppendFilterExpressionThatMayContainDBNull(expression, builder, context);
             }
             finally

--- a/src/HatTrick.DbEx.Sql/Expression/IExpressionEntity.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/IExpressionEntity.cs
@@ -3,6 +3,5 @@
     public interface IExpressionEntity
     {
         SelectExpressionSet BuildInclusiveSelectExpression();
-
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/IExpressionField.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/IExpressionField.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace HatTrick.DbEx.Sql.Expression
+{
+    public interface IExpressionField
+    {
+        Type DeclaredType { get; }
+    }
+}

--- a/src/HatTrick.DbEx.Sql/Expression/LiteralExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/LiteralExpression{T}.cs
@@ -4,10 +4,17 @@ namespace HatTrick.DbEx.Sql.Expression
 {
     public class LiteralExpression<TValue> : LiteralExpression
     {
+        public FieldExpression FieldExpressionHint { get; }
+
         #region constructors
         public LiteralExpression(TValue value) : base(value)
         {
 
+        }
+
+        public LiteralExpression(TValue value, FieldExpression field) : base(value)
+        {
+            FieldExpressionHint = field;
         }
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/BooleanFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/BooleanFieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<BooleanFieldExpression>
     {
         #region constructors
-        protected BooleanFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected BooleanFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(bool), entity)
         {
 
         }
 
-        protected BooleanFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected BooleanFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(bool), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/ByteArrayFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/ByteArrayFieldExpression.cs
@@ -7,11 +7,11 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<ByteArrayFieldExpression>
     {
         #region constructors
-        protected ByteArrayFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected ByteArrayFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(byte[]), entity)
         {
         }
 
-        protected ByteArrayFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected ByteArrayFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(byte[]), entity, alias)
         {
         }
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/ByteFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/ByteFieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<ByteFieldExpression>
     {
         #region constructors
-        protected ByteFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected ByteFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(string), entity)
         {
 
         }
 
-        protected ByteFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected ByteFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(string), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/DateTimeFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/DateTimeFieldExpression.cs
@@ -8,12 +8,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<DateTimeFieldExpression>
     {
         #region constructors
-        protected DateTimeFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected DateTimeFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(DateTime), entity)
         {
 
         }
 
-        protected DateTimeFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected DateTimeFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(DateTime), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/DateTimeOffsetFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/DateTimeOffsetFieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<DateTimeOffsetFieldExpression>
     {
         #region constructors
-        protected DateTimeOffsetFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected DateTimeOffsetFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(DateTimeOffset), entity)
         {
 
         }
 
-        protected DateTimeOffsetFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected DateTimeOffsetFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(DateTimeOffset), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/DecimalFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/DecimalFieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<DecimalFieldExpression>
     {
         #region constructors
-        protected DecimalFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected DecimalFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(decimal), entity)
         {
 
         }
 
-        protected DecimalFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected DecimalFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(decimal), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/DoubleFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/DoubleFieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<DoubleFieldExpression>
     {
         #region constructors
-        protected DoubleFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected DoubleFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(double), entity)
         {
 
         }
 
-        protected DoubleFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected DoubleFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(double), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/EnumFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/EnumFieldExpression{T}.cs
@@ -8,11 +8,11 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEnum : struct, Enum, IComparable
     {
         #region constructors
-        protected EnumFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected EnumFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(TEnum), entity)
         {
         }
 
-        protected EnumFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected EnumFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(TEnum), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/FieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/FieldExpression.cs
@@ -4,6 +4,7 @@ namespace HatTrick.DbEx.Sql.Expression
 {
     public abstract class FieldExpression : 
         IExpression,
+        IExpressionField,
         ISqlMetadataIdentifier,
         IExpressionProvider<EntityExpression>,
         IExpressionAliasProvider,
@@ -11,24 +12,27 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region internals
         protected readonly string identifier;
+        protected readonly Type declaredType;
         protected readonly EntityExpression entity;
         protected readonly string alias;
         #endregion
 
         #region interface
         string ISqlMetadataIdentifier.Identifier => identifier;
+        Type IExpressionField.DeclaredType => declaredType;
         EntityExpression IExpressionProvider<EntityExpression>.Expression => entity;
         string IExpressionAliasProvider.Alias => alias;
         #endregion
 
         #region constructors
-        protected FieldExpression(string identifier, EntityExpression entity) : this(identifier, entity, null)
+        protected FieldExpression(string identifier, Type declaredType, EntityExpression entity) : this(identifier, declaredType, entity, null)
         {
         }
 
-        protected FieldExpression(string identifier, EntityExpression entity, string alias)
+        protected FieldExpression(string identifier, Type declaredType, EntityExpression entity, string alias)
         {
             this.identifier = identifier ?? throw new ArgumentNullException($"{nameof(identifier)} is required.");
+            this.declaredType = declaredType ?? throw new ArgumentNullException($"{nameof(declaredType)} is required.");
             this.entity = entity ?? throw new ArgumentNullException($"{nameof(entity)} is required.");
             this.alias = alias;
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/FieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/FieldExpression{T}.cs
@@ -5,12 +5,12 @@ namespace HatTrick.DbEx.Sql.Expression
     public abstract class FieldExpression<TValue> : FieldExpression
     {
         #region constructors
-        protected FieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected FieldExpression(string identifier, Type declaredType, EntityExpression entity) : base(identifier, declaredType, entity)
         {
 
         }
 
-        protected FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected FieldExpression(string identifier, Type declaredType, EntityExpression entity, string alias) : base(identifier, declaredType, entity, alias)
         {
         }
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/GuidFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/GuidFieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<GuidFieldExpression>
     {
         #region constructors
-        protected GuidFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected GuidFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(Guid), entity)
         {
 
         }
 
-        protected GuidFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected GuidFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(Guid), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/Int16FieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/Int16FieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<Int16FieldExpression>
     {
         #region constructors
-        protected Int16FieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected Int16FieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(short), entity)
         {
 
         }
 
-        protected Int16FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected Int16FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(short), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/Int32FieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/Int32FieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<Int32FieldExpression>
     {
         #region constructors
-        protected Int32FieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected Int32FieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(int), entity)
         {
 
         }
 
-        protected Int32FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected Int32FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(int), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/Int64FieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/Int64FieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<Int64FieldExpression>
     {
         #region constructors
-        protected Int64FieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected Int64FieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(long), entity)
         {
 
         }
 
-        protected Int64FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected Int64FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(long), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableBooleanFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableBooleanFieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableBooleanFieldExpression>
     {
         #region constructors
-        protected NullableBooleanFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected NullableBooleanFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(bool), entity)
         {
 
         }
 
-        protected NullableBooleanFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableBooleanFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(bool), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableByteFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableByteFieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableByteFieldExpression>
     {
         #region constructors
-        protected NullableByteFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected NullableByteFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(byte), entity)
         {
 
         }
 
-        protected NullableByteFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableByteFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(byte), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDateTimeFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDateTimeFieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableDateTimeFieldExpression>
     {
         #region constructors
-        protected NullableDateTimeFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected NullableDateTimeFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(DateTime), entity)
         {
 
         }
 
-        protected NullableDateTimeFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableDateTimeFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(DateTime), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDateTimeOffsetFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDateTimeOffsetFieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableDateTimeOffsetFieldExpression>
     {
         #region constructors
-        protected NullableDateTimeOffsetFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected NullableDateTimeOffsetFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(DateTimeOffset), entity)
         {
 
         }
 
-        protected NullableDateTimeOffsetFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableDateTimeOffsetFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(DateTimeOffset), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDecimalFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDecimalFieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableDecimalFieldExpression>
     {
         #region constructors
-        protected NullableDecimalFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected NullableDecimalFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(decimal), entity)
         {
 
         }
 
-        protected NullableDecimalFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableDecimalFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(decimal), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDoubleFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDoubleFieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableDoubleFieldExpression>
     {
         #region constructors
-        protected NullableDoubleFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected NullableDoubleFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(double), entity)
         {
 
         }
 
-        protected NullableDoubleFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableDoubleFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(double), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableEnumFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableEnumFieldExpression{T}.cs
@@ -9,11 +9,11 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEnum : struct, Enum, IComparable
     {
         #region constructors
-        protected NullableEnumFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected NullableEnumFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(TEnum), entity)
         {
         }
 
-        protected NullableEnumFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableEnumFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(TEnum), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableFieldExpression{T}.cs
@@ -6,12 +6,12 @@ namespace HatTrick.DbEx.Sql.Expression
         where TValue : struct, IComparable
     {
         #region constructors
-        protected NullableFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected NullableFieldExpression(string identifier, Type declaredType, EntityExpression entity) : base(identifier, declaredType, entity)
         {
 
         }
 
-        protected NullableFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableFieldExpression(string identifier, Type declaredType, EntityExpression entity, string alias) : base(identifier, declaredType, entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableGuidFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableGuidFieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableGuidFieldExpression>
     {
         #region constructors
-        protected NullableGuidFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected NullableGuidFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(Guid), entity)
         {
 
         }
 
-        protected NullableGuidFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableGuidFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(Guid), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt16FieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt16FieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableInt16FieldExpression>
     {
         #region constructors
-        protected NullableInt16FieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected NullableInt16FieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(short), entity)
         {
 
         }
 
-        protected NullableInt16FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableInt16FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(short), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt32FieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt32FieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableInt32FieldExpression>
     {
         #region constructors
-        protected NullableInt32FieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected NullableInt32FieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(int), entity)
         {
 
         }
 
-        protected NullableInt32FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableInt32FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(int), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt64FieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt64FieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableInt64FieldExpression>
     {
         #region constructors
-        protected NullableInt64FieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected NullableInt64FieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(long), entity)
         {
 
         }
 
-        protected NullableInt64FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableInt64FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(long), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableSingleFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableSingleFieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableSingleFieldExpression>
     {
         #region constructors
-        protected NullableSingleFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected NullableSingleFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(float), entity)
         {
 
         }
 
-        protected NullableSingleFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableSingleFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(float), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/SingleFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/SingleFieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<SingleFieldExpression>
     {
         #region constructors
-        protected SingleFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected SingleFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(float), entity)
         {
 
         }
 
-        protected SingleFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected SingleFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(float), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/StringFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/StringFieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<StringFieldExpression>
     {
         #region constructors
-        protected StringFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        protected StringFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(string), entity)
         {
 
         }
 
-        protected StringFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected StringFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(string), entity, alias)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Types/DbTypeMap{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Types/DbTypeMap{T}.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Data;
+
+namespace HatTrick.DbEx.Sql.Types
+{
+    public class DbTypeMap<T>
+        where T : Enum
+    {
+        public Type ClrType { get; }
+        public DbType DbType { get; }
+        public T PlatformType { get; }
+
+        public DbTypeMap(Type clrType, DbType dbType, T platformType)
+        {
+            ClrType = clrType;
+            DbType = dbType;
+            PlatformType = platformType;
+        }
+    }
+
+    public abstract class DbTypeMaps<T>
+        where T : Enum
+    {
+        public abstract DbTypeMap<T> FindByDbType(DbType dbType);
+        public abstract DbTypeMap<T> FindByPlatformType(T platformType);
+        public abstract DbTypeMap<T> FindByClrType(Type clrType);
+    }
+}

--- a/test/HatTrick.DbEx.MsSql.Test.Code/Assembler/ParameterBuilderTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Code/Assembler/ParameterBuilderTests.cs
@@ -1,0 +1,456 @@
+﻿using FluentAssertions;
+using System;
+using Xunit;
+
+namespace HatTrick.DbEx.MsSql.Test.Code.Assembler
+{
+    public class ParameterBuilderTests : TestBase
+    {
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_long_parameters_with_same_value_share_the_parameter(int version)
+        {
+            //given
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(1, typeof(long));
+
+            //when
+            var newParameter = parameterBuilder.Add(1, typeof(long));
+
+            //then
+            newParameter.Should().Be(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_long_parameters_with_different_value_result_in_new_parameter(int version)
+        {
+            //given
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(1, typeof(long));
+
+            //when
+            var newParameter = parameterBuilder.Add(2, typeof(long));
+
+            //then
+            newParameter.Should().NotBe(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_long_and_int_parameters_with_samve_value_result_in_new_parameter(int version)
+        {
+            //given
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(1, typeof(long));
+
+            //when
+            var newParameter = parameterBuilder.Add(1, typeof(int));
+
+            //then
+            newParameter.Should().NotBe(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_long_and_int_primitive_parameter_with_different_value_result_in_new_parameter(int version)
+        {
+            //given
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(1, typeof(long));
+
+            //when
+            var newParameter = parameterBuilder.Add(2, typeof(int));
+
+            //then
+            newParameter.Should().NotBe(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_int_parameters_with_same_value_using_generic_version_share_the_parameter(int version)
+        {
+            //given
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(1);
+
+            //when
+            var newParameter = parameterBuilder.Add(1);
+
+            //then
+            newParameter.Should().Be(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_int_parameters_with_different_value_using_generic_version_result_in_new_parameter(int version)
+        {
+            //given
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(1);
+
+            //when
+            var newParameter = parameterBuilder.Add(2);
+
+            //then
+            newParameter.Should().NotBe(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_long_and_int_parameters_with_same_value_using_generic_version_result_in_new_parameter(int version)
+        {
+            //given
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(1, typeof(long));
+
+            //when
+            var newParameter = parameterBuilder.Add<int>(1);
+
+            //then
+            newParameter.Should().NotBe(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_an_int_and_long_parameters_with_different_values_using_generic_version_result_in_new_parameter(int version)
+        {
+            //given
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(1, typeof(long));
+
+            //when
+            var newParameter = parameterBuilder.Add<int>(2);
+
+            //then
+            newParameter.Should().NotBe(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_long_parameters_with_same_value_first_by_object_then_by_generic_share_the_parameter(int version)
+        {
+            //given
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(1, typeof(long));
+
+            //when
+            var newParameter = parameterBuilder.Add<long>(1);
+
+            //then
+            newParameter.Should().Be(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_string_parameter_with_same_value_and_type_share_the_parameter(int version)
+        {
+            //given
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add("HelloWorld", typeof(string));
+
+            //when
+            var newParameter = parameterBuilder.Add("HelloWorld", typeof(string));
+
+            //then
+            newParameter.Should().Be(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_string_parameter_with_different_value_result_in_new_parameter(int version)
+        {
+            //given
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add("HelloWorld", typeof(string));
+
+            //when
+            var newParameter = parameterBuilder.Add("xHelloWorld", typeof(string));
+
+            //then
+            newParameter.Should().NotBe(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_string_parameter_with_same_value_and_type_using_generic_version_share_the_parameter(int version)
+        {
+            //given
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add("HelloWorld");
+
+            //when
+            var newParameter = parameterBuilder.Add("HelloWorld");
+
+            //then
+            newParameter.Should().Be(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_string_parameter_with_different_value_using_generic_version_result_in_new_parameter(int version)
+        {
+            //given
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add("HelloWorld");
+
+            //when
+            var newParameter = parameterBuilder.Add("xHelloWorld");
+
+            //then
+            newParameter.Should().NotBe(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_string_parameter_with_different_value_and_type_using_generic_version_result_in_new_parameter(int version)
+        {
+            //given
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add("HelloWorld", typeof(string));
+
+            //when
+            var newParameter = parameterBuilder.Add<string>("xHelloWorld");
+
+            //then
+            newParameter.Should().NotBe(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_string_parameter_with_same_value_and_type_first_by_object_then_by_generic_share_the_parameter(int version)
+        {
+            //given
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add("HelloWorld", typeof(string));
+
+            //when
+            var newParameter = parameterBuilder.Add<string>("HelloWorld");
+
+            //then
+            newParameter.Should().Be(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_DateTime_parameter_with_same_value_and_type_share_the_parameter(int version)
+        {
+            //given
+            var now = DateTime.UtcNow;
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(now, typeof(DateTime));
+
+            //when
+            var newParameter = parameterBuilder.Add(now, typeof(DateTime));
+
+            //then
+            newParameter.Should().Be(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_DateTime_parameter_with_different_value_result_in_new_parameter(int version)
+        {
+            //given
+            var now = DateTime.UtcNow;
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(now, typeof(DateTime));
+
+            //when
+            var newParameter = parameterBuilder.Add(now.AddMilliseconds(1).Date, typeof(DateTime));
+
+            //then
+            newParameter.Should().NotBe(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_DateTime_parameter_with_same_value_and_type_using_generic_version_share_the_parameter(int version)
+        {
+            //given
+            var now = DateTime.UtcNow;
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(now);
+
+            //when
+            var newParameter = parameterBuilder.Add(now);
+
+            //then
+            newParameter.Should().Be(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_DateTime_parameter_with_different_value_using_generic_version_result_in_new_parameter(int version)
+        {
+            //given
+            var now = DateTime.UtcNow;
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(now);
+
+            //when
+            var newParameter = parameterBuilder.Add(now.AddMilliseconds(1).Date);
+
+            //then
+            newParameter.Should().NotBe(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_DateTime_parameter_with_different_value_and_type_using_generic_version_result_in_new_parameter(int version)
+        {
+            //given
+            var now = DateTime.UtcNow;
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(now, typeof(DateTime));
+
+            //when
+            var newParameter = parameterBuilder.Add<DateTime>(now.AddMilliseconds(1).Date);
+
+            //then
+            newParameter.Should().NotBe(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_DateTime_parameter_with_same_value_and_type_first_by_object_then_by_generic_share_the_parameter(int version)
+        {
+            //given
+            var now = DateTime.UtcNow;
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(now, typeof(DateTime));
+
+            //when
+            var newParameter = parameterBuilder.Add<DateTime>(now);
+
+            //then
+            newParameter.Should().Be(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_byte_array_parameter_with_same_value_and_type_share_the_parameter(int version)
+        {
+            //given
+            var value = new byte[] { 1, 2, 3 };
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(value, typeof(byte[]));
+
+            //when
+            var newParameter = parameterBuilder.Add(value, typeof(byte[]));
+
+            //then
+            newParameter.Should().Be(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_byte_array_parameter_with_different_value_result_in_new_parameter(int version)
+        {
+            //given
+            var value = new byte[] { 1, 2, 3 };
+            var newValue = new byte[] { 1, 2, 3, 4 };
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(value, typeof(byte[]));
+
+            //when
+            var newParameter = parameterBuilder.Add(newValue, typeof(byte[]));
+
+            //then
+            newParameter.Should().NotBe(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_byte_array_parameter_with_same_value_and_type_using_generic_version_share_the_parameter(int version)
+        {
+            //given
+            var value = new byte[] { 1, 2, 3 };
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(value);
+
+            //when
+            var newParameter = parameterBuilder.Add(value);
+
+            //then
+            newParameter.Should().Be(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_byte_array_parameter_with_different_value_using_generic_version_result_in_new_parameter(int version)
+        {
+            //given
+            var value = new byte[] { 1, 2, 3 };
+            var newValue = new byte[] { 1, 2, 3, 4 };
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(value);
+
+            //when
+            var newParameter = parameterBuilder.Add(newValue);
+
+            //then
+            newParameter.Should().NotBe(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_byte_array_parameter_with_different_value_and_type_using_generic_version_result_in_new_parameter(int version)
+        {
+            //given
+            var value = new byte[] { 1, 2, 3 };
+            var newValue = new byte[] { 1, 2, 3, 4 };
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(value, typeof(byte[]));
+
+            //when
+            var newParameter = parameterBuilder.Add<byte[]>(newValue);
+
+            //then
+            newParameter.Should().NotBe(parameter);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_adding_a_byte_array_parameter_with_same_value_and_type_first_by_object_then_by_generic_share_the_parameter(int version)
+        {
+            //given
+            var value = new byte[] { 1, 2, 3 };
+            var database = ConfigureForMsSqlVersion(version);
+            var parameterBuilder = database.ParameterBuilderFactory.CreateSqlParameterBuilder();
+            var parameter = parameterBuilder.Add(value, typeof(byte[]));
+
+            //when
+            var newParameter = parameterBuilder.Add<byte[]>(value);
+
+            //then
+            newParameter.Should().Be(parameter);
+        }
+    }
+}

--- a/test/HatTrick.DbEx.MsSql.Test.Code/Assembler/WhereClauseAssemblerTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Code/Assembler/WhereClauseAssemblerTests.cs
@@ -3,10 +3,11 @@ using DbEx.secDataService;
 using FluentAssertions;
 using HatTrick.DbEx.Sql.Assembler;
 using HatTrick.DbEx.Sql.Builder.Syntax;
+using HatTrick.DbEx.Sql.Configuration;
 using HatTrick.DbEx.Sql.Expression;
 using Xunit;
 
-namespace HatTrick.DbEx.MsSql.Test.Assembler
+namespace HatTrick.DbEx.MsSql.Test.Code.Assembler
 {
     [Trait("Statement", "SELECT")]
     [Trait("Clause", "WHERE")]
@@ -32,7 +33,7 @@ namespace HatTrick.DbEx.MsSql.Test.Assembler
             string whereClause;
 
             //when
-            builder.AppendPart(expressionSet.Where.LeftArg, new AssemblyContext());
+            builder.AppendPart(expressionSet.Where.LeftArg, new AssemblyContext(new SqlStatementAssemblerConfiguration()));
             whereClause = builder.Appender.ToString();
 
             //then

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Select/SelectMany.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Select/SelectMany.cs
@@ -157,5 +157,70 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             //when & then
             await execute.Should().ThrowAsync<DbExpressionException>();
         }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "ORDER BY")]
+        public async Task Can_a_order_by_select_async_when_table_name_is_aliased_execute_successfully(int version, int expected = 50)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var table = dbo.Person.As("dboPerson");
+
+            var names = await db.SelectMany(table.FirstName)
+                .From(table)
+                .OrderBy(table.FirstName)
+                .ExecuteAsync();
+
+            //then
+            names.Should().HaveCount(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        [Trait("Operation", "HAVING")]
+        public async Task Can_a_group_by_with_having_select_async_when_table_name_is_aliased_execute_successfully(int version, int expected = 1)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var table = dbo.Person.As("dboPerson");
+
+            var counts = await db.SelectMany(db.fx.Count(table.FirstName))
+                .From(table)
+                .GroupBy(table.FirstName)
+                .Having(table.FirstName > "U")
+                .ExecuteAsync();
+
+            //then
+            counts.Should().HaveCount(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        [Trait("Operation", "HAVING")]
+        public async Task Can_a_group_by_with_having_select_async_when_table_name_and_field_are_aliased_execute_successfully(int version, int expected = 1)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var table = dbo.Person.As("dboPerson");
+            var field = table.FirstName.As("dboPersonFirstName");
+
+            var counts = await db.SelectMany(
+                    field, 
+                    db.fx.Count().As("NameGreaterThanUCount")
+                )
+                .From(table)
+                .GroupBy(field)
+                .Having(field > "U")
+                .ExecuteAsync();
+
+            //then
+            counts.Should().HaveCount(expected);
+        }
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_SelectOne/SelectOne.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_SelectOne/SelectOne.cs
@@ -49,5 +49,24 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             //then
             person.FirstName.Should().Be("Kenny");
         }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "GROUP BY")]
+        public async Task Can_a_group_by_select_async_when_table_name_is_aliased_runsuccessfully(int version, int expected = 1)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var table = dbo.Person.As("dboPerson");
+
+            var count = await db.SelectOne(db.fx.Count(table.FirstName))
+                .From(table)
+                .GroupBy(table.FirstName)
+                .ExecuteAsync();
+
+            //then
+            count.Should().Be(expected);
+        }
     }
 }


### PR DESCRIPTION
- Added shared parameters in parameter builder (if there is no difference in the parameter, it reuses an existing instead of creating a new one)
- Added declared data type to field expressions so parameter build could better and more efficiently build parameters when supplied a field expressions
- Reworked the type map system to only use what is defined and compiled in code - no boxing/unboxing from DbType to SqlDbType and vice-versa which was causing issues on changing types when round-tripping while building parameters
- Fixed some outstanding issues with aliasing of fields as used in group bys, order bys, having expressions, and filter expressions