### PR TITLE
Support for complex join conditions, refactoring on where clause appending, and minor issues:

### DIFF
--- a/samples/mssql/NetCoreConsoleApp/Data/_Generated/DbExDataService.generated.cs
+++ b/samples/mssql/NetCoreConsoleApp/Data/_Generated/DbExDataService.generated.cs
@@ -25,7 +25,7 @@ namespace SimpleConsole.DataService
         #endregion
 
         #region select one
-        public static IFromExpressionBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>, ITypeContinuationBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>>> SelectOne<TEntity>()
+        public static IFromExpressionBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>, ITypeContinuationExpressionBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>>> SelectOne<TEntity>()
             where TEntity : class, IDbEntity
             => expressionBuilderFactory.CreateSelectOneExpressionBuilder<TEntity>(config);
 

--- a/samples/mssql/ServerSideBlazorApp/Data/_Generated/DbExDataService.generated.cs
+++ b/samples/mssql/ServerSideBlazorApp/Data/_Generated/DbExDataService.generated.cs
@@ -25,7 +25,7 @@ namespace ServerSideBlazorApp.DataService
         #endregion
 
         #region select one
-        public static IFromExpressionBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>, ITypeContinuationBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>>> SelectOne<TEntity>()
+        public static IFromExpressionBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>, ITypeContinuationExpressionBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>>> SelectOne<TEntity>()
             where TEntity : class, IDbEntity
             => expressionBuilderFactory.CreateSelectOneExpressionBuilder<TEntity>(config);
 

--- a/src/HatTrick.DbEx.MsSql/Builder/MsSqlQueryExpressionBuilderFactory.cs
+++ b/src/HatTrick.DbEx.MsSql/Builder/MsSqlQueryExpressionBuilderFactory.cs
@@ -13,10 +13,10 @@ namespace HatTrick.DbEx.MsSql.Builder
     public class MsSqlQueryExpressionBuilderFactory
     {
         #region select one
-        public IFromExpressionBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>, ITypeContinuationBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>>> CreateSelectOneExpressionBuilder<TEntity>(RuntimeSqlDatabaseConfiguration configuration)
+        public IFromExpressionBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>, ITypeContinuationExpressionBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>>> CreateSelectOneExpressionBuilder<TEntity>(RuntimeSqlDatabaseConfiguration configuration)
             where TEntity : class, IDbEntity
         {
-            var builder = new MsSqlSelectQueryExpressionBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>, ITypeContinuationBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>>>(configuration, configuration.QueryExpressionFactory?.CreateQueryExpression<SelectQueryExpression>());
+            var builder = new MsSqlSelectQueryExpressionBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>, ITypeContinuationExpressionBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>>>(configuration, configuration.QueryExpressionFactory?.CreateQueryExpression<SelectQueryExpression>());
             builder.Expression.Select.Top(1);
             return builder;
         }

--- a/src/HatTrick.DbEx.Sql/Assembler/AppenderIndentation.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/AppenderIndentation.cs
@@ -40,6 +40,9 @@ namespace HatTrick.DbEx.Sql.Assembler
         public IAppender Write(string value)
             => appender.Write(value);
 
+        public IAppender Write(char value)
+            => appender.Write(value);
+
         public IAppender If(bool append, params Action<Appender>[] values)
             => appender.If(append, values);
 

--- a/src/HatTrick.DbEx.Sql/Assembler/AssemblyContext.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/AssemblyContext.cs
@@ -60,6 +60,10 @@ namespace HatTrick.DbEx.Sql.Assembler
         public void PopField()
             => fields.Pop();
 
+        public void SetState<T>()
+            where T : class, new()
+            => this.state.Add(typeof(T), new T());
+
         public void SetState<T>(T state)
             where T : class
             => this.state.Add(typeof(T), state);

--- a/src/HatTrick.DbEx.Sql/Assembler/SqlStatementAssembler.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/SqlStatementAssembler.cs
@@ -28,7 +28,6 @@ namespace HatTrick.DbEx.Sql.Assembler
                 return;
 
             builder.Appender.Indent().Write("WHERE")
-                .LineBreak()
                 .Indentation++;
 
             builder.AppendPart(expression.Where, context);

--- a/src/HatTrick.DbEx.Sql/Assembler/_Appenders/JoinOnExpressionPartAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/_Appenders/JoinOnExpressionPartAppender.cs
@@ -24,7 +24,7 @@ namespace HatTrick.DbEx.Sql.Assembler
                 builder.AppendPart(expression.LeftArg, context);
 
                 builder.Appender.Write(FilterOperatorMap[expression.ExpressionOperator]);
-                context.PushField(expression.LeftArg.Expression as FieldExpression);
+                context.PushField(expression.LeftArg as FieldExpression);
                 try
                 {
                     builder.AppendPart(expression.RightArg, context);

--- a/src/HatTrick.DbEx.Sql/Assembler/_Appenders/JoinOnExpressionSetPartAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/_Appenders/JoinOnExpressionSetPartAppender.cs
@@ -1,5 +1,6 @@
 ﻿using HatTrick.DbEx.Sql.Attribute;
 using HatTrick.DbEx.Sql.Expression;
+using System;
 using System.Collections.Generic;
 
 namespace HatTrick.DbEx.Sql.Assembler
@@ -8,7 +9,7 @@ namespace HatTrick.DbEx.Sql.Assembler
     {
         #region internals
         private static IDictionary<ConditionalExpressionOperator, string> _conditionalOperatorMap;
-        private static IDictionary<ConditionalExpressionOperator, string> ConditionalOperatorMap => _conditionalOperatorMap ?? (_conditionalOperatorMap = typeof(ConditionalExpressionOperator).GetValuesAndConditionalOperators());
+        private static IDictionary<ConditionalExpressionOperator, string> ConditionalOperatorMap => _conditionalOperatorMap ?? (_conditionalOperatorMap = typeof(ConditionalExpressionOperator).GetValuesAndConditionalOperators()); // x => string.IsNullOrWhiteSpace(x) ? " " : $" {x} "));
         #endregion
 
         #region methods
@@ -17,22 +18,107 @@ namespace HatTrick.DbEx.Sql.Assembler
             if (expression is null || (expression.LeftArg is null && expression.RightArg is null))
                 return;
 
-            if (expression.Negate)
-                builder.Appender.Write("NOT (");
+            //helper action used to conditionally append text to the appender
+            void ifAppend(bool condition, Action<IAppender> trueAction, Action<IAppender> falseAction = null) { if (condition) trueAction(builder.Appender); else if (falseAction is object) falseAction(builder.Appender); }
 
-            if (expression.LeftArg is object)
+            var thisIsTheRoot = context.GetState<JoinOnExpressionSetContext>() is null;
+            if (thisIsTheRoot)
             {
-                builder.AppendPart(expression.LeftArg, context);
-            }
-            if (expression.RightArg is object)
-            {
-                builder.Appender.Write(ConditionalOperatorMap[expression.ConditionalOperator]);
-                builder.AppendPart(expression.RightArg, context);
+                context.SetState<JoinOnExpressionSetContext>();
             }
 
-            if (expression.Negate)
-                builder.Appender.Write(')');
+
+            try
+            {
+                //implicit conversion will create a FilterExpressionSet for a single filter, evaluate whether each arg is "simple" or "complex" for the current
+                var leftIsAComplexExpression = !(expression.LeftArg is JoinOnExpression || expression.LeftArg is JoinOnExpressionSet leftSet && leftSet.IsSingleFilter);
+                var rightIsAComplexExpression = !(expression.RightArg is JoinOnExpression || expression.RightArg is JoinOnExpressionSet rightSet && rightSet.IsSingleFilter);
+
+                //if the expression set is negated, render "NOT"
+                ifAppend(expression.Negate, AppendNegateStart);
+
+                if (expression.LeftArg is object)
+                {
+                    ifAppend(leftIsAComplexExpression, AppendParensStart);
+
+                    builder.AppendPart(expression.LeftArg, context);
+
+                    ifAppend(leftIsAComplexExpression, AppendParensEnd);
+                }
+                if (expression.RightArg is object)
+                {
+                    if (thisIsTheRoot)
+                    {
+                        builder.Appender.Indentation++;
+                        context.GetState<JoinOnExpressionSetContext>().ExtraIndentionApplied = true;
+                    }
+
+                    AppendConditionalOperator(builder.Appender, expression.ConditionalOperator);
+
+                    ifAppend(rightIsAComplexExpression, AppendParensStart);
+
+                    builder.AppendPart(expression.RightArg, context);
+
+                    ifAppend(rightIsAComplexExpression, AppendParensEnd);
+                }
+
+                ifAppend(expression.Negate, AppendNegateEnd);
+            }
+            finally
+            {
+                if (thisIsTheRoot)
+                {
+                    if (context.GetState<JoinOnExpressionSetContext>().ExtraIndentionApplied)
+                        builder.Appender.Indentation--;
+
+                    context.RemoveState<JoinOnExpressionSetContext>();
+                }
+            }
         }
+
+        private static void AppendNegateStart(IAppender appender)
+            => appender
+                    .Write("NOT")
+                    .LineBreak()
+                    .Indent()
+                    .Write('(')
+                    .LineBreak()
+                    .Indentation++
+                    .Indent();
+
+        private static void AppendNegateEnd(IAppender appender)
+            => appender
+                    .LineBreak()
+                    .Indentation--
+                    .Indent()
+                    .Write(')');
+
+        private static void AppendParensStart(IAppender appender)
+            => appender
+                    .Write('(')
+                    .LineBreak()
+                    .Indentation++
+                    .Indent();
+
+        private static void AppendParensEnd(IAppender appender)
+            => appender
+                    .LineBreak()
+                    .Indentation--
+                    .Indent()
+                    .Write(')');
+
+        private static void AppendConditionalOperator(IAppender appender, ConditionalExpressionOperator condition)
+            => appender
+                    .LineBreak()
+                    .Indent()
+                    .Write(ConditionalOperatorMap[condition])
+                    .LineBreak()
+                    .Indent();
         #endregion
+
+        private class JoinOnExpressionSetContext 
+        { 
+            public bool ExtraIndentionApplied { get; set; }
+        }
     }
 }

