### PR TITLE
Ensure close on DataReader after read in SelectOne pipelines

### DIFF
--- a/samples/mssql/NetCoreConsoleApp/Program.cs
+++ b/samples/mssql/NetCoreConsoleApp/Program.cs
@@ -59,7 +59,6 @@ namespace NetCoreConsoleApp
 		static void RunSelectExpressions()
         {
             var select = new SelectExpressions();
-
             var respa = select.SelectPersonById(1);
             var respb = select.SelectPersonByFirstNameLastNameAndBirthdate("Kyle", "Broflovski", DateTime.Parse("1996-03-01"));
             var respc = select.SelectTotalPurchaseViewByPersonId(2);
@@ -116,7 +115,6 @@ namespace NetCoreConsoleApp
                 inserts.SimpleInsertPerson(p);
             }
             #endregion
-
             #region transactional insert
             {
                 var p = new Person()
@@ -220,9 +218,9 @@ namespace NetCoreConsoleApp
         {
             var updates = new UpdateExpressions();
 
-			#region simple update
-			updates.SimpleUpdatePersonSetCreditScore(1, 50000);
-			#endregion
+            #region simple update
+            updates.SimpleUpdatePersonSetCreditScore(1, 50000);
+            #endregion
 
 			#region join based update
 			updates.UpdateCreditLimitForAllGenderMatchWithinZip(GenderType.Female, "80440", 1500);

--- a/samples/mssql/NetCoreConsoleApp/appsettings.json
+++ b/samples/mssql/NetCoreConsoleApp/appsettings.json
@@ -1,5 +1,5 @@
 {
 	"ConnectionStrings": {
-		"dbex_mssql_test": "Data Source=(LocalDB)\\MSSQLLocalDB;Initial Catalog=MsSqlDbExTest;Integrated Security=true;Connect Timeout=30"
+		"dbex_mssql_test": "Data Source=(LocalDB)\\MSSQLLocalDB;Initial Catalog=MsSqlDbExTest;Integrated Security=true;Connect Timeout=10;Max Pool Size=5;Min Pool Size = 1;"
 	}
 }

--- a/src/HatTrick.DbEx.Sql/Executor/AsyncDataReaderWrapper.cs
+++ b/src/HatTrick.DbEx.Sql/Executor/AsyncDataReaderWrapper.cs
@@ -56,8 +56,7 @@ namespace HatTrick.DbEx.Sql.Executor
             }
             catch
             {
-                if (DataReader is object && !DataReader.IsClosed)
-                    DataReader.Close(); //redundant, but required for sqlCe before rollback...
+                Close();
 
                 if (SqlConnection.IsTransactional)
                 {
@@ -71,6 +70,15 @@ namespace HatTrick.DbEx.Sql.Executor
             }
 
             return null;
+        }
+
+        public void Close()
+        {
+            if (DataReader is object && !DataReader.IsClosed)
+                DataReader.Close();
+
+            if (!SqlConnection.IsTransactional)
+                SqlConnection.Disconnect();
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/HatTrick.DbEx.Sql/Executor/DataReaderWrapper.cs
+++ b/src/HatTrick.DbEx.Sql/Executor/DataReaderWrapper.cs
@@ -39,15 +39,13 @@ namespace HatTrick.DbEx.Sql.Executor
                     }
                     return new Row(currentRowIndex++, row);
                 }
+
                 //asking for a row and the reader has finished, proactively shut everything down.
