### PR TITLE
No exception on empty Enumerable on IN satements

### DIFF
--- a/src/HatTrick.DbEx.Sql/Assembler/_Appenders/InExpressionPartAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/_Appenders/InExpressionPartAppender.cs
@@ -16,6 +16,7 @@ namespace HatTrick.DbEx.Sql.Assembler
         private void AddParametersFromList(ISqlStatementBuilder builder, FieldExpression field, IEnumerable expression)
         {
             var meta = field is object ? builder.FindMetadata(field) : null;
+            var hasElements = false;
             var enumerator = expression.GetEnumerator();
             var firstElement = true;
             while (enumerator.MoveNext())
@@ -32,7 +33,11 @@ namespace HatTrick.DbEx.Sql.Assembler
                     firstElement = false;
                 }
                 AddParameter(builder, field, meta, enumerator.Current);
+                hasElements = true;
             }
+
+            if (!hasElements)
+                builder.Appender.Write("NULL");
         }
 
         private void AddParameter(ISqlStatementBuilder builder, FieldExpression field, ISqlFieldMetadata meta, object expression)

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableStringFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableStringFieldExpression.cs
@@ -7,12 +7,12 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableStringFieldExpression>
     {
         #region constructors
-        protected NullableStringFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(float?), entity)
+        protected NullableStringFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(string), entity)
         {
 
         }
 
-        protected NullableStringFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(float?), entity, alias)
+        protected NullableStringFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(string), entity, alias)
         {
 
         }

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/In.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/In.cs
@@ -4,6 +4,7 @@ using DbEx.dboDataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
 using HatTrick.DbEx.Sql;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -12,6 +13,78 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
     [Trait("Operation", "IN")]
     public class In : ExecutorTestBase
     {
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_selecting_persons_using_empty_enumerable_result_in_no_output(int version, int expectedCount = 0)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+            var personIds = Enumerable.Empty<int>();
+
+            //when
+            var persons = db.SelectMany<Person>()
+                .From(dbo.Person)
+                .Where(dbo.Person.Id.In(personIds))
+                .Execute();
+
+            //then
+            persons.Should().HaveCount(expectedCount);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_selecting_addresses_using_a_null_value_as_first_element_in_the_enumerable_result_in_no_output(int version, int expectedCount = 2)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+            var lines = new List<string> { null, "Box 13", "Apt. 42" };
+
+            //when
+            var addresses = db.SelectMany<Address>()
+                .From(dbo.Address)
+                .Where(dbo.Address.Line2.In(lines))
+                .Execute();
+
+            //then
+            addresses.Should().HaveCount(expectedCount);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_selecting_addresses_using_a_null_value_in_the_enumerable_result_in_correct_output(int version, int expectedCount = 2)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+            var lines = new List<string> { "Box 13", null, "Apt. 42" };
+
+            //when
+            var addresses = db.SelectMany<Address>()
+                .From(dbo.Address)
+                .Where(dbo.Address.Line2.In(lines))
+                .Execute();
+
+            //then
+            addresses.Should().HaveCount(expectedCount);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_selecting_addresses_using_a_null_values_for_every_element_of_the_enumerable_result_in_no_output(int version, int expectedCount = 0)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+            var lines = new List<string> { null, null, null, null };
+
+            //when
+            var addresses = db.SelectMany<Address>()
+                .From(dbo.Address)
+                .Where(dbo.Address.Line2.In(lines))
+                .Execute();
+
+            //then
+            addresses.Should().HaveCount(expectedCount);
+        }
+
         [Theory]
         [MsSqlVersions.AllVersions]
         public void Does_selecting_persons_using_enumerable_of_ids_result_in_correct_output(int version, int expectedCount = 15)


### PR DESCRIPTION
- Provided short circuit on IN statements to ensure successful execution (with no results) when the enumerable is empty
- Fixed issue with NullableStringFieldExpression where it was declaring the wrong type in the constructor call to it's base

Resolves #130 