--- a/src/HatTrick.DbEx.Sql/Builder/JoinExpressionBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/JoinExpressionBuilder{T}.cs
@@ -30,14 +30,13 @@ namespace HatTrick.DbEx.Sql.Builder
             Caller = caller is object ? caller : throw new ArgumentNullException($"{nameof(caller)} is required.");
         }
 
-        T IJoinExpressionBuilder<T>.On(JoinOnExpression expression)
+        T IJoinExpressionBuilder<T>.On(JoinOnExpressionSet joinOn)
         {
-            if (Expression.Joins is null)
-                Expression.Joins = new JoinExpressionSet(new JoinExpression(JoinOn, JoinType, expression, Alias));
-            else
-            {
-                Expression.Joins = new JoinExpressionSet(Expression.Joins.Expressions.Concat(new JoinExpression[1] { new JoinExpression(JoinOn, JoinType, expression, Alias) }));
-            }
+            Expression.Joins = Expression.Joins is null ? 
+                new JoinExpressionSet(new JoinExpression(JoinOn, JoinType, joinOn, Alias)) 
+                : 
+                new JoinExpressionSet(Expression.Joins.Expressions.Concat(new JoinExpression[1] { new JoinExpression(JoinOn, JoinType, joinOn, Alias) }));
+
             return Caller;
         }
     }

--- a/src/HatTrick.DbEx.Sql/Builder/SelectQueryExpressionBuilder{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/SelectQueryExpressionBuilder{T,U}.cs
@@ -9,7 +9,7 @@ namespace HatTrick.DbEx.Sql.Builder
     public abstract class SelectQueryExpressionBuilder<T, U> : SelectQueryExpressionBuilder<T>,
         IValueContinuationExpressionBuilder<T, U>,
         IValueListContinuationExpressionBuilder<T, U>,
-        ITypeContinuationBuilder<T, U>,
+        ITypeContinuationExpressionBuilder<T, U>,
         ITypeListContinuationExpressionBuilder<T, U>,
         IValueListSkipContinuationExpressionBuilder<T, U>,
         ITypeListSkipContinuationExpressionBuilder<T, U>
@@ -61,6 +61,18 @@ namespace HatTrick.DbEx.Sql.Builder
             return this;
         }
 
+        ITypeContinuationExpressionBuilder<T, U> ITypeContinuationExpressionBuilder<T, U>.OrderBy(params OrderByExpression[] orderBy)
+        {
+            OrderBy(orderBy);
+            return this;
+        }
+
+        ITypeContinuationExpressionBuilder<T, U> ITypeContinuationExpressionBuilder<T, U>.OrderBy(IEnumerable<OrderByExpression> orderBy)
+        {
+            OrderBy(orderBy);
+            return this;
+        }
+
         private void OrderBy(IEnumerable<OrderByExpression> orderBy)
         {
             Expression.OrderBy = new OrderByExpressionSet(Expression.OrderBy.Expressions.Concat(orderBy));
@@ -74,13 +86,43 @@ namespace HatTrick.DbEx.Sql.Builder
             return this;
         }
 
+        IValueListContinuationExpressionBuilder<T, U> IValueListContinuationExpressionBuilder<T, U>.GroupBy(IEnumerable<GroupByExpression> groupBy)
+        {
+            GroupBy(groupBy);
+            return this;
+        }
+
         IValueContinuationExpressionBuilder<T, U> IValueContinuationExpressionBuilder<T, U>.GroupBy(params GroupByExpression[] groupBy)
         {
             GroupBy(groupBy);
             return this;
         }
 
+        IValueContinuationExpressionBuilder<T, U> IValueContinuationExpressionBuilder<T, U>.GroupBy(IEnumerable<GroupByExpression> groupBy)
+        {
+            GroupBy(groupBy);
+            return this;
+        }
+
         ITypeListContinuationExpressionBuilder<T, U> ITypeListContinuationExpressionBuilder<T, U>.GroupBy(params GroupByExpression[] groupBy)
+        {
+            GroupBy(groupBy);
+            return this;
+        }
+
+        ITypeListContinuationExpressionBuilder<T, U> ITypeListContinuationExpressionBuilder<T, U>.GroupBy(IEnumerable<GroupByExpression> groupBy)
+        {
+            GroupBy(groupBy);
+            return this;
+        }
+
+        ITypeContinuationExpressionBuilder<T, U> ITypeContinuationExpressionBuilder<T, U>.GroupBy(params GroupByExpression[] groupBy)
+        {
+            GroupBy(groupBy);
+            return this;
+        }
+
+        ITypeContinuationExpressionBuilder<T, U> ITypeContinuationExpressionBuilder<T, U>.GroupBy(IEnumerable<GroupByExpression> groupBy)
         {
             GroupBy(groupBy);
             return this;
@@ -111,6 +153,12 @@ namespace HatTrick.DbEx.Sql.Builder
             return this;
         }
 