-                DataReader.Close();
-                if (!SqlConnection.IsTransactional)
-                    SqlConnection.Disconnect();
+                Close();
             }
             catch
             {
-                if (DataReader != null && !DataReader.IsClosed)
-                    DataReader.Close(); //redundant, but required for sqlCe before rollback...
+                Close();
 
                 if (SqlConnection.IsTransactional)
                 {
@@ -63,7 +61,16 @@ namespace HatTrick.DbEx.Sql.Executor
             return null;
         }
 
-        protected virtual void Dispose(bool disposing)
+        public void Close()
+        {
+            if (DataReader is object && !DataReader.IsClosed)
+                DataReader.Close();
+
+            if (!SqlConnection.IsTransactional)
+                SqlConnection.Disconnect();
+        }
+
+		protected virtual void Dispose(bool disposing)
         {
             if (!disposed)
             {

--- a/src/HatTrick.DbEx.Sql/Executor/IAsyncSqlRowReader.cs
+++ b/src/HatTrick.DbEx.Sql/Executor/IAsyncSqlRowReader.cs
@@ -6,5 +6,6 @@ namespace HatTrick.DbEx.Sql.Executor
     public interface IAsyncSqlRowReader : IDisposable
     {
         Task<ISqlRow> ReadRowAsync();
+        void Close();
     }
 }

--- a/src/HatTrick.DbEx.Sql/Executor/ISqlRowReader.cs
+++ b/src/HatTrick.DbEx.Sql/Executor/ISqlRowReader.cs
@@ -6,5 +6,6 @@ namespace HatTrick.DbEx.Sql.Executor
     public interface ISqlRowReader : IDisposable
     {
         ISqlRow ReadRow();
+        void Close();
     }
 }

--- a/src/HatTrick.DbEx.Sql/Pipeline/SelectQueryExpressionExecutionPipeline.cs
+++ b/src/HatTrick.DbEx.Sql/Pipeline/SelectQueryExpressionExecutionPipeline.cs
@@ -59,6 +59,8 @@ namespace HatTrick.DbEx.Sql.Pipeline
                     var row = reader.ReadRow();
                     if (row == default)
                         return;
+                    else
+                        reader.Close();
 
                     entity = database.EntityFactory.CreateEntity<T>();
                     var mapper = database.MapperFactory.CreateEntityMapper(expression.BaseEntity as EntityExpression<T>);
@@ -81,6 +83,8 @@ namespace HatTrick.DbEx.Sql.Pipeline
                     var row = await reader.ReadRowAsync().ConfigureAwait(false);
                     if (row == default)
                         return;
+                    else
+                        reader.Close();
 
                     value = database.EntityFactory.CreateEntity<T>();
                     var mapper = database.MapperFactory.CreateEntityMapper(expression.BaseEntity as EntityExpression<T>);
@@ -150,6 +154,8 @@ namespace HatTrick.DbEx.Sql.Pipeline
                     var field = reader.ReadRow()?.ReadField();
                     if (field is null)
                         return;
+                    else
+                        reader.Close();
 
                     value = field.GetValue<T>();
                 }
@@ -173,6 +179,8 @@ namespace HatTrick.DbEx.Sql.Pipeline
                     var field = row.ReadField();
                     if (field is null)
                         return;
+                    else
+                        reader.Close();
 
                     value = field.GetValue<T>();
                 },
@@ -241,6 +249,8 @@ namespace HatTrick.DbEx.Sql.Pipeline
                     var row = reader.ReadRow();
                     if (row == default)
                         return;
+                    else
+                        reader.Close();
 
                     value = new ExpandoObject();
                     var mapper = database.MapperFactory.CreateExpandoObjectMapper();
@@ -263,6 +273,8 @@ namespace HatTrick.DbEx.Sql.Pipeline
                     var row = await reader.ReadRowAsync().ConfigureAwait(false);
                     if (row == default)
                         return;
+                    else
+                        reader.Close();
 
                     value = new ExpandoObject();
                     var mapper = database.MapperFactory.CreateExpandoObjectMapper();
@@ -332,6 +344,8 @@ namespace HatTrick.DbEx.Sql.Pipeline
                     var row = reader.ReadRow();
                     if (row is null)
                         return;
+                    else
+                        reader.Close();
 
                     try
                     {
@@ -358,6 +372,8 @@ namespace HatTrick.DbEx.Sql.Pipeline
                     var row = await reader.ReadRowAsync().ConfigureAwait(false);
                     if (row is null)
                         return;
+                    else
+                        reader.Close();
 
                     try
                     {


### PR DESCRIPTION
Exposed ```void Close()``` on IAsyncSqlRowReader and ISqlRowReader.  Allows consumers of implementations to have control over internal reader lifespan even if the Reader data has not been fully exhausted.

closes issue #122 