### PR TITLE
added Enumerable of OrderBy to fluent methods

### DIFF
--- a/src/HatTrick.DbEx.MsSql/Assembler/MsSqlInsertSqlStatementAssembler.cs
+++ b/src/HatTrick.DbEx.MsSql/Assembler/MsSqlInsertSqlStatementAssembler.cs
@@ -35,22 +35,23 @@ namespace HatTrick.DbEx.MsSql.Assembler
 
                 builder.Appender.Indent().Write("(");
 
-                for (var j = 0; j < insert.Value.Expressions.Count; j++)
+                var inserts = insert.Value.Expressions.ToList();
+                for (var j = 0; j < inserts.Count; j++)
                 {
-                    if (identity is object && (insert.Value.Expressions[j] as IAssignmentExpressionProvider).Assignee == identity)
+                    if (identity is object && (inserts[j] as IAssignmentExpressionProvider).Assignee == identity)
                         continue; //don't emit identity columns with the values; they can't be inserted into the table
 
-                    context.PushField((insert.Value.Expressions[j] as IAssignmentExpressionProvider).Assignee);
+                    context.PushField((inserts[j] as IAssignmentExpressionProvider).Assignee);
                     try
                     {
-                        builder.AppendPart((insert.Value.Expressions[j] as IAssignmentExpressionProvider).Assignment, context);
+                        builder.AppendPart((inserts[j] as IAssignmentExpressionProvider).Assignment, context);
                     }
                     finally
                     {
                         context.PopField();
                     }
                     builder.Appender.Write(", ");
-                    if (j == insert.Value.Expressions.Count - 1)
+                    if (j == inserts.Count - 1)
                         builder.Appender.Write(i.ToString());
                 }
 
@@ -69,18 +70,19 @@ namespace HatTrick.DbEx.MsSql.Assembler
                 .Indentation++;
 
             //write out the table structure of the  {insertValueNames} table