+        ITypeContinuationExpressionBuilder<T, U> ITypeContinuationExpressionBuilder<T, U>.Having(HavingExpression having)
+        {
+            Having(having);
+            return this;
+        }
+
         private void Having(HavingExpression having)
         {
             if (having is null)
@@ -126,19 +174,9 @@ namespace HatTrick.DbEx.Sql.Builder
         #endregion
 
         #region where
-        IValueContinuationExpressionBuilder<T, U> IValueContinuationExpressionBuilder<T, U>.Where(FilterExpression expression)
-        {
-            return Where<T, U>(expression) as IValueContinuationExpressionBuilder<T, U>;
-        }
-
         IValueContinuationExpressionBuilder<T, U> IValueContinuationExpressionBuilder<T, U>.Where(FilterExpressionSet expression)
         {
             return Where<T, U>(expression) as IValueContinuationExpressionBuilder<T, U>;
-        }
-
-        IValueListContinuationExpressionBuilder<T, U> IValueListContinuationExpressionBuilder<T, U>.Where(FilterExpression expression)
-        {
-            return Where<T, U>(expression) as IValueListContinuationExpressionBuilder<T, U>;
         }
 
         IValueListContinuationExpressionBuilder<T, U> IValueListContinuationExpressionBuilder<T, U>.Where(FilterExpressionSet expression)
@@ -146,19 +184,9 @@ namespace HatTrick.DbEx.Sql.Builder
             return Where<T, U>(expression) as IValueListContinuationExpressionBuilder<T, U>;
         }
 
-        ITypeContinuationBuilder<T, U> ITypeContinuationBuilder<T, U>.Where(FilterExpression expression)
+        ITypeContinuationExpressionBuilder<T, U> ITypeContinuationExpressionBuilder<T, U>.Where(FilterExpressionSet expression)
         {
-            return Where<T, U>(expression) as ITypeContinuationBuilder<T, U>;
-        }
-
-        ITypeContinuationBuilder<T, U> ITypeContinuationBuilder<T, U>.Where(FilterExpressionSet expression)
-        {
-            return Where<T, U>(expression) as ITypeContinuationBuilder<T, U>;
-        }
-
-        ITypeListContinuationExpressionBuilder<T, U> ITypeListContinuationExpressionBuilder<T, U>.Where(FilterExpression expression)
-        {
-            return Where<T, U>(expression) as ITypeListContinuationExpressionBuilder<T, U>;
+            return Where<T, U>(expression) as ITypeContinuationExpressionBuilder<T, U>;
         }
 
         ITypeListContinuationExpressionBuilder<T, U> ITypeListContinuationExpressionBuilder<T, U>.Where(FilterExpressionSet expression)
@@ -216,28 +244,28 @@ namespace HatTrick.DbEx.Sql.Builder
             return Join<T, IValueListContinuationExpressionBuilder<T, U>>(entity, JoinOperationExpressionOperator.CROSS);
         }
 
-        IJoinExpressionBuilder<T, ITypeContinuationBuilder<T, U>> ITypeContinuationBuilder<T, U>.InnerJoin(EntityExpression entity)
+        IJoinExpressionBuilder<T, ITypeContinuationExpressionBuilder<T, U>> ITypeContinuationExpressionBuilder<T, U>.InnerJoin(EntityExpression entity)
         {
-            return Join<T, ITypeContinuationBuilder<T, U>>(entity, JoinOperationExpressionOperator.INNER);
+            return Join<T, ITypeContinuationExpressionBuilder<T, U>>(entity, JoinOperationExpressionOperator.INNER);
         }
-        IJoinExpressionBuilder<T, ITypeContinuationBuilder<T, U>> ITypeContinuationBuilder<T, U>.LeftJoin(EntityExpression entity)
+        IJoinExpressionBuilder<T, ITypeContinuationExpressionBuilder<T, U>> ITypeContinuationExpressionBuilder<T, U>.LeftJoin(EntityExpression entity)
         {
-            return Join<T, ITypeContinuationBuilder<T, U>>(entity, JoinOperationExpressionOperator.LEFT);
-        }
-
-        IJoinExpressionBuilder<T, ITypeContinuationBuilder<T, U>> ITypeContinuationBuilder<T, U>.RightJoin(EntityExpression entity)
-        {
-            return Join<T, ITypeContinuationBuilder<T, U>>(entity, JoinOperationExpressionOperator.RIGHT);
+            return Join<T, ITypeContinuationExpressionBuilder<T, U>>(entity, JoinOperationExpressionOperator.LEFT);
         }
 
-        IJoinExpressionBuilder<T, ITypeContinuationBuilder<T, U>> ITypeContinuationBuilder<T, U>.FullJoin(EntityExpression entity)
+        IJoinExpressionBuilder<T, ITypeContinuationExpressionBuilder<T, U>> ITypeContinuationExpressionBuilder<T, U>.RightJoin(EntityExpression entity)
         {
-            return Join<T, ITypeContinuationBuilder<T, U>>(entity, JoinOperationExpressionOperator.FULL);
+            return Join<T, ITypeContinuationExpressionBuilder<T, U>>(entity, JoinOperationExpressionOperator.RIGHT);
         }
 
-        IJoinExpressionBuilder<T, ITypeContinuationBuilder<T, U>> ITypeContinuationBuilder<T, U>.CrossJoin(EntityExpression entity)
+        IJoinExpressionBuilder<T, ITypeContinuationExpressionBuilder<T, U>> ITypeContinuationExpressionBuilder<T, U>.FullJoin(EntityExpression entity)
         {
-            return Join<T, ITypeContinuationBuilder<T, U>>(entity, JoinOperationExpressionOperator.CROSS);
+            return Join<T, ITypeContinuationExpressionBuilder<T, U>>(entity, JoinOperationExpressionOperator.FULL);
+        }
+
+        IJoinExpressionBuilder<T, ITypeContinuationExpressionBuilder<T, U>> ITypeContinuationExpressionBuilder<T, U>.CrossJoin(EntityExpression entity)
+        {
+            return Join<T, ITypeContinuationExpressionBuilder<T, U>>(entity, JoinOperationExpressionOperator.CROSS);
         }
 
         IJoinExpressionBuilder<T, ITypeListContinuationExpressionBuilder<T, U>> ITypeListContinuationExpressionBuilder<T, U>.InnerJoin(EntityExpression entity)
@@ -306,24 +334,24 @@ namespace HatTrick.DbEx.Sql.Builder
             return Join<T, IValueListContinuationExpressionBuilder<T, U>>(subquery, JoinOperationExpressionOperator.FULL);
         }
 
-        IAliasRequiredJoinExpressionBuilder<T, ITypeContinuationBuilder<T, U>> ITypeContinuationBuilder<T, U>.InnerJoin(ISubqueryTerminationExpressionBuilder subquery)
+        IAliasRequiredJoinExpressionBuilder<T, ITypeContinuationExpressionBuilder<T, U>> ITypeContinuationExpressionBuilder<T, U>.InnerJoin(ISubqueryTerminationExpressionBuilder subquery)
         {
-            return Join<T, ITypeContinuationBuilder<T, U>>(subquery, JoinOperationExpressionOperator.INNER);
+            return Join<T, ITypeContinuationExpressionBuilder<T, U>>(subquery, JoinOperationExpressionOperator.INNER);
         }
 
-        IAliasRequiredJoinExpressionBuilder<T, ITypeContinuationBuilder<T, U>> ITypeContinuationBuilder<T, U>.LeftJoin(ISubqueryTerminationExpressionBuilder subquery)
+        IAliasRequiredJoinExpressionBuilder<T, ITypeContinuationExpressionBuilder<T, U>> ITypeContinuationExpressionBuilder<T, U>.LeftJoin(ISubqueryTerminationExpressionBuilder subquery)
         {
-            return Join<T, ITypeContinuationBuilder<T, U>>(subquery, JoinOperationExpressionOperator.LEFT);
+            return Join<T, ITypeContinuationExpressionBuilder<T, U>>(subquery, JoinOperationExpressionOperator.LEFT);
         }
 
-        IAliasRequiredJoinExpressionBuilder<T, ITypeContinuationBuilder<T, U>> ITypeContinuationBuilder<T, U>.RightJoin(ISubqueryTerminationExpressionBuilder subquery)
+        IAliasRequiredJoinExpressionBuilder<T, ITypeContinuationExpressionBuilder<T, U>> ITypeContinuationExpressionBuilder<T, U>.RightJoin(ISubqueryTerminationExpressionBuilder subquery)
         {
-            return Join<T, ITypeContinuationBuilder<T, U>>(subquery, JoinOperationExpressionOperator.RIGHT);
+            return Join<T, ITypeContinuationExpressionBuilder<T, U>>(subquery, JoinOperationExpressionOperator.RIGHT);
         }
 
-        IAliasRequiredJoinExpressionBuilder<T, ITypeContinuationBuilder<T, U>> ITypeContinuationBuilder<T, U>.FullJoin(ISubqueryTerminationExpressionBuilder subquery)
+        IAliasRequiredJoinExpressionBuilder<T, ITypeContinuationExpressionBuilder<T, U>> ITypeContinuationExpressionBuilder<T, U>.FullJoin(ISubqueryTerminationExpressionBuilder subquery)
         {
-            return Join<T, ITypeContinuationBuilder<T, U>>(subquery, JoinOperationExpressionOperator.FULL);
+            return Join<T, ITypeContinuationExpressionBuilder<T, U>>(subquery, JoinOperationExpressionOperator.FULL);
         }
 
         IAliasRequiredJoinExpressionBuilder<T, ITypeListContinuationExpressionBuilder<T, U>> ITypeListContinuationExpressionBuilder<T, U>.InnerJoin(ISubqueryTerminationExpressionBuilder subquery)

--- a/src/HatTrick.DbEx.Sql/Builder/Syntax/IJoinExpressionBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/Syntax/IJoinExpressionBuilder{T}.cs
@@ -5,6 +5,6 @@ namespace HatTrick.DbEx.Sql.Builder.Syntax
     public interface IJoinExpressionBuilder<T>
         where T : IExpressionBuilder
     {
-        T On(JoinOnExpression expression);
+        T On(JoinOnExpressionSet expression);
     }
 }