-            for (var i = 0; i < template.Expressions.Count; i++)
+            var templateInserts = template.Expressions.ToList();
+            for (var i = 0; i < templateInserts.Count; i++)
             {
-                if (identity is object && (template.Expressions[i] as IAssignmentExpressionProvider).Assignee == identity)
+                if (identity is object && (templateInserts[i] as IAssignmentExpressionProvider).Assignee == identity)
                     continue; //don't emit identity columns with the values; they can't be inserted into the table
 
                 builder.Appender.Indent();
                 builder.AppendPart(
-                    (template.Expressions[i] as IAssignmentExpressionProvider).Assignee,
+                    (templateInserts[i] as IAssignmentExpressionProvider).Assignee,
                     context
                 );
                 builder.Appender.Write(", ").LineBreak();
-                if (i == template.Expressions.Count - 1)
+                if (i == templateInserts.Count - 1)
                 {
                     builder.Appender.Indent().Write(context.Configuration.IdentifierDelimiter.Begin)
                         .Write(ordinalColumnName)
@@ -93,17 +95,17 @@ namespace HatTrick.DbEx.MsSql.Assembler
                 .Indent().Write("WHEN NOT MATCHED THEN").LineBreak()
                 .Indent().Write("INSERT (").LineBreak().Indentation++;
 
-            for (var i = 0; i < template.Expressions.Count; i++)
+            for (var i = 0; i < templateInserts.Count; i++)
             {
-                if (identity is object && (template.Expressions[i] as IAssignmentExpressionProvider).Assignee == identity)
+                if (identity is object && (templateInserts[i] as IAssignmentExpressionProvider).Assignee == identity)
                     continue; //don't emit identity columns with the values; they can't be inserte into the table
 
                 builder.Appender.Indent();
                 builder.AppendPart(
-                    (template.Expressions[i] as IAssignmentExpressionProvider).Assignee,
+                    (templateInserts[i] as IAssignmentExpressionProvider).Assignee,
                     context
                 );
-                if (i < template.Expressions.Count - 1)
+                if (i < templateInserts.Count - 1)
                     builder.Appender.Write(", ").LineBreak();
                 else
                     builder.Appender.LineBreak();
@@ -114,9 +116,9 @@ namespace HatTrick.DbEx.MsSql.Assembler
             context.PushAppendStyles(EntityExpressionAppendStyle.None, FieldExpressionAppendStyle.None);
             try
             {
-                for (var i = 0; i < template.Expressions.Count; i++)
+                for (var i = 0; i < templateInserts.Count; i++)
                 {
-                    if (identity is object && (template.Expressions[i] as IAssignmentExpressionProvider).Assignee == identity)
+                    if (identity is object && (templateInserts[i] as IAssignmentExpressionProvider).Assignee == identity)
                         continue; //don't emit identity columns with the values; they can't be inserted into the table
 
                     builder.Appender.Indent().Write(context.Configuration.IdentifierDelimiter.Begin)
@@ -124,16 +126,16 @@ namespace HatTrick.DbEx.MsSql.Assembler
                         .Write(context.Configuration.IdentifierDelimiter.End)
                         .Write(".");
 
-                    context.PushField((template.Expressions[i] as IAssignmentExpressionProvider).Assignee);
+                    context.PushField((templateInserts[i] as IAssignmentExpressionProvider).Assignee);
                     try
                     {
-                        builder.AppendPart((template.Expressions[i] as IAssignmentExpressionProvider).Assignee, context);
+                        builder.AppendPart((templateInserts[i] as IAssignmentExpressionProvider).Assignee, context);
                     }
                     finally
                     {
                         context.PopField();
                     }
-                    if (i < template.Expressions.Count - 1)
+                    if (i < templateInserts.Count - 1)
                         builder.Appender.Write(", ");
                     builder.Appender.LineBreak();
                 }
@@ -156,15 +158,15 @@ namespace HatTrick.DbEx.MsSql.Assembler
                 .Write(", ").LineBreak();
 
             //write out all fields for the select from INSERTED table
-            for (var i = 0; i < template.Expressions.Count; i++)
+            for (var i = 0; i < templateInserts.Count; i++)
             {
                 builder.Appender.Indent();
                 builder.Appender.Write("INSERTED.");
                 builder.AppendPart(
-                    (template.Expressions[i] as IAssignmentExpressionProvider).Assignee,
+                    (templateInserts[i] as IAssignmentExpressionProvider).Assignee,
                     context
                 );
-                if (i < template.Expressions.Count - 1)
+                if (i < templateInserts.Count - 1)
                     builder.Appender.Write(", ").LineBreak();
             }
         }

--- a/src/HatTrick.DbEx.MsSql/Assembler/MsSqlSelectSqlStatementAssembler.cs
+++ b/src/HatTrick.DbEx.MsSql/Assembler/MsSqlSelectSqlStatementAssembler.cs
@@ -3,6 +3,7 @@ using HatTrick.DbEx.Sql.Assembler;
 using HatTrick.DbEx.Sql.Expression;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace HatTrick.DbEx.MsSql.Assembler
@@ -27,15 +28,17 @@ namespace HatTrick.DbEx.MsSql.Assembler
             if (context.Configuration.PrependCommaOnSelectClauseParts)
                 builder.Appender.Write(", ");
             builder.Appender.Indentation++.Indent().Write("ROW_NUMBER() OVER (");
-            for (var i = 0; i < expression.OrderBy.Expressions.Count; i++)
+
+            var orderBys = expression.OrderBy.Expressions.ToList();
+            for (var i = 0; i < orderBys.Count; i++)
             {
                 builder.Appender.Indent();
 
                 context.PushAppendStyle(EntityExpressionAppendStyle.None);
-                builder.AppendPart(expression.OrderBy.Expressions[i], context);
+                builder.AppendPart(orderBys[i], context);
                 context.PopAppendStyles();
 
-                if (i < expression.OrderBy.Expressions.Count - 1)
+                if (i < orderBys.Count - 1)
                     builder.Appender.Write(", ");
             }
             builder.Appender.Write(") AS [__index]").LineBreak();

--- a/src/HatTrick.DbEx.MsSql/Assembler/v2005/MsSqlInsertSqlStatementAssembler.cs
+++ b/src/HatTrick.DbEx.MsSql/Assembler/v2005/MsSqlInsertSqlStatementAssembler.cs
@@ -14,7 +14,7 @@ namespace HatTrick.DbEx.MsSql.v2005.Assembler
             if (expression.Inserts.Count > 1)
                 throw new DbExpressionException("MsSql version 2005 does not support inserting multiple records in a single statement.");
 
-            var insertSet = expression.Inserts.Values.Single().Expressions;
+            var insertSet = expression.Inserts.Values.Single().Expressions.ToList();
             var identity = (expression.BaseEntity as IExpressionListProvider<FieldExpression>).Expressions.SingleOrDefault(x => builder.FindMetadata(x).IsIdentity);
 
             builder.Appender.Indent().Write("SET NOCOUNT ON;").LineBreak();

--- a/src/HatTrick.DbEx.Sql/Assembler/AssemblyPartAppenderFactory.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/AssemblyPartAppenderFactory.cs
@@ -18,6 +18,7 @@ namespace HatTrick.DbEx.Sql.Assembler
         private static readonly FilterExpressionSetPartAppender _filterSetAppender = new FilterExpressionSetPartAppender();
         private static readonly JoinExpressionPartAppender _joinAppender = new JoinExpressionPartAppender();
         private static readonly JoinExpressionSetPartAppender _joinSetAppender = new JoinExpressionSetPartAppender();
+        private static readonly JoinOnExpressionSetPartAppender _joinOnSetAppender = new JoinOnExpressionSetPartAppender();
         private static readonly JoinOnExpressionPartAppender _joinOnClauseAppender = new JoinOnExpressionPartAppender();
         private static readonly GroupByExpressionPartAppender _groupByAppender = new GroupByExpressionPartAppender();
         private static readonly GroupByExpressionSetPartAppender _groupBySetAppender = new GroupByExpressionSetPartAppender();
@@ -106,6 +107,7 @@ namespace HatTrick.DbEx.Sql.Assembler
             _partAppenders.TryAdd(typeof(FilterExpressionSet), () => _filterSetAppender);
             _partAppenders.TryAdd(typeof(JoinExpression), () => _joinAppender);
             _partAppenders.TryAdd(typeof(JoinExpressionSet), () => _joinSetAppender);
+            _partAppenders.TryAdd(typeof(JoinOnExpressionSet), () => _joinOnSetAppender);
             _partAppenders.TryAdd(typeof(JoinOnExpression), () => _joinOnClauseAppender);
             _partAppenders.TryAdd(typeof(GroupByExpression), () => _groupByAppender);
             _partAppenders.TryAdd(typeof(GroupByExpressionSet), () => _groupBySetAppender);

--- a/src/HatTrick.DbEx.Sql/Assembler/_Appenders/AssignmentExpressionSetPartAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/_Appenders/AssignmentExpressionSetPartAppender.cs
@@ -12,11 +12,12 @@ namespace HatTrick.DbEx.Sql.Assembler
             if (expression?.Expressions is null || !expression.Expressions.Any())
                 return;
 
-            for (var i = 0; i < expression.Expressions.Count; i++)
+            var inserts = expression.Expressions.ToList();
+            for (var i = 0; i < inserts.Count; i++)
             {
                 builder.Appender.Indent();
-                builder.AppendPart(expression.Expressions[i], context);
-                if (i < expression.Expressions.Count - 1)
+                builder.AppendPart(inserts[i], context);
+                if (i < inserts.Count - 1)
                 {
                     builder.Appender.Write(",").LineBreak();
                 }

--- a/src/HatTrick.DbEx.Sql/Assembler/_Appenders/FilterExpressionSetPartAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/_Appenders/FilterExpressionSetPartAppender.cs
@@ -19,8 +19,8 @@ namespace HatTrick.DbEx.Sql.Assembler
             if (expression is null || (expression.LeftArg is null && expression.RightArg is null))
                 return;
 
-            var thisIsTheRootFilterExperssionSet = context.GetState<ThisIsTheRootFilterExpressionSet>() is null;
-            if (thisIsTheRootFilterExperssionSet)
+            var thisIsTheRootFilterExpressionSet = context.GetState<ThisIsTheRootFilterExpressionSet>() is null;
+            if (thisIsTheRootFilterExpressionSet)
             {
                 context.SetState(new ThisIsTheRootFilterExpressionSet());
             }
@@ -30,7 +30,7 @@ namespace HatTrick.DbEx.Sql.Assembler
                 var hasSet = expression.LeftArg is FilterExpressionSet || expression.RightArg is FilterExpressionSet;
                 void conditionallyAppend(bool condition, Action<IAppender> appendAction) { if (condition) appendAction(builder.Appender); }
 
-                conditionallyAppend(thisIsTheRootFilterExperssionSet, a => a.Indent());
+                conditionallyAppend(thisIsTheRootFilterExpressionSet, a => a.Indent());
 
                 conditionallyAppend(expression.Negate, a => a.Write("NOT "));
                 builder.Appender.Write('(');
@@ -57,7 +57,7 @@ namespace HatTrick.DbEx.Sql.Assembler
             }
             finally
             {
-                if (thisIsTheRootFilterExperssionSet)
+                if (thisIsTheRootFilterExpressionSet)
                     context.RemoveState<ThisIsTheRootFilterExpressionSet>();
             }
         }

--- a/src/HatTrick.DbEx.Sql/Assembler/_Appenders/GroupByExpressionSetPartAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/_Appenders/GroupByExpressionSetPartAppender.cs
@@ -11,16 +11,17 @@ namespace HatTrick.DbEx.Sql.Assembler
             if (expression?.Expressions is null || !expression.Expressions.Any())
                 return;
 
-            for (var i = 0; i < expression.Expressions.Count; i++)
+            var groupBys = expression.Expressions.ToList();
+            for (var i = 0; i < groupBys.Count; i++)
             {
                 builder.Appender.Indent();
 
                 if (context.Configuration.PrependCommaOnSelectClauseParts && i > 0)
                     builder.Appender.Write(",");
 
-                builder.AppendPart(expression.Expressions[i], context);
+                builder.AppendPart(groupBys[i], context);
 
-                if (!context.Configuration.PrependCommaOnSelectClauseParts && i < expression.Expressions.Count - 1)
+                if (!context.Configuration.PrependCommaOnSelectClauseParts && i < groupBys.Count - 1)
                     builder.Appender.Write(",");
 
                 builder.Appender.LineBreak();

--- a/src/HatTrick.DbEx.Sql/Assembler/_Appenders/JoinOnExpressionPartAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/_Appenders/JoinOnExpressionPartAppender.cs
@@ -1,29 +1,49 @@
-﻿using HatTrick.DbEx.Sql.Expression;
-using HatTrick.DbEx.Sql.Attribute;
-using System;
+﻿using HatTrick.DbEx.Sql.Attribute;
+using HatTrick.DbEx.Sql.Expression;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace HatTrick.DbEx.Sql.Assembler
 {
     public class JoinOnExpressionPartAppender : PartAppender<JoinOnExpression>
     {
+        #region internals
         private static IDictionary<FilterExpressionOperator, string> _filterOperatorMap;
         private static IDictionary<FilterExpressionOperator, string> FilterOperatorMap => _filterOperatorMap ?? (_filterOperatorMap = typeof(FilterExpressionOperator).GetValuesAndFilterOperators(x => string.IsNullOrWhiteSpace(x) ? " " : $" {x} "));
+        #endregion
 
+        #region methods
         public override void AppendPart(JoinOnExpression expression, ISqlStatementBuilder builder, AssemblyContext context)
         {
             context.PushAppendStyles(EntityExpressionAppendStyle.Alias, FieldExpressionAppendStyle.Alias);
             try
             {
+                if (expression.Negate)
+                {
+                    builder.Appender.Write("NOT (");
+                }
                 builder.AppendPart(expression.LeftArg, context);
+
                 builder.Appender.Write(FilterOperatorMap[expression.ExpressionOperator]);
-                builder.AppendPart(expression.RightArg, context);
+                context.PushField(expression.LeftArg.Expression as FieldExpression);
+                try
+                {
+                    builder.AppendPart(expression.RightArg, context);
+                }
+                finally
+                {
+                    context.PopField();
+                }
+
+                if (expression.Negate)
+                {
+                    builder.Appender.Write(')');
+                }
             }
             finally
             {
                 context.PopAppendStyles();
             }
         }
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Assembler/_Appenders/JoinOnExpressionSetPartAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/_Appenders/JoinOnExpressionSetPartAppender.cs
@@ -1,0 +1,38 @@
+﻿using HatTrick.DbEx.Sql.Attribute;
+using HatTrick.DbEx.Sql.Expression;
+using System.Collections.Generic;
+
+namespace HatTrick.DbEx.Sql.Assembler
+{
+    public class JoinOnExpressionSetPartAppender : PartAppender<JoinOnExpressionSet>
+    {
+        #region internals
+        private static IDictionary<ConditionalExpressionOperator, string> _conditionalOperatorMap;
+        private static IDictionary<ConditionalExpressionOperator, string> ConditionalOperatorMap => _conditionalOperatorMap ?? (_conditionalOperatorMap = typeof(ConditionalExpressionOperator).GetValuesAndConditionalOperators());
+        #endregion
+
+        #region methods
+        public override void AppendPart(JoinOnExpressionSet expression, ISqlStatementBuilder builder, AssemblyContext context)
+        {
+            if (expression is null || (expression.LeftArg is null && expression.RightArg is null))
+                return;
+
+            if (expression.Negate)
+                builder.Appender.Write("NOT (");
+
+            if (expression.LeftArg is object)
+            {
+                builder.AppendPart(expression.LeftArg, context);
+            }
+            if (expression.RightArg is object)
+            {
+                builder.Appender.Write(ConditionalOperatorMap[expression.ConditionalOperator]);
+                builder.AppendPart(expression.RightArg, context);
+            }
+
+            if (expression.Negate)
+                builder.Appender.Write(')');
+        }
+        #endregion
+    }
+}

--- a/src/HatTrick.DbEx.Sql/Assembler/_Appenders/OrderByExpressionSetPartAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/_Appenders/OrderByExpressionSetPartAppender.cs
@@ -11,16 +11,17 @@ namespace HatTrick.DbEx.Sql.Assembler
             if (expression?.Expressions is null || !expression.Expressions.Any())
                 return;
 
-            for (var i = 0; i < expression.Expressions.Count; i++)
+            var orderBys = expression.Expressions.ToList();
+            for (var i = 0; i < orderBys.Count; i++)
             {
                 builder.Appender.Indent();
 
                 if (context.Configuration.PrependCommaOnSelectClauseParts && i > 0)
                     builder.Appender.Write(",");
 
-                builder.AppendPart(expression.Expressions[i], context);
+                builder.AppendPart(orderBys[i], context);
 
-                if (!context.Configuration.PrependCommaOnSelectClauseParts && i < expression.Expressions.Count - 1)
+                if (!context.Configuration.PrependCommaOnSelectClauseParts && i < orderBys.Count - 1)
                     builder.Appender.Write(",");
 
                 builder.Appender.LineBreak();

--- a/src/HatTrick.DbEx.Sql/Assembler/_Appenders/SelectExpressionSetPartAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/_Appenders/SelectExpressionSetPartAppender.cs
@@ -11,7 +11,8 @@ namespace HatTrick.DbEx.Sql.Assembler
             if (expression?.Expressions is null || !expression.Expressions.Any())
                 return;
 
-            for (var i = 0; i < expression.Expressions.Count; i++)
+            var selects = expression.Expressions.ToList();
+            for (var i = 0; i < selects.Count; i++)
             {
                 builder.Appender.Indent();
                 if (context.Configuration.PrependCommaOnSelectClauseParts && i > 0)
@@ -19,9 +20,9 @@ namespace HatTrick.DbEx.Sql.Assembler
                     builder.Appender.Write(",");
                 }
 
-                builder.AppendPart(expression.Expressions[i], context);
+                builder.AppendPart(selects[i], context);
 
-                if (!context.Configuration.PrependCommaOnSelectClauseParts && i < expression.Expressions.Count - 1)
+                if (!context.Configuration.PrependCommaOnSelectClauseParts && i < selects.Count - 1)
                 {
                     builder.Appender.Write(",");
                 }

--- a/src/HatTrick.DbEx.Sql/Builder/JoinExpressionBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/JoinExpressionBuilder{T}.cs
@@ -1,6 +1,7 @@
 ﻿using HatTrick.DbEx.Sql.Builder.Syntax;
 using HatTrick.DbEx.Sql.Expression;
 using System;
+using System.Linq;
 
 namespace HatTrick.DbEx.Sql.Builder
 {
@@ -34,7 +35,9 @@ namespace HatTrick.DbEx.Sql.Builder
             if (Expression.Joins is null)
                 Expression.Joins = new JoinExpressionSet(new JoinExpression(JoinOn, JoinType, expression, Alias));
             else
-                Expression.Joins.Expressions.Add(new JoinExpression(JoinOn, JoinType, expression, Alias));
+            {
+                Expression.Joins = new JoinExpressionSet(Expression.Joins.Expressions.Concat(new JoinExpression[1] { new JoinExpression(JoinOn, JoinType, expression, Alias) }));
+            }
             return Caller;
         }
     }

--- a/src/HatTrick.DbEx.Sql/Builder/SelectQueryExpressionBuilder{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/SelectQueryExpressionBuilder{T,U}.cs
@@ -1,6 +1,8 @@
 ﻿using HatTrick.DbEx.Sql.Builder.Syntax;
 using HatTrick.DbEx.Sql.Configuration;
 using HatTrick.DbEx.Sql.Expression;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace HatTrick.DbEx.Sql.Builder
 {
@@ -29,7 +31,19 @@ namespace HatTrick.DbEx.Sql.Builder
             return this;
         }
 
+        IValueListContinuationExpressionBuilder<T, U> IValueListContinuationExpressionBuilder<T, U>.OrderBy(IEnumerable<OrderByExpression> orderBy)
+        {
+            OrderBy(orderBy);
+            return this;
+        }
+
         IValueContinuationExpressionBuilder<T, U> IValueContinuationExpressionBuilder<T, U>.OrderBy(params OrderByExpression[] orderBy)
+        {
+            OrderBy(orderBy);
+            return this;
+        }
+
+        IValueContinuationExpressionBuilder<T, U> IValueContinuationExpressionBuilder<T, U>.OrderBy(IEnumerable<OrderByExpression> orderBy)
         {
             OrderBy(orderBy);
             return this;
@@ -41,10 +55,15 @@ namespace HatTrick.DbEx.Sql.Builder
             return this;
         }
 
-        private void OrderBy(params OrderByExpression[] orderBy)
+        ITypeListContinuationExpressionBuilder<T, U> ITypeListContinuationExpressionBuilder<T, U>.OrderBy(IEnumerable<OrderByExpression> orderBy)
         {
-            foreach (var o in orderBy)
-                Expression.OrderBy.Expressions.Add(o);
+            OrderBy(orderBy);
+            return this;
+        }
+
+        private void OrderBy(IEnumerable<OrderByExpression> orderBy)
+        {
+            Expression.OrderBy = new OrderByExpressionSet(Expression.OrderBy.Expressions.Concat(orderBy));
         }
         #endregion
 
@@ -67,10 +86,9 @@ namespace HatTrick.DbEx.Sql.Builder
             return this;
         }
 
-        private void GroupBy(params GroupByExpression[] groupBy)
+        private void GroupBy(IEnumerable<GroupByExpression> groupBy)
         {
-            foreach (var grouping in groupBy)
-                Expression.GroupBy.Expressions.Add(grouping);
+            Expression.GroupBy = new GroupByExpressionSet(Expression.GroupBy.Expressions.Concat(groupBy));
         }
         #endregion
 

--- a/src/HatTrick.DbEx.Sql/Builder/Syntax/_Type/ITypeListContinuationExpressionBuilder{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/Syntax/_Type/ITypeListContinuationExpressionBuilder{T,U}.cs
@@ -1,4 +1,5 @@
 ﻿using HatTrick.DbEx.Sql.Expression;
+using System.Collections.Generic;
 
 namespace HatTrick.DbEx.Sql.Builder.Syntax
 {
@@ -17,6 +18,7 @@ namespace HatTrick.DbEx.Sql.Builder.Syntax
         IAliasRequiredJoinExpressionBuilder<T, ITypeListContinuationExpressionBuilder<T, U>> RightJoin(ISubqueryTerminationExpressionBuilder subquery);
         IAliasRequiredJoinExpressionBuilder<T, ITypeListContinuationExpressionBuilder<T, U>> FullJoin(ISubqueryTerminationExpressionBuilder subquery);
         ITypeListContinuationExpressionBuilder<T, U> OrderBy(params OrderByExpression[] orderBy);
+        ITypeListContinuationExpressionBuilder<T, U> OrderBy(IEnumerable<OrderByExpression> orderBy);
         ITypeListContinuationExpressionBuilder<T, U> GroupBy(params GroupByExpression[] groupBy);
         ITypeListContinuationExpressionBuilder<T, U> Having(HavingExpression havingCondition);
         ITypeListSkipContinuationExpressionBuilder<T, U> Skip(int skipValue);

--- a/src/HatTrick.DbEx.Sql/Builder/Syntax/_Value/IValueContinuationExpressionBuilder{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/Syntax/_Value/IValueContinuationExpressionBuilder{T,U}.cs
@@ -1,4 +1,5 @@
 ﻿using HatTrick.DbEx.Sql.Expression;
+using System.Collections.Generic;
 
 namespace HatTrick.DbEx.Sql.Builder.Syntax
 {
@@ -20,6 +21,7 @@ namespace HatTrick.DbEx.Sql.Builder.Syntax
         IAliasRequiredJoinExpressionBuilder<T, IValueContinuationExpressionBuilder<T, U>> RightJoin(ISubqueryTerminationExpressionBuilder subquery);
         IAliasRequiredJoinExpressionBuilder<T, IValueContinuationExpressionBuilder<T, U>> FullJoin(ISubqueryTerminationExpressionBuilder subquery);
         IValueContinuationExpressionBuilder<T, U> OrderBy(params OrderByExpression[] orderBy);
+        IValueContinuationExpressionBuilder<T, U> OrderBy(IEnumerable<OrderByExpression> orderBy);
         IValueContinuationExpressionBuilder<T, U> GroupBy(params GroupByExpression[] groupBy);
         IValueContinuationExpressionBuilder<T, U> Having(HavingExpression havingCondition);
     }

--- a/src/HatTrick.DbEx.Sql/Builder/Syntax/_Value/IValueListContinuationExpressionBuilder{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/Syntax/_Value/IValueListContinuationExpressionBuilder{T,U}.cs
@@ -1,4 +1,5 @@
 ﻿using HatTrick.DbEx.Sql.Expression;
+using System.Collections.Generic;
 
 namespace HatTrick.DbEx.Sql.Builder.Syntax
 {
@@ -20,6 +21,7 @@ namespace HatTrick.DbEx.Sql.Builder.Syntax
         IAliasRequiredJoinExpressionBuilder<T, IValueListContinuationExpressionBuilder<T, U>> RightJoin(ISubqueryTerminationExpressionBuilder subquery);
         IAliasRequiredJoinExpressionBuilder<T, IValueListContinuationExpressionBuilder<T, U>> FullJoin(ISubqueryTerminationExpressionBuilder subquery);
         IValueListContinuationExpressionBuilder<T, U> OrderBy(params OrderByExpression[] orderBy);
+        IValueListContinuationExpressionBuilder<T, U> OrderBy(IEnumerable<OrderByExpression> orderBy);
         IValueListContinuationExpressionBuilder<T, U> GroupBy(params GroupByExpression[] groupBy);
         IValueListContinuationExpressionBuilder<T, U> Having(HavingExpression havingCondition);
         IValueListSkipContinuationExpressionBuilder<T, U> Skip(int skipValue);

--- a/src/HatTrick.DbEx.Sql/Builder/UpdateQueryExpressionBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/UpdateQueryExpressionBuilder{T}.cs
@@ -2,6 +2,7 @@
 using HatTrick.DbEx.Sql.Configuration;
 using HatTrick.DbEx.Sql.Expression;
 using System;
+using System.Linq;
 
 namespace HatTrick.DbEx.Sql.Builder
 {
@@ -41,8 +42,7 @@ namespace HatTrick.DbEx.Sql.Builder
 
         IUpdateFromExpressionBuilder IUpdateInitiationExpressionBuilder.Update(AssignmentExpression[] assignments)
         {
-            foreach (var assignment in assignments)
-                Expression.Assign.Expressions.Add(assignment);
+            Expression.Assign = new AssignmentExpressionSet(Expression.Assign.Expressions.Concat(assignments));
             return this;
         }
 

--- a/src/HatTrick.DbEx.Sql/Expression/AssignmentExpressionSet.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/AssignmentExpressionSet.cs
@@ -7,7 +7,7 @@ namespace HatTrick.DbEx.Sql.Expression
     public class AssignmentExpressionSet : IExpressionSet<AssignmentExpression>
     {
         #region interface
-        public IList<AssignmentExpression> Expressions { get; }
+        public IEnumerable<AssignmentExpression> Expressions { get; private set; }
         #endregion
 
         #region constructors
@@ -16,14 +16,14 @@ namespace HatTrick.DbEx.Sql.Expression
             Expressions = new List<AssignmentExpression>();
         }
 
-        public AssignmentExpressionSet(IList<AssignmentExpression> assignments)
+        public AssignmentExpressionSet(IEnumerable<AssignmentExpression> assignments)
         {
             Expressions = assignments?.ToList() ?? throw new ArgumentNullException($"{nameof(assignments)} is required.");
         }
 
         public AssignmentExpressionSet(AssignmentExpression assignment)
         {
-            Expressions.Add(assignment ?? throw new ArgumentNullException($"{nameof(assignment)} is required."));
+            Expressions = Expressions.Concat(new AssignmentExpression[1] { assignment ?? throw new ArgumentNullException($"{nameof(assignment)} is required.") });
         }
         #endregion
 
@@ -36,11 +36,11 @@ namespace HatTrick.DbEx.Sql.Expression
         {
             if (aSet is null)
             {
-                aSet = new AssignmentExpressionSet(b);
+                aSet = b;
             }
             else
             {
-                aSet.Expressions.Add(b);
+                aSet.Expressions = aSet.Expressions.Concat(new AssignmentExpression[1] { b });
             }
             return aSet;
         }
@@ -48,11 +48,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public static AssignmentExpressionSet operator &(AssignmentExpressionSet aSet, AssignmentExpressionSet bSet)
         {
             if (aSet is null)
-            {
-                aSet = new AssignmentExpressionSet();
-            }
-            foreach (var b in bSet.Expressions)
-                aSet.Expressions.Add(b);
+                return bSet;
+
+            aSet.Expressions = aSet.Expressions.Concat(bSet?.Expressions);
             return aSet;
         }
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/FilterExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/FilterExpression.cs
@@ -15,10 +15,16 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region constructors
         public FilterExpression(ExpressionMediator leftArg, ExpressionMediator rightArg, FilterExpressionOperator filterExpressionOperator)
+            : this(leftArg, rightArg, filterExpressionOperator, false)
+        {
+        }
+
+        public FilterExpression(ExpressionMediator leftArg, ExpressionMediator rightArg, FilterExpressionOperator filterExpressionOperator, bool negate)
         {
             LeftArg = leftArg ?? throw new ArgumentNullException($"{nameof(leftArg)} is required.");
             RightArg = rightArg ?? throw new ArgumentNullException($"{nameof(rightArg)} is required.");
             ExpressionOperator = filterExpressionOperator;
+            Negate = negate;
         }
         #endregion
 

--- a/src/HatTrick.DbEx.Sql/Expression/FilterExpressionSet.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/FilterExpressionSet.cs
@@ -3,8 +3,7 @@
 namespace HatTrick.DbEx.Sql.Expression
 {
     public class FilterExpressionSet : 
-        IExpression, 
-        IFunctionExpression
+        IExpression
     {
         #region interface
         public readonly ConditionalExpressionOperator ConditionalOperator;

--- a/src/HatTrick.DbEx.Sql/Expression/GroupByExpressionSet.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/GroupByExpressionSet.cs
@@ -9,7 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IExpressionSet<GroupByExpression>
     {
         #region interface
-        public IList<GroupByExpression> Expressions { get; } = new List<GroupByExpression>();
+        public IEnumerable<GroupByExpression> Expressions { get; private set; } = new List<GroupByExpression>();
         #endregion
 
         #region constructors
@@ -20,13 +20,21 @@ namespace HatTrick.DbEx.Sql.Expression
 
         public GroupByExpressionSet(GroupByExpression groupByExpression)
         {
-            Expressions.Add(groupByExpression ?? throw new ArgumentNullException($"{nameof(groupByExpression)} is required."));
+            Expressions = Expressions.Concat(new GroupByExpression[1] { groupByExpression ?? throw new ArgumentNullException($"{nameof(groupByExpression)} is required.") });
         }
 
         public GroupByExpressionSet(GroupByExpression aGroupByExpression, GroupByExpression bGroupByExpression)
         {
-            Expressions.Add(aGroupByExpression ?? throw new ArgumentNullException($"{nameof(aGroupByExpression)} is required."));
-            Expressions.Add(bGroupByExpression ?? throw new ArgumentNullException($"{nameof(bGroupByExpression)} is required."));
+            Expressions = new List<GroupByExpression>
+            {
+                aGroupByExpression ?? throw new ArgumentNullException($"{nameof(aGroupByExpression)} is required."),
+                bGroupByExpression ?? throw new ArgumentNullException($"{nameof(bGroupByExpression)} is required.")
+            };
+        }
+
+        public GroupByExpressionSet(IEnumerable<GroupByExpression> groupByExpression)
+        {
+            Expressions = groupByExpression ?? throw new ArgumentNullException($"{nameof(groupByExpression)} is required.");
         }
         #endregion
 
@@ -39,19 +47,21 @@ namespace HatTrick.DbEx.Sql.Expression
         {
             if (aSet is null)
             {
-                aSet = new GroupByExpressionSet(b);
+                aSet = b;
             }
             else
             {
-                aSet.Expressions.Add(b);
+                aSet.Expressions = aSet.Expressions.Concat(new GroupByExpression[1] { b });
             }
             return aSet;
         }
 
         public static GroupByExpressionSet operator &(GroupByExpressionSet aSet, GroupByExpressionSet bSet)
         {
-            foreach (var b in bSet.Expressions)
-                aSet.Expressions.Add(b);
+            if (aSet is null)
+                return bSet;
+
+            aSet.Expressions = aSet.Expressions.Concat(bSet?.Expressions);
             return aSet;
         }
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/IExpressionSet{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/IExpressionSet{T}.cs
@@ -5,6 +5,6 @@ namespace HatTrick.DbEx.Sql.Expression
     public interface IExpressionSet<T> : IExpressionSet
         where T : class, IExpression
     {
-        IList<T> Expressions { get; }
+        IEnumerable<T> Expressions { get; }
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/InsertExpressionSet.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/InsertExpressionSet.cs
@@ -8,18 +8,16 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region interface
         public IDbEntity Entity { get; }
-        public IList<InsertExpression> Expressions { get; } = new List<InsertExpression>();
+        public IEnumerable<InsertExpression> Expressions { get; private set; } = new List<InsertExpression>();
         #endregion
 
         #region constructors
         protected InsertExpressionSet() { }
 
-        public InsertExpressionSet(IDbEntity entity, IList<InsertExpression> fields)
+        public InsertExpressionSet(IDbEntity entity, IEnumerable<InsertExpression> fields)
         {
-            if (entity == null)
-                throw new ArgumentNullException($"{nameof(entity)} is required.");
-            Entity = entity;
-            Expressions = fields?.ToList() ?? throw new ArgumentNullException($"{nameof(fields)} is required.");
+            Entity = entity ?? throw new ArgumentNullException($"{nameof(entity)} is required.");
+            Expressions = fields ?? throw new ArgumentNullException($"{nameof(fields)} is required.");
         }
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/InsertExpressionSet{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/InsertExpressionSet{T}.cs
@@ -4,7 +4,8 @@ using System.Linq;
 
 namespace HatTrick.DbEx.Sql.Expression
 {
-    public class InsertExpressionSet<T> : InsertExpressionSet, IExpressionSet<InsertExpression>
+    public class InsertExpressionSet<T> : InsertExpressionSet, 
+        IExpressionSet<InsertExpression>
     {
         #region interface
         public new T Entity { get; private set; }
@@ -16,18 +17,12 @@ namespace HatTrick.DbEx.Sql.Expression
 
         }
 
-        public InsertExpressionSet(T entity, IList<InsertExpression> fields) : base(entity as IDbEntity, fields)
+        public InsertExpressionSet(T entity, IEnumerable<InsertExpression> fields) : base(entity as IDbEntity, fields)
         {
         }
 
         public InsertExpressionSet(T entity, params InsertExpression[] fields) : base(entity as IDbEntity, fields?.ToArray())
         {
-        }
-
-        public InsertExpressionSet(InsertExpression aInsertExpression, InsertExpression bInsertExpression)
-        {
-            Expressions.Add(aInsertExpression ?? throw new ArgumentNullException($"{nameof(aInsertExpression)} is required."));
-            Expressions.Add(bInsertExpression ?? throw new ArgumentNullException($"{nameof(bInsertExpression)} is required."));
         }
         #endregion
 

--- a/src/HatTrick.DbEx.Sql/Expression/JoinExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/JoinExpression.cs
@@ -7,7 +7,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IExpressionAliasProvider
     {
         #region interface
-        public JoinOnExpression JoinOnExpression { get; private set; }
+        public JoinOnExpressionSet JoinOnExpression { get; private set; }
         public IExpression JoinToo { get; private set; }
         public JoinOperationExpressionOperator JoinType { get; private set; }
         private string Alias { get; set; }

--- a/src/HatTrick.DbEx.Sql/Expression/JoinExpressionSet.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/JoinExpressionSet.cs
@@ -9,7 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IExpressionSet<JoinExpression>
     {
         #region interface
-        public IList<JoinExpression> Expressions { get; }  = new List<JoinExpression>();
+        public IEnumerable<JoinExpression> Expressions { get; private set; }  = new List<JoinExpression>();
         #endregion
 
         #region constructors
@@ -20,13 +20,21 @@ namespace HatTrick.DbEx.Sql.Expression
 
         public JoinExpressionSet(JoinExpression joinExpression)
         {
-            Expressions.Add(joinExpression ?? throw new ArgumentNullException($"{nameof(joinExpression)} is required."));
+            Expressions = Expressions.Concat(new JoinExpression[1] { joinExpression ?? throw new ArgumentNullException($"{nameof(joinExpression)} is required.") });
         }
 
         public JoinExpressionSet(JoinExpression aJoinExpression, JoinExpression bJoinExpression)
         {
-            Expressions.Add(aJoinExpression ?? throw new ArgumentNullException($"{nameof(aJoinExpression)} is required."));
-            Expressions.Add(bJoinExpression ?? throw new ArgumentNullException($"{nameof(bJoinExpression)} is required."));
+            Expressions = new List<JoinExpression>
+            {
+                aJoinExpression ?? throw new ArgumentNullException($"{nameof(aJoinExpression)} is required."),
+                bJoinExpression ?? throw new ArgumentNullException($"{nameof(bJoinExpression)} is required.")
+            };
+        }
+
+        public JoinExpressionSet(IEnumerable<JoinExpression> joinExpressions)
+        {
+            Expressions = joinExpressions ?? throw new ArgumentNullException($"{nameof(joinExpressions)} is required.");
         }
         #endregion
 
@@ -37,14 +45,23 @@ namespace HatTrick.DbEx.Sql.Expression
         #region logical & operator
         public static JoinExpressionSet operator &(JoinExpressionSet aSet, JoinExpression b)
         {
-            aSet.Expressions.Add(b);
+            if (aSet is null)
+            {
+                aSet = new JoinExpressionSet(b);
+            }
+            else
+            {
+                aSet.Expressions = aSet.Expressions.Concat(new JoinExpression[1] { b });
+            }
             return aSet;
         }
 
         public static JoinExpressionSet operator &(JoinExpressionSet aSet, JoinExpressionSet bSet)
         {
-            foreach (var b in bSet.Expressions)
-                aSet.Expressions.Add(b);
+            if (aSet is null)
+                return bSet;
+
+            aSet.Expressions = aSet.Expressions.Concat(bSet?.Expressions);
             return aSet;
         }
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/JoinOnExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/JoinOnExpression.cs
@@ -6,27 +6,24 @@ namespace HatTrick.DbEx.Sql.Expression
         IExpression
     {
         #region interface
-        public IExpression LeftArg { get; set; }
-        public IExpression RightArg { get; set; }
+        public ExpressionMediator LeftArg { get; set; }
+        public ExpressionMediator RightArg { get; set; }
         public readonly FilterExpressionOperator ExpressionOperator;
         public bool Negate { get; set; }
         #endregion
 
         #region constructors
-        public JoinOnExpression(FilterExpression expression)
+        public JoinOnExpression(ExpressionMediator leftArg, ExpressionMediator rightArg, FilterExpressionOperator filterExpressionOperator)
+            : this(leftArg, rightArg, filterExpressionOperator, false)
         {
-            LeftArg = expression.LeftArg ?? throw new ArgumentNullException($"{nameof(expression)} and the {nameof(expression.LeftArg)} of {nameof(expression)} is required.");
-            RightArg = expression.RightArg ?? throw new ArgumentNullException($"{nameof(expression)} and the {nameof(expression.RightArg)} of {nameof(expression)} is required.");
-            ExpressionOperator = expression.ExpressionOperator;
-            Negate = expression.Negate;
         }
 
-        private JoinOnExpression(IExpression leftArg, IExpression rightArg, FilterExpressionOperator expresionOperator, bool negate)
+        public JoinOnExpression(ExpressionMediator leftArg, ExpressionMediator rightArg, FilterExpressionOperator expresionOperator, bool negate)
         {
             LeftArg = leftArg ?? throw new ArgumentNullException($"{nameof(leftArg)} is required.");
             RightArg = rightArg ?? throw new ArgumentNullException($"{nameof(rightArg)} is required.");
             ExpressionOperator = expresionOperator;
-            Negate =negate;
+            Negate = negate;
         }
 
         #endregion
@@ -42,34 +39,26 @@ namespace HatTrick.DbEx.Sql.Expression
         #region conditional &, | operators
         public static JoinOnExpressionSet operator &(JoinOnExpression a, JoinOnExpression b)
         {
-            if (a is null && b is object) { return new JoinOnExpressionSet(new NullableLiteralExpression(), b, ConditionalExpressionOperator.And, b.Negate); }
-            if (a is object && b is null) { return new JoinOnExpressionSet(a, new NullableLiteralExpression(), ConditionalExpressionOperator.And, a.Negate); }
-            if (a is null && b is null) { return null; }
-
-            return new JoinOnExpressionSet(a, b, ConditionalExpressionOperator.And);
+            return new JoinOnExpressionSet(a ?? throw new ArgumentNullException($"{a} is required."), b ?? throw new ArgumentNullException($"{b} is required."), ConditionalExpressionOperator.And);
         }
 
         public static JoinOnExpressionSet operator |(JoinOnExpression a, JoinOnExpression b)
         {
-            if (a is null && b is object) { return new JoinOnExpressionSet(new NullableLiteralExpression(), b, ConditionalExpressionOperator.Or, b.Negate); }
-            if (a is object && b is null) { return new JoinOnExpressionSet(a, new NullableLiteralExpression(), ConditionalExpressionOperator.Or, a.Negate); }
-            if (a is null && b is null) { return null; }
-
-            return new JoinOnExpressionSet(a, b, ConditionalExpressionOperator.Or);
+            return new JoinOnExpressionSet(a ?? throw new ArgumentNullException($"{a} is required."), b ?? throw new ArgumentNullException($"{b} is required."), ConditionalExpressionOperator.Or);
         }
         #endregion
 
         #region implicit filter expression set operator
-        public static implicit operator JoinOnExpression(FilterExpression a) => new JoinOnExpression(a);
+        public static implicit operator JoinOnExpression(FilterExpression a) => new JoinOnExpression(a.LeftArg, a.RightArg, a.ExpressionOperator);
 
-        public static implicit operator JoinOnExpressionSet(JoinOnExpression a) => new JoinOnExpressionSet(a.LeftArg, a.RightArg, ConditionalExpressionOperator.And, a.Negate);
+        public static implicit operator JoinOnExpressionSet(JoinOnExpression a) => new JoinOnExpressionSet(a);
         #endregion
 
         #region negation operator
-        public static JoinOnExpression operator !(JoinOnExpression filter)
+        public static JoinOnExpression operator !(JoinOnExpression joinOn)
         {
-            if (filter is object) filter.Negate = !filter.Negate;
-            return filter;
+            if (joinOn is object) joinOn.Negate = !joinOn.Negate;
+            return joinOn;
         }
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/OrderByExpressionSet.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/OrderByExpressionSet.cs
@@ -9,7 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IExpressionSet<OrderByExpression>
     {
         #region interface
-        public IList<OrderByExpression> Expressions { get; }  = new List<OrderByExpression>();
+        public IEnumerable<OrderByExpression> Expressions { get; private set; }  = new List<OrderByExpression>();
         #endregion
 
         #region constructors
@@ -20,13 +20,21 @@ namespace HatTrick.DbEx.Sql.Expression
 
         public OrderByExpressionSet(OrderByExpression orderByExpression)
         {
-            Expressions.Add(orderByExpression ?? throw new ArgumentNullException($"{nameof(orderByExpression)} is required."));
+            Expressions = Expressions.Concat(new OrderByExpression[1] { orderByExpression ?? throw new ArgumentNullException($"{nameof(orderByExpression)} is required.") });
         }
 
         public OrderByExpressionSet(OrderByExpression aOrderByExpression, OrderByExpression bOrderByExpression)
         {
-            Expressions.Add(aOrderByExpression ?? throw new ArgumentNullException($"{nameof(aOrderByExpression)} is required."));
-            Expressions.Add(bOrderByExpression ?? throw new ArgumentNullException($"{nameof(bOrderByExpression)} is required."));
+            Expressions = new List<OrderByExpression>
+            {
+                aOrderByExpression ?? throw new ArgumentNullException($"{nameof(aOrderByExpression)} is required."),
+                bOrderByExpression ?? throw new ArgumentNullException($"{nameof(bOrderByExpression)} is required.")
+            };
+        }
+
+        public OrderByExpressionSet(IEnumerable<OrderByExpression> orderByExpression)
+        {
+            Expressions = orderByExpression ?? throw new ArgumentNullException($"{nameof(orderByExpression)} is required.");
         }
         #endregion
 
@@ -43,24 +51,17 @@ namespace HatTrick.DbEx.Sql.Expression
             }
             else
             {
-                aSet.Expressions.Add(b);
+                aSet.Expressions = aSet.Expressions.Concat(new OrderByExpression[1] { b });
             }
             return aSet;
         }
 
         public static OrderByExpressionSet operator &(OrderByExpressionSet aSet, OrderByExpressionSet bSet)
         {
-            foreach (var b in bSet.Expressions)
-            {
-                if (aSet is null)
-                {
-                    aSet = b;
-                }
-                else
-                {
-                    aSet.Expressions.Add(b);
-                }
-            }
+            if (aSet is null)
+                return bSet;
+
+            aSet.Expressions = aSet.Expressions.Concat(bSet?.Expressions);
             return aSet;
         }
         #endregion


### PR DESCRIPTION
- Added fluent methods to accept an enumerable of OrderByExpressionsto perform ordering
- Changed all expression containers from holding IList<T> to IEnumerable<T>
- Reworked some of join specifics (implicit conversions, appenders, etc) to prep for supporting joins using multiple columns/expressions