--- a/src/HatTrick.DbEx.Sql/Builder/Syntax/_Type/ITypeContinuationExpressionBuilder{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/Syntax/_Type/ITypeContinuationExpressionBuilder{T,U}.cs
@@ -1,21 +1,25 @@
 ﻿using HatTrick.DbEx.Sql.Expression;
+using System.Collections.Generic;
 
 namespace HatTrick.DbEx.Sql.Builder.Syntax
 {
-    public interface ITypeContinuationBuilder<T, U> : ITypeContinuationExpressionBuilder<T>, IContinuationExpressionBuilder<T, U>
+    public interface ITypeContinuationExpressionBuilder<T, U> : ITypeContinuationExpressionBuilder<T>, IContinuationExpressionBuilder<T, U>
         where U : class, IContinuationExpressionBuilder<T>
     {
-        ITypeContinuationBuilder<T, U> Where(FilterExpression expression);
-        ITypeContinuationBuilder<T, U> Where(FilterExpressionSet expression);
-        IJoinExpressionBuilder<T, ITypeContinuationBuilder<T, U>> InnerJoin(EntityExpression entity);
-        IJoinExpressionBuilder<T, ITypeContinuationBuilder<T, U>> LeftJoin(EntityExpression entity);
-        IJoinExpressionBuilder<T, ITypeContinuationBuilder<T, U>> RightJoin(EntityExpression entity);
-        IJoinExpressionBuilder<T, ITypeContinuationBuilder<T, U>> FullJoin(EntityExpression entity);
-        IJoinExpressionBuilder<T, ITypeContinuationBuilder<T, U>> CrossJoin(EntityExpression entity);
-        IAliasRequiredJoinExpressionBuilder<T, ITypeContinuationBuilder<T, U>> InnerJoin(ISubqueryTerminationExpressionBuilder subquery);
-        IAliasRequiredJoinExpressionBuilder<T, ITypeContinuationBuilder<T, U>> LeftJoin(ISubqueryTerminationExpressionBuilder subquery);
-        IAliasRequiredJoinExpressionBuilder<T, ITypeContinuationBuilder<T, U>> RightJoin(ISubqueryTerminationExpressionBuilder subquery);
-        IAliasRequiredJoinExpressionBuilder<T, ITypeContinuationBuilder<T, U>> FullJoin(ISubqueryTerminationExpressionBuilder subquery);
-
+        ITypeContinuationExpressionBuilder<T, U> Where(FilterExpressionSet expression);
+        IJoinExpressionBuilder<T, ITypeContinuationExpressionBuilder<T, U>> InnerJoin(EntityExpression entity);
+        IJoinExpressionBuilder<T, ITypeContinuationExpressionBuilder<T, U>> LeftJoin(EntityExpression entity);
+        IJoinExpressionBuilder<T, ITypeContinuationExpressionBuilder<T, U>> RightJoin(EntityExpression entity);
+        IJoinExpressionBuilder<T, ITypeContinuationExpressionBuilder<T, U>> FullJoin(EntityExpression entity);
+        IJoinExpressionBuilder<T, ITypeContinuationExpressionBuilder<T, U>> CrossJoin(EntityExpression entity);
+        IAliasRequiredJoinExpressionBuilder<T, ITypeContinuationExpressionBuilder<T, U>> InnerJoin(ISubqueryTerminationExpressionBuilder subquery);
+        IAliasRequiredJoinExpressionBuilder<T, ITypeContinuationExpressionBuilder<T, U>> LeftJoin(ISubqueryTerminationExpressionBuilder subquery);
+        IAliasRequiredJoinExpressionBuilder<T, ITypeContinuationExpressionBuilder<T, U>> RightJoin(ISubqueryTerminationExpressionBuilder subquery);
+        IAliasRequiredJoinExpressionBuilder<T, ITypeContinuationExpressionBuilder<T, U>> FullJoin(ISubqueryTerminationExpressionBuilder subquery);
+        ITypeContinuationExpressionBuilder<T, U> OrderBy(params OrderByExpression[] orderBy);
+        ITypeContinuationExpressionBuilder<T, U> OrderBy(IEnumerable<OrderByExpression> orderBy);
+        ITypeContinuationExpressionBuilder<T, U> GroupBy(params GroupByExpression[] groupBy);
+        ITypeContinuationExpressionBuilder<T, U> GroupBy(IEnumerable<GroupByExpression> groupBy);
+        ITypeContinuationExpressionBuilder<T, U> Having(HavingExpression havingCondition);
     }
 }

--- a/src/HatTrick.DbEx.Sql/Builder/Syntax/_Type/ITypeListContinuationExpressionBuilder{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/Syntax/_Type/ITypeListContinuationExpressionBuilder{T,U}.cs
@@ -6,7 +6,6 @@ namespace HatTrick.DbEx.Sql.Builder.Syntax
     public interface ITypeListContinuationExpressionBuilder<T,U> : ITypeListContinuationExpressionBuilder<T>, IContinuationExpressionBuilder<T,U>
         where U : class, IContinuationExpressionBuilder<T>
     {
-        ITypeListContinuationExpressionBuilder<T, U> Where(FilterExpression expression);
         ITypeListContinuationExpressionBuilder<T, U> Where(FilterExpressionSet expression);
         IJoinExpressionBuilder<T, ITypeListContinuationExpressionBuilder<T, U>> InnerJoin(EntityExpression entity);
         IJoinExpressionBuilder<T, ITypeListContinuationExpressionBuilder<T, U>> LeftJoin(EntityExpression entity);
@@ -20,6 +19,7 @@ namespace HatTrick.DbEx.Sql.Builder.Syntax
         ITypeListContinuationExpressionBuilder<T, U> OrderBy(params OrderByExpression[] orderBy);
         ITypeListContinuationExpressionBuilder<T, U> OrderBy(IEnumerable<OrderByExpression> orderBy);
         ITypeListContinuationExpressionBuilder<T, U> GroupBy(params GroupByExpression[] groupBy);
+        ITypeListContinuationExpressionBuilder<T, U> GroupBy(IEnumerable<GroupByExpression> groupBy);
         ITypeListContinuationExpressionBuilder<T, U> Having(HavingExpression havingCondition);
         ITypeListSkipContinuationExpressionBuilder<T, U> Skip(int skipValue);
     }

--- a/src/HatTrick.DbEx.Sql/Builder/Syntax/_Value/IValueContinuationExpressionBuilder{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/Syntax/_Value/IValueContinuationExpressionBuilder{T,U}.cs
@@ -9,7 +9,6 @@ namespace HatTrick.DbEx.Sql.Builder.Syntax
         IContinuationExpressionBuilder<T, U>
         where U : class, IContinuationExpressionBuilder<T>
     {
-        IValueContinuationExpressionBuilder<T, U> Where(FilterExpression expression);
         IValueContinuationExpressionBuilder<T, U> Where(FilterExpressionSet expression);
         IJoinExpressionBuilder<T, IValueContinuationExpressionBuilder<T, U>> InnerJoin(EntityExpression entity);
         IJoinExpressionBuilder<T, IValueContinuationExpressionBuilder<T, U>> LeftJoin(EntityExpression entity);
@@ -23,6 +22,7 @@ namespace HatTrick.DbEx.Sql.Builder.Syntax
         IValueContinuationExpressionBuilder<T, U> OrderBy(params OrderByExpression[] orderBy);
         IValueContinuationExpressionBuilder<T, U> OrderBy(IEnumerable<OrderByExpression> orderBy);
         IValueContinuationExpressionBuilder<T, U> GroupBy(params GroupByExpression[] groupBy);
+        IValueContinuationExpressionBuilder<T, U> GroupBy(IEnumerable<GroupByExpression> groupBy);
         IValueContinuationExpressionBuilder<T, U> Having(HavingExpression havingCondition);
     }
 }

--- a/src/HatTrick.DbEx.Sql/Builder/Syntax/_Value/IValueListContinuationExpressionBuilder{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/Syntax/_Value/IValueListContinuationExpressionBuilder{T,U}.cs
@@ -9,7 +9,6 @@ namespace HatTrick.DbEx.Sql.Builder.Syntax
         IContinuationExpressionBuilder<T,U>
         where U : class, IContinuationExpressionBuilder<T>
     {
-        IValueListContinuationExpressionBuilder<T, U> Where(FilterExpression expression);
         IValueListContinuationExpressionBuilder<T, U> Where(FilterExpressionSet expression);
         IJoinExpressionBuilder<T, IValueListContinuationExpressionBuilder<T, U>> InnerJoin(EntityExpression entity);
         IJoinExpressionBuilder<T, IValueListContinuationExpressionBuilder<T, U>> LeftJoin(EntityExpression entity);
@@ -23,6 +22,7 @@ namespace HatTrick.DbEx.Sql.Builder.Syntax
         IValueListContinuationExpressionBuilder<T, U> OrderBy(params OrderByExpression[] orderBy);
         IValueListContinuationExpressionBuilder<T, U> OrderBy(IEnumerable<OrderByExpression> orderBy);
         IValueListContinuationExpressionBuilder<T, U> GroupBy(params GroupByExpression[] groupBy);
+        IValueListContinuationExpressionBuilder<T, U> GroupBy(IEnumerable<GroupByExpression> orderBy);
         IValueListContinuationExpressionBuilder<T, U> Having(HavingExpression havingCondition);
         IValueListSkipContinuationExpressionBuilder<T, U> Skip(int skipValue);
     }

--- a/src/HatTrick.DbEx.Sql/Expression/FilterExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/FilterExpression.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using HatTrick.DbEx.Sql.Expression;
 
 namespace HatTrick.DbEx.Sql.Expression
 {
@@ -7,9 +8,9 @@ namespace HatTrick.DbEx.Sql.Expression
         IFunctionExpression
     {
         #region interface
-        public ExpressionMediator LeftArg { get; set; }
-        public ExpressionMediator RightArg { get; set; }
-        public readonly FilterExpressionOperator ExpressionOperator;
+        public ExpressionMediator LeftArg { get; private set; }
+        public ExpressionMediator RightArg { get; private set; }
+        public FilterExpressionOperator ExpressionOperator { get; private set; }
         public bool Negate { get; set; }
         #endregion
 
@@ -56,12 +57,15 @@ namespace HatTrick.DbEx.Sql.Expression
         }
         #endregion
 
-        #region implicit filter expression set operator
-        public static implicit operator FilterExpressionSet(FilterExpression a) => a is null ? null : new FilterExpressionSet(a);
-        #endregion
+        #region implicit operators
+        public static implicit operator FilterExpressionSet(FilterExpression a) 
+            => a is null ? null : new FilterExpressionSet(a);
 
-        #region implicit having expression set operator
-        public static implicit operator HavingExpression(FilterExpression a) => new HavingExpression(a);
+        public static implicit operator HavingExpression(FilterExpression a) 
+            => new HavingExpression(a);
+
+        public static implicit operator JoinOnExpressionSet(FilterExpression a)
+            => a is null ? null : a.ConvertToJoinOnExpressionSet();
         #endregion
 
         #region negation operator

--- a/src/HatTrick.DbEx.Sql/Expression/FilterExpressionSet.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/FilterExpressionSet.cs
@@ -6,10 +6,10 @@ namespace HatTrick.DbEx.Sql.Expression
         IExpression
     {
         #region interface
-        public readonly ConditionalExpressionOperator ConditionalOperator;
-        public bool Negate { get; set; }
-        public IExpression LeftArg { get; set; }
-        public IExpression RightArg { get; set; }
+        public ConditionalExpressionOperator ConditionalOperator { get; private set; }
+        public bool Negate { get; private set; }
+        public IExpression LeftArg { get; private set; }
+        public IExpression RightArg { get; private set; }
         public bool IsSingleFilter => RightArg is null;
         public object SingleFilter => RightArg is null ? LeftArg : null;
         #endregion
@@ -32,14 +32,14 @@ namespace HatTrick.DbEx.Sql.Expression
             ConditionalOperator = conditionalOperator;
         }
 
-        public FilterExpressionSet(FilterExpressionSet leftArg, FilterExpression rightArg, ConditionalExpressionOperator conditionalOperator)
+        protected FilterExpressionSet(FilterExpressionSet leftArg, FilterExpression rightArg, ConditionalExpressionOperator conditionalOperator)
         {
             LeftArg = leftArg ?? throw new ArgumentNullException($"{nameof(leftArg)} is required.");
             RightArg = rightArg ?? throw new ArgumentNullException($"{nameof(rightArg)} is required.");
             ConditionalOperator = conditionalOperator;
         }
 
-        public FilterExpressionSet(FilterExpressionSet leftArg, FilterExpressionSet rightArg, ConditionalExpressionOperator conditionalOperator)
+        protected FilterExpressionSet(FilterExpressionSet leftArg, FilterExpressionSet rightArg, ConditionalExpressionOperator conditionalOperator)
         {
             LeftArg = leftArg ?? throw new ArgumentNullException($"{nameof(leftArg)} is required.");
             RightArg = rightArg ?? throw new ArgumentNullException($"{nameof(rightArg)} is required.");
@@ -51,7 +51,7 @@ namespace HatTrick.DbEx.Sql.Expression
         public override string ToString() => (Negate) ? $"NOT ({LeftArg} {ConditionalOperator} {RightArg})" : $"{LeftArg} {ConditionalOperator} {RightArg}";
         #endregion
 
-        #region conditional &, | operators
+        #region implicit operators
         public static FilterExpressionSet operator &(FilterExpressionSet a, FilterExpression b)
         {
             if (a is null && b is object) { return new FilterExpressionSet(b); }
@@ -87,13 +87,13 @@ namespace HatTrick.DbEx.Sql.Expression
 
             return new FilterExpressionSet(a, b, ConditionalExpressionOperator.Or);
         }
-        #endregion
 
-        #region implicit having expression set operator
-        public static implicit operator HavingExpression(FilterExpressionSet a) => new HavingExpression(a);
-        #endregion
+        public static implicit operator JoinOnExpressionSet(FilterExpressionSet filter)
+            => filter.ConvertToJoinOnExpressionSet();
 
-        #region negation operator
+        public static implicit operator HavingExpression(FilterExpressionSet a) 
+            => new HavingExpression(a);
+
         public static FilterExpressionSet operator !(FilterExpressionSet filter)
         {
             if (filter is object) filter.Negate = !filter.Negate;

--- a/src/HatTrick.DbEx.Sql/Expression/FilterExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/FilterExpression{T}.cs
@@ -1,9 +1,8 @@
-﻿using System;
-
-namespace HatTrick.DbEx.Sql.Expression
+﻿namespace HatTrick.DbEx.Sql.Expression
 {
     public class FilterExpression<T> : FilterExpression
     {
+        #region constructors
         public FilterExpression(ExpressionMediator leftArg, ExpressionMediator rightArg, FilterExpressionOperator expressionOperator)
             : base(leftArg, rightArg, expressionOperator)
         {
@@ -13,15 +12,17 @@ namespace HatTrick.DbEx.Sql.Expression
             : base(leftArg, rightArg, expressionOperator)
         {
         }
+        #endregion
 
-        public FilterExpression(NullableExpressionMediator<T> leftArg, ExpressionMediator rightArg, FilterExpressionOperator expressionOperator)
-            : base(leftArg, rightArg, expressionOperator)
-        {
-        }
+        #region implicit operators
+        public static implicit operator FilterExpressionSet(FilterExpression<T> a)
+            => a is null ? null : new FilterExpressionSet(a);
 
-        public FilterExpression(NullableExpressionMediator<T> leftArg, NullableExpressionMediator<T> rightArg, FilterExpressionOperator expressionOperator)
-            : base(leftArg, rightArg, expressionOperator)
-        {
-        }
+        public static implicit operator HavingExpression(FilterExpression<T> a)
+            => new HavingExpression(a);
+
+        public static implicit operator JoinOnExpressionSet(FilterExpression<T> a)
+            => a is null ? null : a.ConvertToJoinOnExpressionSet();
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/JoinExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/JoinExpression.cs
@@ -15,7 +15,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region constructors
-        public JoinExpression(IExpression joinToo, JoinOperationExpressionOperator joinType, JoinOnExpression onCondition, string alias)
+        public JoinExpression(IExpression joinToo, JoinOperationExpressionOperator joinType, JoinOnExpressionSet onCondition, string alias)
         {
             JoinToo = joinToo ?? throw new ArgumentNullException($"{nameof(joinToo)} is required.");
             JoinType = joinType;

--- a/src/HatTrick.DbEx.Sql/Expression/JoinOnExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/JoinOnExpression.cs
@@ -2,23 +2,23 @@
 
 namespace HatTrick.DbEx.Sql.Expression
 {
-    public class JoinOnExpression : 
+    public class JoinOnExpression :
         IExpression
     {
         #region interface
-        public ExpressionMediator LeftArg { get; set; }
-        public ExpressionMediator RightArg { get; set; }
-        public readonly FilterExpressionOperator ExpressionOperator;
-        public bool Negate { get; set; }
+        public IExpression LeftArg { get; private set; }
+        public IExpression RightArg { get; private set; }
+        public FilterExpressionOperator ExpressionOperator { get; private set; }
+        public bool Negate { get; private set; }
         #endregion
 
         #region constructors
-        public JoinOnExpression(ExpressionMediator leftArg, ExpressionMediator rightArg, FilterExpressionOperator filterExpressionOperator)
+        public JoinOnExpression(IExpression leftArg, IExpression rightArg, FilterExpressionOperator filterExpressionOperator)
             : this(leftArg, rightArg, filterExpressionOperator, false)
         {
         }
 
-        public JoinOnExpression(ExpressionMediator leftArg, ExpressionMediator rightArg, FilterExpressionOperator expresionOperator, bool negate)
+        public JoinOnExpression(IExpression leftArg, IExpression rightArg, FilterExpressionOperator expresionOperator, bool negate)
         {
             LeftArg = leftArg ?? throw new ArgumentNullException($"{nameof(leftArg)} is required.");
             RightArg = rightArg ?? throw new ArgumentNullException($"{nameof(rightArg)} is required.");
@@ -36,22 +36,9 @@ namespace HatTrick.DbEx.Sql.Expression
         }
         #endregion
 
-        #region conditional &, | operators
-        public static JoinOnExpressionSet operator &(JoinOnExpression a, JoinOnExpression b)
-        {
-            return new JoinOnExpressionSet(a ?? throw new ArgumentNullException($"{a} is required."), b ?? throw new ArgumentNullException($"{b} is required."), ConditionalExpressionOperator.And);
-        }
-
-        public static JoinOnExpressionSet operator |(JoinOnExpression a, JoinOnExpression b)
-        {
-            return new JoinOnExpressionSet(a ?? throw new ArgumentNullException($"{a} is required."), b ?? throw new ArgumentNullException($"{b} is required."), ConditionalExpressionOperator.Or);
-        }
-        #endregion
-
         #region implicit filter expression set operator
-        public static implicit operator JoinOnExpression(FilterExpression a) => new JoinOnExpression(a.LeftArg, a.RightArg, a.ExpressionOperator);
-
-        public static implicit operator JoinOnExpressionSet(JoinOnExpression a) => new JoinOnExpressionSet(a);
+        public static implicit operator JoinOnExpressionSet(JoinOnExpression a)
+            => a is null ? null : new JoinOnExpressionSet(a);
         #endregion
 
         #region negation operator
@@ -62,5 +49,4 @@ namespace HatTrick.DbEx.Sql.Expression
         }
         #endregion
     }
-    
 }

--- a/src/HatTrick.DbEx.Sql/Expression/JoinOnExpressionSet.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/JoinOnExpressionSet.cs
@@ -10,38 +10,44 @@ namespace HatTrick.DbEx.Sql.Expression
         public bool Negate { get; set; }
         public IExpression LeftArg { get; set; }
         public IExpression RightArg { get; set; }
+        public bool IsSingleFilter => RightArg is null;
+        public object SingleFilter => RightArg is null ? LeftArg : null;
         #endregion
 
         #region constructors
         protected JoinOnExpressionSet()
-        { 
-        
-        }
-
-        public JoinOnExpressionSet(JoinOnExpression singleFilter)
         {
-            LeftArg = singleFilter ?? throw new ArgumentNullException($"{nameof(singleFilter)} is required.");
+
         }
 
-        public JoinOnExpressionSet(JoinOnExpression leftArg, JoinOnExpression rightArg, ConditionalExpressionOperator conditionalOperator)
+        public JoinOnExpressionSet(JoinOnExpression singleJoin)
         {
-            LeftArg = leftArg ?? throw new ArgumentNullException($"{nameof(leftArg)} is required.");
-            RightArg = rightArg ?? throw new ArgumentNullException($"{nameof(rightArg)} is required.");
-            ConditionalOperator = conditionalOperator;
+            LeftArg = singleJoin ?? throw new ArgumentNullException($"{nameof(singleJoin)} is required.");
         }
 
-        public JoinOnExpressionSet(JoinOnExpressionSet leftArg, JoinOnExpression rightArg, ConditionalExpressionOperator conditionalOperator)
+        protected JoinOnExpressionSet(JoinOnExpressionSet leftArg, JoinOnExpression rightArg, ConditionalExpressionOperator conditionalOperator)
         {
             LeftArg = leftArg ?? throw new ArgumentNullException($"{nameof(leftArg)} is required.");
             RightArg = rightArg ?? throw new ArgumentNullException($"{nameof(rightArg)} is required.");
             ConditionalOperator = conditionalOperator;
         }
 
-        public JoinOnExpressionSet(JoinOnExpressionSet leftArg, JoinOnExpressionSet rightArg, ConditionalExpressionOperator conditionalOperator)
+        protected JoinOnExpressionSet(JoinOnExpressionSet leftArg, JoinOnExpressionSet rightArg, ConditionalExpressionOperator conditionalOperator)
         {
             LeftArg = leftArg ?? throw new ArgumentNullException($"{nameof(leftArg)} is required.");
             RightArg = rightArg ?? throw new ArgumentNullException($"{nameof(rightArg)} is required.");
             ConditionalOperator = conditionalOperator;
+        }
+
+        public JoinOnExpressionSet(IExpression leftArg, IExpression rightArg, ConditionalExpressionOperator conditionalOperator, bool negate)
+        {
+            if (leftArg is null && rightArg is null)
+                throw new ArgumentNullException($"{nameof(leftArg)} or {nameof(leftArg)} must be non-null.");
+
+            LeftArg = leftArg;
+            RightArg = rightArg;
+            ConditionalOperator = conditionalOperator;
+            Negate = negate;
         }
         #endregion
 
@@ -89,12 +95,12 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region negation operator
-        public static JoinOnExpressionSet operator !(JoinOnExpressionSet filter)
+        public static JoinOnExpressionSet operator !(JoinOnExpressionSet a)
         {
-            if (filter is object) filter.Negate = !filter.Negate;
-            return filter;
+            if (a is object) a.Negate = !a.Negate;
+            return a;
         }
         #endregion
     }
-    
+
 }

--- a/src/HatTrick.DbEx.Sql/_Extensions/Attribute/ConditionalExpressionOperatorAttributeExtensions.cs
+++ b/src/HatTrick.DbEx.Sql/_Extensions/Attribute/ConditionalExpressionOperatorAttributeExtensions.cs
@@ -51,14 +51,19 @@ namespace HatTrick.DbEx.Sql.Attribute
             return default;
         }
 
-        public static SortedDictionary<ConditionalExpressionOperator, string> GetValuesAndConditionalOperators(this Type type)
+        public static SortedDictionary<ConditionalExpressionOperator, string> GetValuesAndConditionalOperators(this Type type, Func<string, string> formatValue = null)
         {
             if (type != typeof(ConditionalExpressionOperator))
                 throw new InvalidOperationException($"Type must be {nameof(ConditionalExpressionOperator)}");
 
             var sortedDictionary = new SortedDictionary<ConditionalExpressionOperator, string>();
             foreach (var value in Enum.GetValues(type))
-                sortedDictionary.Add((ConditionalExpressionOperator)value, GetConditionalOperator((ConditionalExpressionOperator)value));
+            {
+                var condition = GetConditionalOperator((ConditionalExpressionOperator)value);
+                if (formatValue is object)
+                    condition = formatValue(condition);
+                sortedDictionary.Add((ConditionalExpressionOperator)value, condition);
+            }
             return sortedDictionary;
         }
     }

--- a/src/HatTrick.DbEx.Sql/_Extensions/Expression/FilterExpressionExtensions.cs
+++ b/src/HatTrick.DbEx.Sql/_Extensions/Expression/FilterExpressionExtensions.cs
@@ -1,0 +1,40 @@
+﻿namespace HatTrick.DbEx.Sql.Expression
+{
+    public static class FilterExpressionExtensions
+    {
+        public static JoinOnExpressionSet ConvertToJoinOnExpressionSet(this FilterExpression filter)
+        {
+            return ConvertToJoinOnExpressionSet(new FilterExpressionSet(filter));
+        }
+
+        public static JoinOnExpressionSet ConvertToJoinOnExpressionSet(this FilterExpressionSet filterSet)
+        {
+            return ConvertToJoinOnExpressionSet(filterSet.LeftArg, filterSet.RightArg, filterSet.ConditionalOperator, filterSet.Negate);
+        }
+
+        private static JoinOnExpressionSet ConvertToJoinOnExpressionSet(IExpression leftArg, IExpression rightArg, ConditionalExpressionOperator conditionalOperator, bool negate)
+        {
+            //left
+            if (leftArg is FilterExpressionSet leftSet)
+            {
+                leftArg = leftSet.ConvertToJoinOnExpressionSet();
+            }
+            else if (leftArg is FilterExpression leftExp)
+            {
+                leftArg = new JoinOnExpression(leftExp.LeftArg, leftExp.RightArg, leftExp.ExpressionOperator);
+            }
+
+            //right
+            if (rightArg is FilterExpressionSet rightSet)
+            {
+                rightArg = rightSet.ConvertToJoinOnExpressionSet();
+            }
+            else if (rightArg is FilterExpression rightExp)
+            {
+                rightArg = new JoinOnExpression(rightExp.LeftArg, rightExp.RightArg, rightExp.ExpressionOperator);
+            }
+
+            return new JoinOnExpressionSet(leftArg, rightArg, conditionalOperator, negate);
+        }
+    }
+}

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/Join.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/Join.cs
@@ -1,0 +1,97 @@
+﻿using DbEx.Data;
+using DbEx.DataService;
+using DbEx.dboDataService;
+using FluentAssertions;
+using HatTrick.DbEx.MsSql.Test.Executor;
+using HatTrick.DbEx.Sql;
+using System.Linq;
+using Xunit;
+
+namespace HatTrick.DbEx.MsSql.Test.Database.Executor
+{
+    public partial class Join : ExecutorTestBase
+    {
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "INNER JOIN")]
+        public void Does_persons_with_address_and_address_id_constrained_to_value_in_join_condition_succeed(int version, int expected = 14)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany(dbo.Person.Id)
+                .From(dbo.Person)
+                .InnerJoin(dbo.PersonAddress).On(dbo.Person.Id == dbo.PersonAddress.PersonId & dbo.PersonAddress.AddressId == 1);
+
+            //when               
+            var persons = exp.Execute();
+
+            //then
+            persons.Should().HaveCount(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "INNER JOIN")]
+        public void Does_persons_joined_back_to_persons_on_firstname_and_lastname_succeed(int version, int expected = 50)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany(db.alias("joined", "Id").ToInt())
+                .From(dbo.Person)
+                .InnerJoin(dbo.Person.As("joined")).On(dbo.Person.FirstName == db.alias("joined", "FirstName").ToString() & dbo.Person.LastName == db.alias("joined", "LastName").ToString());
+
+            //when               
+            var persons = exp.Execute();
+
+            //then
+            persons.Should().HaveCount(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "INNER JOIN")]
+        public void Does_persons_joined_back_to_persons_on_firstname_and_lastname_with_where_clause_succeed(int version, string firstName = "Kyle", int expected = 1)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany(db.alias("joined", "Id").ToInt())
+                .From(dbo.Person)
+                .InnerJoin(dbo.Person.As("joined")).On(dbo.Person.FirstName == db.alias("joined", "FirstName").ToString() & dbo.Person.LastName == db.alias("joined", "LastName").ToString())
+                .Where(dbo.Person.FirstName == firstName);
+
+            //when               
+            var persons = exp.Execute();
+
+            //then
+            persons.Should().HaveCount(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "DISTINCT")]
+        [Trait("Operation", "IN")]
+        [Trait("Operation", "INNER JOIN")]
+        public void Does_persons_joined_to_personaddress_joined_to_address_with_in_condition_on_addresstype_and_where_clause_succeed(int version, string firstName = "Kyle", int expectedCount = 1, int expectedId = 3)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany(dbo.Address.Id)
+                .Distinct()
+                .From(dbo.Person)
+                .InnerJoin(dbo.PersonAddress).On(dbo.Person.Id == dbo.PersonAddress.AddressId)
+                .InnerJoin(dbo.Address).On(dbo.PersonAddress.AddressId == dbo.Address.Id & dbo.Address.AddressType.In(AddressType.Billing, AddressType.Mailing))
+                .Where(dbo.Person.FirstName == firstName);
+
+            //when               
+            var addressIds = exp.Execute();
+
+            //then
+            addressIds.Should().HaveCount(expectedCount);
+            ((int)addressIds.First()).Should().Be(expectedId);
+        }
+    }
+}

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/OrderBy.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/OrderBy.cs
@@ -1,0 +1,240 @@
+﻿
+using DbEx.Data;
+using DbEx.DataService;
+using DbEx.dboData;
+using DbEx.dboDataService;
+using FluentAssertions;
+using HatTrick.DbEx.MsSql.Test.Executor;
+using HatTrick.DbEx.Sql;
+using System.Linq;
+using Xunit;
+
+namespace HatTrick.DbEx.MsSql.Test.Database.Executor
+{
+    [Trait("Statement", "SELECT")]
+    [Trait("Operation", "ORDER BY")]
+    public partial class OrderBy : ExecutorTestBase
+    {
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_selecting_value_list_with_order_by_asc_succeed(int version, int expectedCount = 50, int expectedId = 1)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany(dbo.Person.Id)
+                .From(dbo.Person)
+                .OrderBy(dbo.Person.Id.Asc);
+
+            //when               
+            var persons = exp.Execute();
+
+            //then
+            persons.Should().HaveCount(expectedCount);
+            persons.First().Should().Be(expectedId);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_selecting_value_list_with_order_by_desc_succeed(int version, int expectedCount = 50, int expectedId = 1)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany(dbo.Person.Id)
+                .From(dbo.Person)
+                .OrderBy(dbo.Person.Id.Desc);
+
+            //when               
+            var persons = exp.Execute();
+
+            //then
+            persons.Should().HaveCount(expectedCount);
+            persons.First().Should().NotBe(expectedId);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_selecting_value_with_order_by_asc_succeed(int version, int expected = 1)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(dbo.Person.Id)
+                .From(dbo.Person)
+                .OrderBy(dbo.Person.Id.Asc);
+
+            //when               
+            var persons = exp.Execute();
+
+            //then
+            persons.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_selecting_value_with_order_by_desc_succeed(int version, int expected = 1)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(dbo.Person.Id)
+                .From(dbo.Person)
+                .OrderBy(dbo.Person.Id.Desc);
+
+            //when               
+            var persons = exp.Execute();
+
+            //then
+            persons.Should().NotBe(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_selecting_dynamic_value_list_with_order_by_asc_succeed(int version, int expectedCount = 50, int expectedId = 1)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany(dbo.Person.Id, dbo.Person.FirstName)
+                .From(dbo.Person)
+                .OrderBy(dbo.Person.Id.Asc);
+
+            //when               
+            var persons = exp.Execute();
+
+            //then
+            persons.Should().HaveCount(expectedCount);
+            ((int)persons.First().Id).Should().Be(expectedId);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_selecting_dynamic_value_list_with_order_by_desc_succeed(int version, int expectedCount = 50, int expectedId = 1)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany(dbo.Person.Id, dbo.Person.FirstName)
+                .From(dbo.Person)
+                .OrderBy(dbo.Person.Id.Desc);
+
+            //when               
+            var persons = exp.Execute();
+
+            //then
+            persons.Should().HaveCount(expectedCount);
+            ((int)persons.First().Id).Should().NotBe(expectedId);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_selecting_dynamic_value_with_order_by_asc_succeed(int version, int expectedId = 1)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(dbo.Person.Id, dbo.Person.FirstName)
+                .From(dbo.Person)
+                .OrderBy(dbo.Person.Id.Asc);
+
+            //when               
+            var persons = exp.Execute();
+
+            //then
+            ((int)persons.Id).Should().Be(expectedId);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_selecting_dynamic_value_with_order_by_desc_succeed(int version, int expectedId = 1)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne(dbo.Person.Id, dbo.Person.FirstName)
+                .From(dbo.Person)
+                .OrderBy(dbo.Person.Id.Desc);
+
+            //when               
+            var persons = exp.Execute();
+
+            //then
+            ((int)persons.Id).Should().NotBe(expectedId);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_selecting_entity_list_with_order_by_asc_succeed(int version, int expectedCount = 50, int expectedId = 1)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person)
+                .OrderBy(dbo.Person.Id.Asc);
+
+            //when               
+            var persons = exp.Execute();
+
+            //then
+            persons.Should().HaveCount(expectedCount);
+            persons.First().Id.Should().Be(expectedId);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_selecting_entity_list_with_order_by_desc_succeed(int version, int expectedCount = 50, int expectedId = 1)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person)
+                .OrderBy(dbo.Person.Id.Desc);
+
+            //when               
+            var persons = exp.Execute();
+
+            //then
+            persons.Should().HaveCount(expectedCount);
+            persons.First().Should().NotBe(expectedId);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_selecting_entity_with_order_by_asc_succeed(int version, int expected = 1)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person)
+                .OrderBy(dbo.Person.Id.Asc);
+
+            //when               
+            var persons = exp.Execute();
+
+            //then
+            persons.Id.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_selecting_entity_with_order_by_desc_succeed(int version, int expected = 1)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person)
+                .OrderBy(dbo.Person.Id.Desc);
+
+            //when               
+            var persons = exp.Execute();
+
+            //then
+            persons.Id.Should().NotBe(expected);
+        }
+    }
+}

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/DateAdd.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/DateAdd.cs
@@ -11,11 +11,11 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
 {
     [Trait("Statement", "SELECT")]
     [Trait("Function", "DATEADD")]
-    [Trait("Operation", "WHERE")]
     public partial class DateAdd : ExecutorTestBase
     {
         [Theory]
         [MsSqlVersions.AllVersions]
+        [Trait("Operation", "WHERE")]
         public void Does_dateadd_of_year_to_shipdate_succeed(int version, int expectedValue = 2018)
         {
             //given
@@ -36,6 +36,7 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
 
         [Theory]
         [MsSqlVersions.AllVersions]
+        [Trait("Operation", "WHERE")]
         public void Does_dateadd_of_year_to_null_shipdate_returning_datetime_succeed(int version)
         {
             //given

--- a/test/HatTrick.DbEx.MsSql.Test/Generated/DbExDataService.generated.cs
+++ b/test/HatTrick.DbEx.MsSql.Test/Generated/DbExDataService.generated.cs
@@ -25,7 +25,7 @@ namespace DbEx.DataService
         #endregion
 
         #region select one
-        public static IFromExpressionBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>, ITypeContinuationBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>>> SelectOne<TEntity>()
+        public static IFromExpressionBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>, ITypeContinuationExpressionBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>>> SelectOne<TEntity>()
             where TEntity : class, IDbEntity
             => expressionBuilderFactory.CreateSelectOneExpressionBuilder<TEntity>(config);
 

--- a/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/RuntimeDb.htt
+++ b/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/RuntimeDb.htt
@@ -11,7 +11,7 @@
         #endregion
 
         #region select one
-        public static IFromExpressionBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>, ITypeContinuationBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>>> SelectOne<TEntity>()
+        public static IFromExpressionBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>, ITypeContinuationExpressionBuilder<TEntity, ITypeContinuationExpressionBuilder<TEntity>>> SelectOne<TEntity>()
             where TEntity : class, IDbEntity
             => expressionBuilderFactory.CreateSelectOneExpressionBuilder<TEntity>(config);
 


### PR DESCRIPTION
- Added support for complex join conditions
- Corrected interface name from "ITypeContinuationBuilder" to "ITypeContinuationExpressionBuilder"
- Reworked formatting in Where clauses
- Added missing OrderBy, GroupBy, and Having methods to fluent builder for single entities (SelectOne<Entity>)

Resolves #161