### PR TITLE
Subclassing of field expressions into entity specific field expression classes

### DIFF
--- a/samples/mssql/NetCoreConsoleApp/Data/_Generated/DbExDataService.generated.cs
+++ b/samples/mssql/NetCoreConsoleApp/Data/_Generated/DbExDataService.generated.cs
@@ -341,18 +341,19 @@ namespace SimpleConsole.dboDataService
     #endregion
 
     #region address entity expression
+
     public partial class AddressEntity : EntityExpression<Address>
     {
         #region interface properties
-        public Int32FieldExpression<Address> Id { get; private set; }
-        public NullableEnumFieldExpression<Address, SimpleConsole.Data.AddressType> AddressType { get; private set; }
-        public StringFieldExpression<Address> Line1 { get; private set; }
-        public NullableStringFieldExpression<Address> Line2 { get; private set; }
-        public StringFieldExpression<Address> City { get; private set; }
-        public StringFieldExpression<Address> State { get; private set; }
-        public StringFieldExpression<Address> Zip { get; private set; }
-        public DateTimeFieldExpression<Address> DateCreated { get; private set; }
-        public DateTimeFieldExpression<Address> DateUpdated { get; private set; }
+        public IdField Id { get; private set; }
+        public AddressTypeField AddressType { get; private set; }
+        public Line1Field Line1 { get; private set; }
+        public Line2Field Line2 { get; private set; }
+        public CityField City { get; private set; }
+        public StateField State { get; private set; }
+        public ZipField Zip { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
+        public DateUpdatedField DateUpdated { get; private set; }
         #endregion
 
         #region constructors
@@ -366,15 +367,15 @@ namespace SimpleConsole.dboDataService
 
         private AddressEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<Address>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.AddressType", AddressType = new NullableEnumFieldExpression<Address, SimpleConsole.Data.AddressType>($"{identifier}.AddressType", this));
-            Fields.Add($"{identifier}.Line1", Line1 = new StringFieldExpression<Address>($"{identifier}.Line1", this));
-            Fields.Add($"{identifier}.Line2", Line2 = new NullableStringFieldExpression<Address>($"{identifier}.Line2", this));
-            Fields.Add($"{identifier}.City", City = new StringFieldExpression<Address>($"{identifier}.City", this));
-            Fields.Add($"{identifier}.State", State = new StringFieldExpression<Address>($"{identifier}.State", this));
-            Fields.Add($"{identifier}.Zip", Zip = new StringFieldExpression<Address>($"{identifier}.Zip", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeFieldExpression<Address>($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateTimeFieldExpression<Address>($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.AddressType", AddressType = new AddressTypeField($"{identifier}.AddressType", this));
+            Fields.Add($"{identifier}.Line1", Line1 = new Line1Field($"{identifier}.Line1", this));
+            Fields.Add($"{identifier}.Line2", Line2 = new Line2Field($"{identifier}.Line2", this));
+            Fields.Add($"{identifier}.City", City = new CityField($"{identifier}.City", this));
+            Fields.Add($"{identifier}.State", State = new StateField($"{identifier}.State", this));
+            Fields.Add($"{identifier}.Zip", Zip = new ZipField($"{identifier}.Zip", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
         }
         #endregion
 
@@ -443,22 +444,184 @@ namespace SimpleConsole.dboDataService
 			address.DateUpdated = reader.ReadField().GetValue<DateTime>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<Address>
+        {
+            #region constructors
+            public IdField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region address type field expression
+        public partial class AddressTypeField : NullableEnumFieldExpression<Address, SimpleConsole.Data.AddressType>
+        {
+            #region constructors
+            public AddressTypeField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(SimpleConsole.Data.AddressType value) => new AssignmentExpression(this, new LiteralExpression<SimpleConsole.Data.AddressType>(value));
+            public AssignmentExpression Set(EnumElement<SimpleConsole.Data.AddressType> value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(SimpleConsole.Data.AddressType? value) => new AssignmentExpression(this, new LiteralExpression<SimpleConsole.Data.AddressType?>(value));
+            public AssignmentExpression Set(NullableEnumElement<SimpleConsole.Data.AddressType> value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region line1 field expression
+        public partial class Line1Field : StringFieldExpression<Address>
+        {
+            #region constructors
+            public Line1Field(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region line2 field expression
+        public partial class Line2Field : NullableStringFieldExpression<Address>
+        {
+            #region constructors
+            public Line2Field(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(NullableStringElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region city field expression
+        public partial class CityField : StringFieldExpression<Address>
+        {
+            #region constructors
+            public CityField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region state field expression
+        public partial class StateField : StringFieldExpression<Address>
+        {
+            #region constructors
+            public StateField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region zip field expression
+        public partial class ZipField : StringFieldExpression<Address>
+        {
+            #region constructors
+            public ZipField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeFieldExpression<Address>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date updated field expression
+        public partial class DateUpdatedField : DateTimeFieldExpression<Address>
+        {
+            #region constructors
+            public DateUpdatedField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
     #region person entity expression
+
     public partial class PersonEntity : EntityExpression<Person>
     {
         #region interface properties
-        public Int32FieldExpression<Person> Id { get; private set; }
-        public StringFieldExpression<Person> FirstName { get; private set; }
-        public StringFieldExpression<Person> LastName { get; private set; }
-        public NullableDateTimeFieldExpression<Person> BirthDate { get; private set; }
-        public EnumFieldExpression<Person, SimpleConsole.Data.GenderType> GenderType { get; private set; }
-        public NullableInt32FieldExpression<Person> CreditLimit { get; private set; }
-        public NullableInt32FieldExpression<Person> YearOfLastCreditLimitReview { get; private set; }
-        public DateTimeFieldExpression<Person> DateCreated { get; private set; }
-        public DateTimeFieldExpression<Person> DateUpdated { get; private set; }
+        public IdField Id { get; private set; }
+        public FirstNameField FirstName { get; private set; }
+        public LastNameField LastName { get; private set; }
+        public BirthDateField BirthDate { get; private set; }
+        public GenderTypeField GenderType { get; private set; }
+        public CreditLimitField CreditLimit { get; private set; }
+        public YearOfLastCreditLimitReviewField YearOfLastCreditLimitReview { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
+        public DateUpdatedField DateUpdated { get; private set; }
         #endregion
 
         #region constructors
@@ -472,15 +635,15 @@ namespace SimpleConsole.dboDataService
 
         private PersonEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<Person>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.FirstName", FirstName = new StringFieldExpression<Person>($"{identifier}.FirstName", this));
-            Fields.Add($"{identifier}.LastName", LastName = new StringFieldExpression<Person>($"{identifier}.LastName", this));
-            Fields.Add($"{identifier}.BirthDate", BirthDate = new NullableDateTimeFieldExpression<Person>($"{identifier}.BirthDate", this));
-            Fields.Add($"{identifier}.GenderType", GenderType = new EnumFieldExpression<Person, SimpleConsole.Data.GenderType>($"{identifier}.GenderType", this));
-            Fields.Add($"{identifier}.CreditLimit", CreditLimit = new NullableInt32FieldExpression<Person>($"{identifier}.CreditLimit", this));
-            Fields.Add($"{identifier}.YearOfLastCreditLimitReview", YearOfLastCreditLimitReview = new NullableInt32FieldExpression<Person>($"{identifier}.YearOfLastCreditLimitReview", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeFieldExpression<Person>($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateTimeFieldExpression<Person>($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.FirstName", FirstName = new FirstNameField($"{identifier}.FirstName", this));
+            Fields.Add($"{identifier}.LastName", LastName = new LastNameField($"{identifier}.LastName", this));
+            Fields.Add($"{identifier}.BirthDate", BirthDate = new BirthDateField($"{identifier}.BirthDate", this));
+            Fields.Add($"{identifier}.GenderType", GenderType = new GenderTypeField($"{identifier}.GenderType", this));
+            Fields.Add($"{identifier}.CreditLimit", CreditLimit = new CreditLimitField($"{identifier}.CreditLimit", this));
+            Fields.Add($"{identifier}.YearOfLastCreditLimitReview", YearOfLastCreditLimitReview = new YearOfLastCreditLimitReviewField($"{identifier}.YearOfLastCreditLimitReview", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
         }
         #endregion
 
@@ -549,17 +712,183 @@ namespace SimpleConsole.dboDataService
 			person.DateUpdated = reader.ReadField().GetValue<DateTime>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<Person>
+        {
+            #region constructors
+            public IdField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region first name field expression
+        public partial class FirstNameField : StringFieldExpression<Person>
+        {
+            #region constructors
+            public FirstNameField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region last name field expression
+        public partial class LastNameField : StringFieldExpression<Person>
+        {
+            #region constructors
+            public LastNameField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region birth date field expression
+        public partial class BirthDateField : NullableDateTimeFieldExpression<Person>
+        {
+            #region constructors
+            public BirthDateField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DateTime? value) => new AssignmentExpression(this, new LiteralExpression<DateTime?>(value));
+            public AssignmentExpression Set(NullableDateTimeElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region gender type field expression
+        public partial class GenderTypeField : EnumFieldExpression<Person, SimpleConsole.Data.GenderType>
+        {
+            #region constructors
+            public GenderTypeField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(SimpleConsole.Data.GenderType value) => new AssignmentExpression(this, new LiteralExpression<SimpleConsole.Data.GenderType>(value));
+            public AssignmentExpression Set(EnumElement<SimpleConsole.Data.GenderType> value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region credit limit field expression
+        public partial class CreditLimitField : NullableInt32FieldExpression<Person>
+        {
+            #region constructors
+            public CreditLimitField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(int? value) => new AssignmentExpression(this, new LiteralExpression<int?>(value));
+            public AssignmentExpression Set(NullableInt32Element value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region year of last credit limit review field expression
+        public partial class YearOfLastCreditLimitReviewField : NullableInt32FieldExpression<Person>
+        {
+            #region constructors
+            public YearOfLastCreditLimitReviewField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(int? value) => new AssignmentExpression(this, new LiteralExpression<int?>(value));
+            public AssignmentExpression Set(NullableInt32Element value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeFieldExpression<Person>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date updated field expression
+        public partial class DateUpdatedField : DateTimeFieldExpression<Person>
+        {
+            #region constructors
+            public DateUpdatedField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
     #region person address entity expression
+
     public partial class PersonAddressEntity : EntityExpression<PersonAddress>
     {
         #region interface properties
-        public Int32FieldExpression<PersonAddress> Id { get; private set; }
-        public Int32FieldExpression<PersonAddress> PersonId { get; private set; }
-        public Int32FieldExpression<PersonAddress> AddressId { get; private set; }
-        public DateTimeFieldExpression<PersonAddress> DateCreated { get; private set; }
+        public IdField Id { get; private set; }
+        public PersonIdField PersonId { get; private set; }
+        public AddressIdField AddressId { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
         #endregion
 
         #region constructors
@@ -573,10 +902,10 @@ namespace SimpleConsole.dboDataService
 
         private PersonAddressEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<PersonAddress>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.PersonId", PersonId = new Int32FieldExpression<PersonAddress>($"{identifier}.PersonId", this));
-            Fields.Add($"{identifier}.AddressId", AddressId = new Int32FieldExpression<PersonAddress>($"{identifier}.AddressId", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeFieldExpression<PersonAddress>($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.PersonId", PersonId = new PersonIdField($"{identifier}.PersonId", this));
+            Fields.Add($"{identifier}.AddressId", AddressId = new AddressIdField($"{identifier}.AddressId", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
         }
         #endregion
 
@@ -625,30 +954,102 @@ namespace SimpleConsole.dboDataService
 			personAddress.DateCreated = reader.ReadField().GetValue<DateTime>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<PersonAddress>
+        {
+            #region constructors
+            public IdField(string identifier, PersonAddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region person id field expression
+        public partial class PersonIdField : Int32FieldExpression<PersonAddress>
+        {
+            #region constructors
+            public PersonIdField(string identifier, PersonAddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region address id field expression
+        public partial class AddressIdField : Int32FieldExpression<PersonAddress>
+        {
+            #region constructors
+            public AddressIdField(string identifier, PersonAddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeFieldExpression<PersonAddress>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, PersonAddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
     #region product entity expression
+
     public partial class ProductEntity : EntityExpression<Product>
     {
         #region interface properties
-        public Int32FieldExpression<Product> Id { get; private set; }
-        public NullableEnumFieldExpression<Product, SimpleConsole.Data.ProductCategoryType> ProductCategoryType { get; private set; }
-        public StringFieldExpression<Product> Name { get; private set; }
-        public NullableStringFieldExpression<Product> Description { get; private set; }
-        public DoubleFieldExpression<Product> ListPrice { get; private set; }
-        public DoubleFieldExpression<Product> Price { get; private set; }
-        public Int32FieldExpression<Product> Quantity { get; private set; }
-        public NullableByteArrayFieldExpression<Product> Image { get; private set; }
-        public NullableDecimalFieldExpression<Product> Height { get; private set; }
-        public NullableDecimalFieldExpression<Product> Width { get; private set; }
-        public NullableDecimalFieldExpression<Product> Depth { get; private set; }
-        public NullableDecimalFieldExpression<Product> Weight { get; private set; }
-        public DecimalFieldExpression<Product> ShippingWeight { get; private set; }
-        public NullableTimeSpanFieldExpression<Product> ValidStartTimeOfDayForPurchase { get; private set; }
-        public NullableTimeSpanFieldExpression<Product> ValidEndTimeOfDayForPurchase { get; private set; }
-        public DateTimeFieldExpression<Product> DateCreated { get; private set; }
-        public DateTimeFieldExpression<Product> DateUpdated { get; private set; }
+        public IdField Id { get; private set; }
+        public ProductCategoryTypeField ProductCategoryType { get; private set; }
+        public NameField Name { get; private set; }
+        public DescriptionField Description { get; private set; }
+        public ListPriceField ListPrice { get; private set; }
+        public PriceField Price { get; private set; }
+        public QuantityField Quantity { get; private set; }
+        public ImageField Image { get; private set; }
+        public HeightField Height { get; private set; }
+        public WidthField Width { get; private set; }
+        public DepthField Depth { get; private set; }
+        public WeightField Weight { get; private set; }
+        public ShippingWeightField ShippingWeight { get; private set; }
+        public ValidStartTimeOfDayForPurchaseField ValidStartTimeOfDayForPurchase { get; private set; }
+        public ValidEndTimeOfDayForPurchaseField ValidEndTimeOfDayForPurchase { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
+        public DateUpdatedField DateUpdated { get; private set; }
         #endregion
 
         #region constructors
@@ -662,23 +1063,23 @@ namespace SimpleConsole.dboDataService
 
         private ProductEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<Product>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.ProductCategoryType", ProductCategoryType = new NullableEnumFieldExpression<Product, SimpleConsole.Data.ProductCategoryType>($"{identifier}.ProductCategoryType", this));
-            Fields.Add($"{identifier}.Name", Name = new StringFieldExpression<Product>($"{identifier}.Name", this));
-            Fields.Add($"{identifier}.Description", Description = new NullableStringFieldExpression<Product>($"{identifier}.Description", this));
-            Fields.Add($"{identifier}.ListPrice", ListPrice = new DoubleFieldExpression<Product>($"{identifier}.ListPrice", this));
-            Fields.Add($"{identifier}.Price", Price = new DoubleFieldExpression<Product>($"{identifier}.Price", this));
-            Fields.Add($"{identifier}.Quantity", Quantity = new Int32FieldExpression<Product>($"{identifier}.Quantity", this));
-            Fields.Add($"{identifier}.Image", Image = new NullableByteArrayFieldExpression<Product>($"{identifier}.Image", this));
-            Fields.Add($"{identifier}.Height", Height = new NullableDecimalFieldExpression<Product>($"{identifier}.Height", this));
-            Fields.Add($"{identifier}.Width", Width = new NullableDecimalFieldExpression<Product>($"{identifier}.Width", this));
-            Fields.Add($"{identifier}.Depth", Depth = new NullableDecimalFieldExpression<Product>($"{identifier}.Depth", this));
-            Fields.Add($"{identifier}.Weight", Weight = new NullableDecimalFieldExpression<Product>($"{identifier}.Weight", this));
-            Fields.Add($"{identifier}.ShippingWeight", ShippingWeight = new DecimalFieldExpression<Product>($"{identifier}.ShippingWeight", this));
-            Fields.Add($"{identifier}.ValidStartTimeOfDayForPurchase", ValidStartTimeOfDayForPurchase = new NullableTimeSpanFieldExpression<Product>($"{identifier}.ValidStartTimeOfDayForPurchase", this));
-            Fields.Add($"{identifier}.ValidEndTimeOfDayForPurchase", ValidEndTimeOfDayForPurchase = new NullableTimeSpanFieldExpression<Product>($"{identifier}.ValidEndTimeOfDayForPurchase", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeFieldExpression<Product>($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateTimeFieldExpression<Product>($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.ProductCategoryType", ProductCategoryType = new ProductCategoryTypeField($"{identifier}.ProductCategoryType", this));
+            Fields.Add($"{identifier}.Name", Name = new NameField($"{identifier}.Name", this));
+            Fields.Add($"{identifier}.Description", Description = new DescriptionField($"{identifier}.Description", this));
+            Fields.Add($"{identifier}.ListPrice", ListPrice = new ListPriceField($"{identifier}.ListPrice", this));
+            Fields.Add($"{identifier}.Price", Price = new PriceField($"{identifier}.Price", this));
+            Fields.Add($"{identifier}.Quantity", Quantity = new QuantityField($"{identifier}.Quantity", this));
+            Fields.Add($"{identifier}.Image", Image = new ImageField($"{identifier}.Image", this));
+            Fields.Add($"{identifier}.Height", Height = new HeightField($"{identifier}.Height", this));
+            Fields.Add($"{identifier}.Width", Width = new WidthField($"{identifier}.Width", this));
+            Fields.Add($"{identifier}.Depth", Depth = new DepthField($"{identifier}.Depth", this));
+            Fields.Add($"{identifier}.Weight", Weight = new WeightField($"{identifier}.Weight", this));
+            Fields.Add($"{identifier}.ShippingWeight", ShippingWeight = new ShippingWeightField($"{identifier}.ShippingWeight", this));
+            Fields.Add($"{identifier}.ValidStartTimeOfDayForPurchase", ValidStartTimeOfDayForPurchase = new ValidStartTimeOfDayForPurchaseField($"{identifier}.ValidStartTimeOfDayForPurchase", this));
+            Fields.Add($"{identifier}.ValidEndTimeOfDayForPurchase", ValidEndTimeOfDayForPurchase = new ValidEndTimeOfDayForPurchaseField($"{identifier}.ValidEndTimeOfDayForPurchase", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
         }
         #endregion
 
@@ -779,26 +1180,344 @@ namespace SimpleConsole.dboDataService
 			product.DateUpdated = reader.ReadField().GetValue<DateTime>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<Product>
+        {
+            #region constructors
+            public IdField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region product category type field expression
+        public partial class ProductCategoryTypeField : NullableEnumFieldExpression<Product, SimpleConsole.Data.ProductCategoryType>
+        {
+            #region constructors
+            public ProductCategoryTypeField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(SimpleConsole.Data.ProductCategoryType value) => new AssignmentExpression(this, new LiteralExpression<SimpleConsole.Data.ProductCategoryType>(value));
+            public AssignmentExpression Set(EnumElement<SimpleConsole.Data.ProductCategoryType> value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(SimpleConsole.Data.ProductCategoryType? value) => new AssignmentExpression(this, new LiteralExpression<SimpleConsole.Data.ProductCategoryType?>(value));
+            public AssignmentExpression Set(NullableEnumElement<SimpleConsole.Data.ProductCategoryType> value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region name field expression
+        public partial class NameField : StringFieldExpression<Product>
+        {
+            #region constructors
+            public NameField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region description field expression
+        public partial class DescriptionField : NullableStringFieldExpression<Product>
+        {
+            #region constructors
+            public DescriptionField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(NullableStringElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region list price field expression
+        public partial class ListPriceField : DoubleFieldExpression<Product>
+        {
+            #region constructors
+            public ListPriceField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(double value) => new AssignmentExpression(this, new LiteralExpression<double>(value));
+            public AssignmentExpression Set(DoubleElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region price field expression
+        public partial class PriceField : DoubleFieldExpression<Product>
+        {
+            #region constructors
+            public PriceField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(double value) => new AssignmentExpression(this, new LiteralExpression<double>(value));
+            public AssignmentExpression Set(DoubleElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region quantity field expression
+        public partial class QuantityField : Int32FieldExpression<Product>
+        {
+            #region constructors
+            public QuantityField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region image field expression
+        public partial class ImageField : NullableByteArrayFieldExpression<Product>
+        {
+            #region constructors
+            public ImageField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(byte[] value) => new AssignmentExpression(this, new LiteralExpression<byte[]>(value));
+            public AssignmentExpression Set(ByteArrayElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(NullableByteArrayElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region height field expression
+        public partial class HeightField : NullableDecimalFieldExpression<Product>
+        {
+            #region constructors
+            public HeightField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(decimal value) => new AssignmentExpression(this, new LiteralExpression<decimal>(value));
+            public AssignmentExpression Set(DecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(decimal? value) => new AssignmentExpression(this, new LiteralExpression<decimal?>(value));
+            public AssignmentExpression Set(NullableDecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region width field expression
+        public partial class WidthField : NullableDecimalFieldExpression<Product>
+        {
+            #region constructors
+            public WidthField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(decimal value) => new AssignmentExpression(this, new LiteralExpression<decimal>(value));
+            public AssignmentExpression Set(DecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(decimal? value) => new AssignmentExpression(this, new LiteralExpression<decimal?>(value));
+            public AssignmentExpression Set(NullableDecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region depth field expression
+        public partial class DepthField : NullableDecimalFieldExpression<Product>
+        {
+            #region constructors
+            public DepthField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(decimal value) => new AssignmentExpression(this, new LiteralExpression<decimal>(value));
+            public AssignmentExpression Set(DecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(decimal? value) => new AssignmentExpression(this, new LiteralExpression<decimal?>(value));
+            public AssignmentExpression Set(NullableDecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region weight field expression
+        public partial class WeightField : NullableDecimalFieldExpression<Product>
+        {
+            #region constructors
+            public WeightField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(decimal value) => new AssignmentExpression(this, new LiteralExpression<decimal>(value));
+            public AssignmentExpression Set(DecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(decimal? value) => new AssignmentExpression(this, new LiteralExpression<decimal?>(value));
+            public AssignmentExpression Set(NullableDecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region shipping weight field expression
+        public partial class ShippingWeightField : DecimalFieldExpression<Product>
+        {
+            #region constructors
+            public ShippingWeightField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(decimal value) => new AssignmentExpression(this, new LiteralExpression<decimal>(value));
+            public AssignmentExpression Set(DecimalElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region valid start time of day for purchase field expression
+        public partial class ValidStartTimeOfDayForPurchaseField : NullableTimeSpanFieldExpression<Product>
+        {
+            #region constructors
+            public ValidStartTimeOfDayForPurchaseField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(TimeSpan value) => new AssignmentExpression(this, new LiteralExpression<TimeSpan>(value));
+            public AssignmentExpression Set(TimeSpanElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(TimeSpan? value) => new AssignmentExpression(this, new LiteralExpression<TimeSpan?>(value));
+            public AssignmentExpression Set(NullableTimeSpanElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region valid end time of day for purchase field expression
+        public partial class ValidEndTimeOfDayForPurchaseField : NullableTimeSpanFieldExpression<Product>
+        {
+            #region constructors
+            public ValidEndTimeOfDayForPurchaseField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(TimeSpan value) => new AssignmentExpression(this, new LiteralExpression<TimeSpan>(value));
+            public AssignmentExpression Set(TimeSpanElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(TimeSpan? value) => new AssignmentExpression(this, new LiteralExpression<TimeSpan?>(value));
+            public AssignmentExpression Set(NullableTimeSpanElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeFieldExpression<Product>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date updated field expression
+        public partial class DateUpdatedField : DateTimeFieldExpression<Product>
+        {
+            #region constructors
+            public DateUpdatedField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
     #region purchase entity expression
+
     public partial class PurchaseEntity : EntityExpression<Purchase>
     {
         #region interface properties
-        public Int32FieldExpression<Purchase> Id { get; private set; }
-        public Int32FieldExpression<Purchase> PersonId { get; private set; }
-        public StringFieldExpression<Purchase> OrderNumber { get; private set; }
-        public Int32FieldExpression<Purchase> TotalPurchaseQuantity { get; private set; }
-        public DoubleFieldExpression<Purchase> TotalPurchaseAmount { get; private set; }
-        public DateTimeFieldExpression<Purchase> PurchaseDate { get; private set; }
-        public NullableDateTimeFieldExpression<Purchase> ShipDate { get; private set; }
-        public NullableDateTimeFieldExpression<Purchase> ExpectedDeliveryDate { get; private set; }
-        public NullableGuidFieldExpression<Purchase> TrackingIdentifier { get; private set; }
-        public EnumFieldExpression<Purchase, SimpleConsole.Data.PaymentMethodType> PaymentMethodType { get; private set; }
-        public NullableEnumFieldExpression<Purchase, SimpleConsole.Data.PaymentSourceType> PaymentSourceType { get; private set; }
-        public DateTimeFieldExpression<Purchase> DateCreated { get; private set; }
-        public DateTimeFieldExpression<Purchase> DateUpdated { get; private set; }
+        public IdField Id { get; private set; }
+        public PersonIdField PersonId { get; private set; }
+        public OrderNumberField OrderNumber { get; private set; }
+        public TotalPurchaseQuantityField TotalPurchaseQuantity { get; private set; }
+        public TotalPurchaseAmountField TotalPurchaseAmount { get; private set; }
+        public PurchaseDateField PurchaseDate { get; private set; }
+        public ShipDateField ShipDate { get; private set; }
+        public ExpectedDeliveryDateField ExpectedDeliveryDate { get; private set; }
+        public TrackingIdentifierField TrackingIdentifier { get; private set; }
+        public PaymentMethodTypeField PaymentMethodType { get; private set; }
+        public PaymentSourceTypeField PaymentSourceType { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
+        public DateUpdatedField DateUpdated { get; private set; }
         #endregion
 
         #region constructors
@@ -812,19 +1531,19 @@ namespace SimpleConsole.dboDataService
 
         private PurchaseEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<Purchase>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.PersonId", PersonId = new Int32FieldExpression<Purchase>($"{identifier}.PersonId", this));
-            Fields.Add($"{identifier}.OrderNumber", OrderNumber = new StringFieldExpression<Purchase>($"{identifier}.OrderNumber", this));
-            Fields.Add($"{identifier}.TotalPurchaseQuantity", TotalPurchaseQuantity = new Int32FieldExpression<Purchase>($"{identifier}.TotalPurchaseQuantity", this));
-            Fields.Add($"{identifier}.TotalPurchaseAmount", TotalPurchaseAmount = new DoubleFieldExpression<Purchase>($"{identifier}.TotalPurchaseAmount", this));
-            Fields.Add($"{identifier}.PurchaseDate", PurchaseDate = new DateTimeFieldExpression<Purchase>($"{identifier}.PurchaseDate", this));
-            Fields.Add($"{identifier}.ShipDate", ShipDate = new NullableDateTimeFieldExpression<Purchase>($"{identifier}.ShipDate", this));
-            Fields.Add($"{identifier}.ExpectedDeliveryDate", ExpectedDeliveryDate = new NullableDateTimeFieldExpression<Purchase>($"{identifier}.ExpectedDeliveryDate", this));
-            Fields.Add($"{identifier}.TrackingIdentifier", TrackingIdentifier = new NullableGuidFieldExpression<Purchase>($"{identifier}.TrackingIdentifier", this));
-            Fields.Add($"{identifier}.PaymentMethodType", PaymentMethodType = new EnumFieldExpression<Purchase, SimpleConsole.Data.PaymentMethodType>($"{identifier}.PaymentMethodType", this));
-            Fields.Add($"{identifier}.PaymentSourceType", PaymentSourceType = new NullableEnumFieldExpression<Purchase, SimpleConsole.Data.PaymentSourceType>($"{identifier}.PaymentSourceType", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeFieldExpression<Purchase>($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateTimeFieldExpression<Purchase>($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.PersonId", PersonId = new PersonIdField($"{identifier}.PersonId", this));
+            Fields.Add($"{identifier}.OrderNumber", OrderNumber = new OrderNumberField($"{identifier}.OrderNumber", this));
+            Fields.Add($"{identifier}.TotalPurchaseQuantity", TotalPurchaseQuantity = new TotalPurchaseQuantityField($"{identifier}.TotalPurchaseQuantity", this));
+            Fields.Add($"{identifier}.TotalPurchaseAmount", TotalPurchaseAmount = new TotalPurchaseAmountField($"{identifier}.TotalPurchaseAmount", this));
+            Fields.Add($"{identifier}.PurchaseDate", PurchaseDate = new PurchaseDateField($"{identifier}.PurchaseDate", this));
+            Fields.Add($"{identifier}.ShipDate", ShipDate = new ShipDateField($"{identifier}.ShipDate", this));
+            Fields.Add($"{identifier}.ExpectedDeliveryDate", ExpectedDeliveryDate = new ExpectedDeliveryDateField($"{identifier}.ExpectedDeliveryDate", this));
+            Fields.Add($"{identifier}.TrackingIdentifier", TrackingIdentifier = new TrackingIdentifierField($"{identifier}.TrackingIdentifier", this));
+            Fields.Add($"{identifier}.PaymentMethodType", PaymentMethodType = new PaymentMethodTypeField($"{identifier}.PaymentMethodType", this));
+            Fields.Add($"{identifier}.PaymentSourceType", PaymentSourceType = new PaymentSourceTypeField($"{identifier}.PaymentSourceType", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
         }
         #endregion
 
@@ -909,20 +1628,257 @@ namespace SimpleConsole.dboDataService
 			purchase.DateUpdated = reader.ReadField().GetValue<DateTime>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<Purchase>
+        {
+            #region constructors
+            public IdField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region person id field expression
+        public partial class PersonIdField : Int32FieldExpression<Purchase>
+        {
+            #region constructors
+            public PersonIdField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region order number field expression
+        public partial class OrderNumberField : StringFieldExpression<Purchase>
+        {
+            #region constructors
+            public OrderNumberField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region total purchase quantity field expression
+        public partial class TotalPurchaseQuantityField : Int32FieldExpression<Purchase>
+        {
+            #region constructors
+            public TotalPurchaseQuantityField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region total purchase amount field expression
+        public partial class TotalPurchaseAmountField : DoubleFieldExpression<Purchase>
+        {
+            #region constructors
+            public TotalPurchaseAmountField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(double value) => new AssignmentExpression(this, new LiteralExpression<double>(value));
+            public AssignmentExpression Set(DoubleElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region purchase date field expression
+        public partial class PurchaseDateField : DateTimeFieldExpression<Purchase>
+        {
+            #region constructors
+            public PurchaseDateField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region ship date field expression
+        public partial class ShipDateField : NullableDateTimeFieldExpression<Purchase>
+        {
+            #region constructors
+            public ShipDateField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DateTime? value) => new AssignmentExpression(this, new LiteralExpression<DateTime?>(value));
+            public AssignmentExpression Set(NullableDateTimeElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region expected delivery date field expression
+        public partial class ExpectedDeliveryDateField : NullableDateTimeFieldExpression<Purchase>
+        {
+            #region constructors
+            public ExpectedDeliveryDateField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DateTime? value) => new AssignmentExpression(this, new LiteralExpression<DateTime?>(value));
+            public AssignmentExpression Set(NullableDateTimeElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region tracking identifier field expression
+        public partial class TrackingIdentifierField : NullableGuidFieldExpression<Purchase>
+        {
+            #region constructors
+            public TrackingIdentifierField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(Guid value) => new AssignmentExpression(this, new LiteralExpression<Guid>(value));
+            public AssignmentExpression Set(GuidElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(Guid? value) => new AssignmentExpression(this, new LiteralExpression<Guid?>(value));
+            public AssignmentExpression Set(NullableGuidElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region payment method type field expression
+        public partial class PaymentMethodTypeField : EnumFieldExpression<Purchase, SimpleConsole.Data.PaymentMethodType>
+        {
+            #region constructors
+            public PaymentMethodTypeField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(SimpleConsole.Data.PaymentMethodType value) => new AssignmentExpression(this, new LiteralExpression<SimpleConsole.Data.PaymentMethodType>(value));
+            public AssignmentExpression Set(EnumElement<SimpleConsole.Data.PaymentMethodType> value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region payment source type field expression
+        public partial class PaymentSourceTypeField : NullableEnumFieldExpression<Purchase, SimpleConsole.Data.PaymentSourceType>
+        {
+            #region constructors
+            public PaymentSourceTypeField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(SimpleConsole.Data.PaymentSourceType value) => new AssignmentExpression(this, new LiteralExpression<SimpleConsole.Data.PaymentSourceType>(value));
+            public AssignmentExpression Set(EnumElement<SimpleConsole.Data.PaymentSourceType> value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(SimpleConsole.Data.PaymentSourceType? value) => new AssignmentExpression(this, new LiteralExpression<SimpleConsole.Data.PaymentSourceType?>(value));
+            public AssignmentExpression Set(NullableEnumElement<SimpleConsole.Data.PaymentSourceType> value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeFieldExpression<Purchase>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date updated field expression
+        public partial class DateUpdatedField : DateTimeFieldExpression<Purchase>
+        {
+            #region constructors
+            public DateUpdatedField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
     #region purchase line entity expression
+
     public partial class PurchaseLineEntity : EntityExpression<PurchaseLine>
     {
         #region interface properties
-        public Int32FieldExpression<PurchaseLine> Id { get; private set; }
-        public Int32FieldExpression<PurchaseLine> PurchaseId { get; private set; }
-        public Int32FieldExpression<PurchaseLine> ProductId { get; private set; }
-        public DecimalFieldExpression<PurchaseLine> PurchasePrice { get; private set; }
-        public Int32FieldExpression<PurchaseLine> Quantity { get; private set; }
-        public DateTimeFieldExpression<PurchaseLine> DateCreated { get; private set; }
-        public DateTimeFieldExpression<PurchaseLine> DateUpdated { get; private set; }
+        public IdField Id { get; private set; }
+        public PurchaseIdField PurchaseId { get; private set; }
+        public ProductIdField ProductId { get; private set; }
+        public PurchasePriceField PurchasePrice { get; private set; }
+        public QuantityField Quantity { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
+        public DateUpdatedField DateUpdated { get; private set; }
         #endregion
 
         #region constructors
@@ -936,13 +1892,13 @@ namespace SimpleConsole.dboDataService
 
         private PurchaseLineEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<PurchaseLine>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.PurchaseId", PurchaseId = new Int32FieldExpression<PurchaseLine>($"{identifier}.PurchaseId", this));
-            Fields.Add($"{identifier}.ProductId", ProductId = new Int32FieldExpression<PurchaseLine>($"{identifier}.ProductId", this));
-            Fields.Add($"{identifier}.PurchasePrice", PurchasePrice = new DecimalFieldExpression<PurchaseLine>($"{identifier}.PurchasePrice", this));
-            Fields.Add($"{identifier}.Quantity", Quantity = new Int32FieldExpression<PurchaseLine>($"{identifier}.Quantity", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeFieldExpression<PurchaseLine>($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateTimeFieldExpression<PurchaseLine>($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.PurchaseId", PurchaseId = new PurchaseIdField($"{identifier}.PurchaseId", this));
+            Fields.Add($"{identifier}.ProductId", ProductId = new ProductIdField($"{identifier}.ProductId", this));
+            Fields.Add($"{identifier}.PurchasePrice", PurchasePrice = new PurchasePriceField($"{identifier}.PurchasePrice", this));
+            Fields.Add($"{identifier}.Quantity", Quantity = new QuantityField($"{identifier}.Quantity", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
         }
         #endregion
 
@@ -1003,16 +1959,139 @@ namespace SimpleConsole.dboDataService
 			purchaseLine.DateUpdated = reader.ReadField().GetValue<DateTime>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public IdField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region purchase id field expression
+        public partial class PurchaseIdField : Int32FieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public PurchaseIdField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region product id field expression
+        public partial class ProductIdField : Int32FieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public ProductIdField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region purchase price field expression
+        public partial class PurchasePriceField : DecimalFieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public PurchasePriceField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(decimal value) => new AssignmentExpression(this, new LiteralExpression<decimal>(value));
+            public AssignmentExpression Set(DecimalElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region quantity field expression
+        public partial class QuantityField : Int32FieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public QuantityField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeFieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date updated field expression
+        public partial class DateUpdatedField : DateTimeFieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public DateUpdatedField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
     #region person total purchases view entity expression
+
     public partial class PersonTotalPurchasesViewEntity : EntityExpression<PersonTotalPurchasesView>
     {
         #region interface properties
-        public Int32FieldExpression<PersonTotalPurchasesView> Id { get; private set; }
-        public NullableDoubleFieldExpression<PersonTotalPurchasesView> TotalAmount { get; private set; }
-        public NullableInt32FieldExpression<PersonTotalPurchasesView> TotalCount { get; private set; }
+        public IdField Id { get; private set; }
+        public TotalAmountField TotalAmount { get; private set; }
+        public TotalCountField TotalCount { get; private set; }
         #endregion
 
         #region constructors
@@ -1026,9 +2105,9 @@ namespace SimpleConsole.dboDataService
 
         private PersonTotalPurchasesViewEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<PersonTotalPurchasesView>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.TotalAmount", TotalAmount = new NullableDoubleFieldExpression<PersonTotalPurchasesView>($"{identifier}.TotalAmount", this));
-            Fields.Add($"{identifier}.TotalCount", TotalCount = new NullableInt32FieldExpression<PersonTotalPurchasesView>($"{identifier}.TotalCount", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.TotalAmount", TotalAmount = new TotalAmountField($"{identifier}.TotalAmount", this));
+            Fields.Add($"{identifier}.TotalCount", TotalCount = new TotalCountField($"{identifier}.TotalCount", this));
         }
         #endregion
 
@@ -1074,6 +2153,66 @@ namespace SimpleConsole.dboDataService
 			personTotalPurchasesView.TotalCount = reader.ReadField().GetValue<int?>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<PersonTotalPurchasesView>
+        {
+            #region constructors
+            public IdField(string identifier, PersonTotalPurchasesViewEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region total amount field expression
+        public partial class TotalAmountField : NullableDoubleFieldExpression<PersonTotalPurchasesView>
+        {
+            #region constructors
+            public TotalAmountField(string identifier, PersonTotalPurchasesViewEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(double value) => new AssignmentExpression(this, new LiteralExpression<double>(value));
+            public AssignmentExpression Set(DoubleElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(double? value) => new AssignmentExpression(this, new LiteralExpression<double?>(value));
+            public AssignmentExpression Set(NullableDoubleElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region total count field expression
+        public partial class TotalCountField : NullableInt32FieldExpression<PersonTotalPurchasesView>
+        {
+            #region constructors
+            public TotalCountField(string identifier, PersonTotalPurchasesViewEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(int? value) => new AssignmentExpression(this, new LiteralExpression<int?>(value));
+            public AssignmentExpression Set(NullableInt32Element value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
@@ -1128,13 +2267,14 @@ namespace SimpleConsole.secDataService
     #endregion
 
     #region person entity expression
+
     public partial class PersonEntity : EntityExpression<Person>
     {
         #region interface properties
-        public Int32FieldExpression<Person> Id { get; private set; }
-        public StringFieldExpression<Person> SSN { get; private set; }
-        public DateTimeOffsetFieldExpression<Person> DateCreated { get; private set; }
-        public DateTimeOffsetFieldExpression<Person> DateUpdated { get; private set; }
+        public IdField Id { get; private set; }
+        public SSNField SSN { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
+        public DateUpdatedField DateUpdated { get; private set; }
         #endregion
 
         #region constructors
@@ -1148,10 +2288,10 @@ namespace SimpleConsole.secDataService
 
         private PersonEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<Person>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.SSN", SSN = new StringFieldExpression<Person>($"{identifier}.SSN", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeOffsetFieldExpression<Person>($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateTimeOffsetFieldExpression<Person>($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.SSN", SSN = new SSNField($"{identifier}.SSN", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
         }
         #endregion
 
@@ -1200,6 +2340,77 @@ namespace SimpleConsole.secDataService
 			person.DateUpdated = reader.ReadField().GetValue<DateTimeOffset>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<Person>
+        {
+            #region constructors
+            public IdField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region s s n field expression
+        public partial class SSNField : StringFieldExpression<Person>
+        {
+            #region constructors
+            public SSNField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeOffsetFieldExpression<Person>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTimeOffset value) => new AssignmentExpression(this, new LiteralExpression<DateTimeOffset>(value));
+            public AssignmentExpression Set(DateTimeOffsetElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date updated field expression
+        public partial class DateUpdatedField : DateTimeOffsetFieldExpression<Person>
+        {
+            #region constructors
+            public DateUpdatedField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTimeOffset value) => new AssignmentExpression(this, new LiteralExpression<DateTimeOffset>(value));
+            public AssignmentExpression Set(DateTimeOffsetElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 

--- a/samples/mssql/ServerSideBlazorApp/Data/_Generated/DbExDataService.generated.cs
+++ b/samples/mssql/ServerSideBlazorApp/Data/_Generated/DbExDataService.generated.cs
@@ -341,18 +341,19 @@ namespace ServerSideBlazorApp.dboDataService
     #endregion
 
     #region address entity expression
+
     public partial class AddressEntity : EntityExpression<Address>
     {
         #region interface properties
-        public Int32FieldExpression<Address> Id { get; private set; }
-        public NullableEnumFieldExpression<Address, ServerSideBlazorApp.Data.AddressType> AddressType { get; private set; }
-        public StringFieldExpression<Address> Line1 { get; private set; }
-        public NullableStringFieldExpression<Address> Line2 { get; private set; }
-        public StringFieldExpression<Address> City { get; private set; }
-        public StringFieldExpression<Address> State { get; private set; }
-        public StringFieldExpression<Address> Zip { get; private set; }
-        public DateTimeFieldExpression<Address> DateCreated { get; private set; }
-        public DateTimeFieldExpression<Address> DateUpdated { get; private set; }
+        public IdField Id { get; private set; }
+        public AddressTypeField AddressType { get; private set; }
+        public Line1Field Line1 { get; private set; }
+        public Line2Field Line2 { get; private set; }
+        public CityField City { get; private set; }
+        public StateField State { get; private set; }
+        public ZipField Zip { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
+        public DateUpdatedField DateUpdated { get; private set; }
         #endregion
 
         #region constructors
@@ -366,15 +367,15 @@ namespace ServerSideBlazorApp.dboDataService
 
         private AddressEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<Address>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.AddressType", AddressType = new NullableEnumFieldExpression<Address, ServerSideBlazorApp.Data.AddressType>($"{identifier}.AddressType", this));
-            Fields.Add($"{identifier}.Line1", Line1 = new StringFieldExpression<Address>($"{identifier}.Line1", this));
-            Fields.Add($"{identifier}.Line2", Line2 = new NullableStringFieldExpression<Address>($"{identifier}.Line2", this));
-            Fields.Add($"{identifier}.City", City = new StringFieldExpression<Address>($"{identifier}.City", this));
-            Fields.Add($"{identifier}.State", State = new StringFieldExpression<Address>($"{identifier}.State", this));
-            Fields.Add($"{identifier}.Zip", Zip = new StringFieldExpression<Address>($"{identifier}.Zip", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeFieldExpression<Address>($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateTimeFieldExpression<Address>($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.AddressType", AddressType = new AddressTypeField($"{identifier}.AddressType", this));
+            Fields.Add($"{identifier}.Line1", Line1 = new Line1Field($"{identifier}.Line1", this));
+            Fields.Add($"{identifier}.Line2", Line2 = new Line2Field($"{identifier}.Line2", this));
+            Fields.Add($"{identifier}.City", City = new CityField($"{identifier}.City", this));
+            Fields.Add($"{identifier}.State", State = new StateField($"{identifier}.State", this));
+            Fields.Add($"{identifier}.Zip", Zip = new ZipField($"{identifier}.Zip", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
         }
         #endregion
 
@@ -443,22 +444,184 @@ namespace ServerSideBlazorApp.dboDataService
 			address.DateUpdated = reader.ReadField().GetValue<DateTime>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<Address>
+        {
+            #region constructors
+            public IdField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region address type field expression
+        public partial class AddressTypeField : NullableEnumFieldExpression<Address, ServerSideBlazorApp.Data.AddressType>
+        {
+            #region constructors
+            public AddressTypeField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(ServerSideBlazorApp.Data.AddressType value) => new AssignmentExpression(this, new LiteralExpression<ServerSideBlazorApp.Data.AddressType>(value));
+            public AssignmentExpression Set(EnumElement<ServerSideBlazorApp.Data.AddressType> value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(ServerSideBlazorApp.Data.AddressType? value) => new AssignmentExpression(this, new LiteralExpression<ServerSideBlazorApp.Data.AddressType?>(value));
+            public AssignmentExpression Set(NullableEnumElement<ServerSideBlazorApp.Data.AddressType> value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region line1 field expression
+        public partial class Line1Field : StringFieldExpression<Address>
+        {
+            #region constructors
+            public Line1Field(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region line2 field expression
+        public partial class Line2Field : NullableStringFieldExpression<Address>
+        {
+            #region constructors
+            public Line2Field(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(NullableStringElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region city field expression
+        public partial class CityField : StringFieldExpression<Address>
+        {
+            #region constructors
+            public CityField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region state field expression
+        public partial class StateField : StringFieldExpression<Address>
+        {
+            #region constructors
+            public StateField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region zip field expression
+        public partial class ZipField : StringFieldExpression<Address>
+        {
+            #region constructors
+            public ZipField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeFieldExpression<Address>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date updated field expression
+        public partial class DateUpdatedField : DateTimeFieldExpression<Address>
+        {
+            #region constructors
+            public DateUpdatedField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
     #region customer entity expression
+
     public partial class CustomerEntity : EntityExpression<Customer>
     {
         #region interface properties
-        public Int32FieldExpression<Customer> Id { get; private set; }
-        public StringFieldExpression<Customer> FirstName { get; private set; }
-        public StringFieldExpression<Customer> LastName { get; private set; }
-        public NullableDateTimeFieldExpression<Customer> BirthDate { get; private set; }
-        public EnumFieldExpression<Customer, ServerSideBlazorApp.Data.GenderType> GenderType { get; private set; }
-        public NullableInt32FieldExpression<Customer> CreditLimit { get; private set; }
-        public NullableInt32FieldExpression<Customer> YearOfLastCreditLimitReview { get; private set; }
-        public DateTimeFieldExpression<Customer> DateCreated { get; private set; }
-        public DateTimeFieldExpression<Customer> DateUpdated { get; private set; }
+        public IdField Id { get; private set; }
+        public FirstNameField FirstName { get; private set; }
+        public LastNameField LastName { get; private set; }
+        public BirthDateField BirthDate { get; private set; }
+        public GenderTypeField GenderType { get; private set; }
+        public CreditLimitField CreditLimit { get; private set; }
+        public YearOfLastCreditLimitReviewField YearOfLastCreditLimitReview { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
+        public DateUpdatedField DateUpdated { get; private set; }
         #endregion
 
         #region constructors
@@ -472,15 +635,15 @@ namespace ServerSideBlazorApp.dboDataService
 
         private CustomerEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<Customer>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.FirstName", FirstName = new StringFieldExpression<Customer>($"{identifier}.FirstName", this));
-            Fields.Add($"{identifier}.LastName", LastName = new StringFieldExpression<Customer>($"{identifier}.LastName", this));
-            Fields.Add($"{identifier}.BirthDate", BirthDate = new NullableDateTimeFieldExpression<Customer>($"{identifier}.BirthDate", this));
-            Fields.Add($"{identifier}.GenderType", GenderType = new EnumFieldExpression<Customer, ServerSideBlazorApp.Data.GenderType>($"{identifier}.GenderType", this));
-            Fields.Add($"{identifier}.CreditLimit", CreditLimit = new NullableInt32FieldExpression<Customer>($"{identifier}.CreditLimit", this));
-            Fields.Add($"{identifier}.YearOfLastCreditLimitReview", YearOfLastCreditLimitReview = new NullableInt32FieldExpression<Customer>($"{identifier}.YearOfLastCreditLimitReview", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeFieldExpression<Customer>($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateTimeFieldExpression<Customer>($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.FirstName", FirstName = new FirstNameField($"{identifier}.FirstName", this));
+            Fields.Add($"{identifier}.LastName", LastName = new LastNameField($"{identifier}.LastName", this));
+            Fields.Add($"{identifier}.BirthDate", BirthDate = new BirthDateField($"{identifier}.BirthDate", this));
+            Fields.Add($"{identifier}.GenderType", GenderType = new GenderTypeField($"{identifier}.GenderType", this));
+            Fields.Add($"{identifier}.CreditLimit", CreditLimit = new CreditLimitField($"{identifier}.CreditLimit", this));
+            Fields.Add($"{identifier}.YearOfLastCreditLimitReview", YearOfLastCreditLimitReview = new YearOfLastCreditLimitReviewField($"{identifier}.YearOfLastCreditLimitReview", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
         }
         #endregion
 
@@ -549,17 +712,183 @@ namespace ServerSideBlazorApp.dboDataService
 			customer.DateUpdated = reader.ReadField().GetValue<DateTime>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<Customer>
+        {
+            #region constructors
+            public IdField(string identifier, CustomerEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region first name field expression
+        public partial class FirstNameField : StringFieldExpression<Customer>
+        {
+            #region constructors
+            public FirstNameField(string identifier, CustomerEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region last name field expression
+        public partial class LastNameField : StringFieldExpression<Customer>
+        {
+            #region constructors
+            public LastNameField(string identifier, CustomerEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region birth date field expression
+        public partial class BirthDateField : NullableDateTimeFieldExpression<Customer>
+        {
+            #region constructors
+            public BirthDateField(string identifier, CustomerEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DateTime? value) => new AssignmentExpression(this, new LiteralExpression<DateTime?>(value));
+            public AssignmentExpression Set(NullableDateTimeElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region gender type field expression
+        public partial class GenderTypeField : EnumFieldExpression<Customer, ServerSideBlazorApp.Data.GenderType>
+        {
+            #region constructors
+            public GenderTypeField(string identifier, CustomerEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(ServerSideBlazorApp.Data.GenderType value) => new AssignmentExpression(this, new LiteralExpression<ServerSideBlazorApp.Data.GenderType>(value));
+            public AssignmentExpression Set(EnumElement<ServerSideBlazorApp.Data.GenderType> value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region credit limit field expression
+        public partial class CreditLimitField : NullableInt32FieldExpression<Customer>
+        {
+            #region constructors
+            public CreditLimitField(string identifier, CustomerEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(int? value) => new AssignmentExpression(this, new LiteralExpression<int?>(value));
+            public AssignmentExpression Set(NullableInt32Element value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region year of last credit limit review field expression
+        public partial class YearOfLastCreditLimitReviewField : NullableInt32FieldExpression<Customer>
+        {
+            #region constructors
+            public YearOfLastCreditLimitReviewField(string identifier, CustomerEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(int? value) => new AssignmentExpression(this, new LiteralExpression<int?>(value));
+            public AssignmentExpression Set(NullableInt32Element value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeFieldExpression<Customer>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, CustomerEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date updated field expression
+        public partial class DateUpdatedField : DateTimeFieldExpression<Customer>
+        {
+            #region constructors
+            public DateUpdatedField(string identifier, CustomerEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
     #region customer address entity expression
+
     public partial class CustomerAddressEntity : EntityExpression<CustomerAddress>
     {
         #region interface properties
-        public Int32FieldExpression<CustomerAddress> Id { get; private set; }
-        public Int32FieldExpression<CustomerAddress> PersonId { get; private set; }
-        public Int32FieldExpression<CustomerAddress> AddressId { get; private set; }
-        public DateTimeFieldExpression<CustomerAddress> DateCreated { get; private set; }
+        public IdField Id { get; private set; }
+        public PersonIdField PersonId { get; private set; }
+        public AddressIdField AddressId { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
         #endregion
 
         #region constructors
@@ -573,10 +902,10 @@ namespace ServerSideBlazorApp.dboDataService
 
         private CustomerAddressEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<CustomerAddress>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.PersonId", PersonId = new Int32FieldExpression<CustomerAddress>($"{identifier}.PersonId", this));
-            Fields.Add($"{identifier}.AddressId", AddressId = new Int32FieldExpression<CustomerAddress>($"{identifier}.AddressId", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeFieldExpression<CustomerAddress>($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.PersonId", PersonId = new PersonIdField($"{identifier}.PersonId", this));
+            Fields.Add($"{identifier}.AddressId", AddressId = new AddressIdField($"{identifier}.AddressId", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
         }
         #endregion
 
@@ -625,30 +954,102 @@ namespace ServerSideBlazorApp.dboDataService
 			customerAddress.DateCreated = reader.ReadField().GetValue<DateTime>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<CustomerAddress>
+        {
+            #region constructors
+            public IdField(string identifier, CustomerAddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region person id field expression
+        public partial class PersonIdField : Int32FieldExpression<CustomerAddress>
+        {
+            #region constructors
+            public PersonIdField(string identifier, CustomerAddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region address id field expression
+        public partial class AddressIdField : Int32FieldExpression<CustomerAddress>
+        {
+            #region constructors
+            public AddressIdField(string identifier, CustomerAddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeFieldExpression<CustomerAddress>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, CustomerAddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
     #region product entity expression
+
     public partial class ProductEntity : EntityExpression<Product>
     {
         #region interface properties
-        public Int32FieldExpression<Product> Id { get; private set; }
-        public NullableEnumFieldExpression<Product, ServerSideBlazorApp.Data.ProductCategoryType> ProductCategoryType { get; private set; }
-        public StringFieldExpression<Product> Name { get; private set; }
-        public NullableStringFieldExpression<Product> Description { get; private set; }
-        public DoubleFieldExpression<Product> ListPrice { get; private set; }
-        public DoubleFieldExpression<Product> Price { get; private set; }
-        public Int32FieldExpression<Product> Quantity { get; private set; }
-        public NullableByteArrayFieldExpression<Product> Image { get; private set; }
-        public NullableDecimalFieldExpression<Product> Height { get; private set; }
-        public NullableDecimalFieldExpression<Product> Width { get; private set; }
-        public NullableDecimalFieldExpression<Product> Depth { get; private set; }
-        public NullableDecimalFieldExpression<Product> Weight { get; private set; }
-        public DecimalFieldExpression<Product> ShippingWeight { get; private set; }
-        public NullableTimeSpanFieldExpression<Product> ValidStartTimeOfDayForPurchase { get; private set; }
-        public NullableTimeSpanFieldExpression<Product> ValidEndTimeOfDayForPurchase { get; private set; }
-        public DateTimeFieldExpression<Product> DateCreated { get; private set; }
-        public DateTimeFieldExpression<Product> DateUpdated { get; private set; }
+        public IdField Id { get; private set; }
+        public ProductCategoryTypeField ProductCategoryType { get; private set; }
+        public NameField Name { get; private set; }
+        public DescriptionField Description { get; private set; }
+        public ListPriceField ListPrice { get; private set; }
+        public PriceField Price { get; private set; }
+        public QuantityField Quantity { get; private set; }
+        public ImageField Image { get; private set; }
+        public HeightField Height { get; private set; }
+        public WidthField Width { get; private set; }
+        public DepthField Depth { get; private set; }
+        public WeightField Weight { get; private set; }
+        public ShippingWeightField ShippingWeight { get; private set; }
+        public ValidStartTimeOfDayForPurchaseField ValidStartTimeOfDayForPurchase { get; private set; }
+        public ValidEndTimeOfDayForPurchaseField ValidEndTimeOfDayForPurchase { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
+        public DateUpdatedField DateUpdated { get; private set; }
         #endregion
 
         #region constructors
@@ -662,23 +1063,23 @@ namespace ServerSideBlazorApp.dboDataService
 
         private ProductEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<Product>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.ProductCategoryType", ProductCategoryType = new NullableEnumFieldExpression<Product, ServerSideBlazorApp.Data.ProductCategoryType>($"{identifier}.ProductCategoryType", this));
-            Fields.Add($"{identifier}.Name", Name = new StringFieldExpression<Product>($"{identifier}.Name", this));
-            Fields.Add($"{identifier}.Description", Description = new NullableStringFieldExpression<Product>($"{identifier}.Description", this));
-            Fields.Add($"{identifier}.ListPrice", ListPrice = new DoubleFieldExpression<Product>($"{identifier}.ListPrice", this));
-            Fields.Add($"{identifier}.Price", Price = new DoubleFieldExpression<Product>($"{identifier}.Price", this));
-            Fields.Add($"{identifier}.Quantity", Quantity = new Int32FieldExpression<Product>($"{identifier}.Quantity", this));
-            Fields.Add($"{identifier}.Image", Image = new NullableByteArrayFieldExpression<Product>($"{identifier}.Image", this));
-            Fields.Add($"{identifier}.Height", Height = new NullableDecimalFieldExpression<Product>($"{identifier}.Height", this));
-            Fields.Add($"{identifier}.Width", Width = new NullableDecimalFieldExpression<Product>($"{identifier}.Width", this));
-            Fields.Add($"{identifier}.Depth", Depth = new NullableDecimalFieldExpression<Product>($"{identifier}.Depth", this));
-            Fields.Add($"{identifier}.Weight", Weight = new NullableDecimalFieldExpression<Product>($"{identifier}.Weight", this));
-            Fields.Add($"{identifier}.ShippingWeight", ShippingWeight = new DecimalFieldExpression<Product>($"{identifier}.ShippingWeight", this));
-            Fields.Add($"{identifier}.ValidStartTimeOfDayForPurchase", ValidStartTimeOfDayForPurchase = new NullableTimeSpanFieldExpression<Product>($"{identifier}.ValidStartTimeOfDayForPurchase", this));
-            Fields.Add($"{identifier}.ValidEndTimeOfDayForPurchase", ValidEndTimeOfDayForPurchase = new NullableTimeSpanFieldExpression<Product>($"{identifier}.ValidEndTimeOfDayForPurchase", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeFieldExpression<Product>($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateTimeFieldExpression<Product>($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.ProductCategoryType", ProductCategoryType = new ProductCategoryTypeField($"{identifier}.ProductCategoryType", this));
+            Fields.Add($"{identifier}.Name", Name = new NameField($"{identifier}.Name", this));
+            Fields.Add($"{identifier}.Description", Description = new DescriptionField($"{identifier}.Description", this));
+            Fields.Add($"{identifier}.ListPrice", ListPrice = new ListPriceField($"{identifier}.ListPrice", this));
+            Fields.Add($"{identifier}.Price", Price = new PriceField($"{identifier}.Price", this));
+            Fields.Add($"{identifier}.Quantity", Quantity = new QuantityField($"{identifier}.Quantity", this));
+            Fields.Add($"{identifier}.Image", Image = new ImageField($"{identifier}.Image", this));
+            Fields.Add($"{identifier}.Height", Height = new HeightField($"{identifier}.Height", this));
+            Fields.Add($"{identifier}.Width", Width = new WidthField($"{identifier}.Width", this));
+            Fields.Add($"{identifier}.Depth", Depth = new DepthField($"{identifier}.Depth", this));
+            Fields.Add($"{identifier}.Weight", Weight = new WeightField($"{identifier}.Weight", this));
+            Fields.Add($"{identifier}.ShippingWeight", ShippingWeight = new ShippingWeightField($"{identifier}.ShippingWeight", this));
+            Fields.Add($"{identifier}.ValidStartTimeOfDayForPurchase", ValidStartTimeOfDayForPurchase = new ValidStartTimeOfDayForPurchaseField($"{identifier}.ValidStartTimeOfDayForPurchase", this));
+            Fields.Add($"{identifier}.ValidEndTimeOfDayForPurchase", ValidEndTimeOfDayForPurchase = new ValidEndTimeOfDayForPurchaseField($"{identifier}.ValidEndTimeOfDayForPurchase", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
         }
         #endregion
 
@@ -779,26 +1180,344 @@ namespace ServerSideBlazorApp.dboDataService
 			product.DateUpdated = reader.ReadField().GetValue<DateTime>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<Product>
+        {
+            #region constructors
+            public IdField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region product category type field expression
+        public partial class ProductCategoryTypeField : NullableEnumFieldExpression<Product, ServerSideBlazorApp.Data.ProductCategoryType>
+        {
+            #region constructors
+            public ProductCategoryTypeField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(ServerSideBlazorApp.Data.ProductCategoryType value) => new AssignmentExpression(this, new LiteralExpression<ServerSideBlazorApp.Data.ProductCategoryType>(value));
+            public AssignmentExpression Set(EnumElement<ServerSideBlazorApp.Data.ProductCategoryType> value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(ServerSideBlazorApp.Data.ProductCategoryType? value) => new AssignmentExpression(this, new LiteralExpression<ServerSideBlazorApp.Data.ProductCategoryType?>(value));
+            public AssignmentExpression Set(NullableEnumElement<ServerSideBlazorApp.Data.ProductCategoryType> value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region name field expression
+        public partial class NameField : StringFieldExpression<Product>
+        {
+            #region constructors
+            public NameField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region description field expression
+        public partial class DescriptionField : NullableStringFieldExpression<Product>
+        {
+            #region constructors
+            public DescriptionField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(NullableStringElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region list price field expression
+        public partial class ListPriceField : DoubleFieldExpression<Product>
+        {
+            #region constructors
+            public ListPriceField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(double value) => new AssignmentExpression(this, new LiteralExpression<double>(value));
+            public AssignmentExpression Set(DoubleElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region price field expression
+        public partial class PriceField : DoubleFieldExpression<Product>
+        {
+            #region constructors
+            public PriceField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(double value) => new AssignmentExpression(this, new LiteralExpression<double>(value));
+            public AssignmentExpression Set(DoubleElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region quantity field expression
+        public partial class QuantityField : Int32FieldExpression<Product>
+        {
+            #region constructors
+            public QuantityField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region image field expression
+        public partial class ImageField : NullableByteArrayFieldExpression<Product>
+        {
+            #region constructors
+            public ImageField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(byte[] value) => new AssignmentExpression(this, new LiteralExpression<byte[]>(value));
+            public AssignmentExpression Set(ByteArrayElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(NullableByteArrayElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region height field expression
+        public partial class HeightField : NullableDecimalFieldExpression<Product>
+        {
+            #region constructors
+            public HeightField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(decimal value) => new AssignmentExpression(this, new LiteralExpression<decimal>(value));
+            public AssignmentExpression Set(DecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(decimal? value) => new AssignmentExpression(this, new LiteralExpression<decimal?>(value));
+            public AssignmentExpression Set(NullableDecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region width field expression
+        public partial class WidthField : NullableDecimalFieldExpression<Product>
+        {
+            #region constructors
+            public WidthField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(decimal value) => new AssignmentExpression(this, new LiteralExpression<decimal>(value));
+            public AssignmentExpression Set(DecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(decimal? value) => new AssignmentExpression(this, new LiteralExpression<decimal?>(value));
+            public AssignmentExpression Set(NullableDecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region depth field expression
+        public partial class DepthField : NullableDecimalFieldExpression<Product>
+        {
+            #region constructors
+            public DepthField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(decimal value) => new AssignmentExpression(this, new LiteralExpression<decimal>(value));
+            public AssignmentExpression Set(DecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(decimal? value) => new AssignmentExpression(this, new LiteralExpression<decimal?>(value));
+            public AssignmentExpression Set(NullableDecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region weight field expression
+        public partial class WeightField : NullableDecimalFieldExpression<Product>
+        {
+            #region constructors
+            public WeightField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(decimal value) => new AssignmentExpression(this, new LiteralExpression<decimal>(value));
+            public AssignmentExpression Set(DecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(decimal? value) => new AssignmentExpression(this, new LiteralExpression<decimal?>(value));
+            public AssignmentExpression Set(NullableDecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region shipping weight field expression
+        public partial class ShippingWeightField : DecimalFieldExpression<Product>
+        {
+            #region constructors
+            public ShippingWeightField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(decimal value) => new AssignmentExpression(this, new LiteralExpression<decimal>(value));
+            public AssignmentExpression Set(DecimalElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region valid start time of day for purchase field expression
+        public partial class ValidStartTimeOfDayForPurchaseField : NullableTimeSpanFieldExpression<Product>
+        {
+            #region constructors
+            public ValidStartTimeOfDayForPurchaseField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(TimeSpan value) => new AssignmentExpression(this, new LiteralExpression<TimeSpan>(value));
+            public AssignmentExpression Set(TimeSpanElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(TimeSpan? value) => new AssignmentExpression(this, new LiteralExpression<TimeSpan?>(value));
+            public AssignmentExpression Set(NullableTimeSpanElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region valid end time of day for purchase field expression
+        public partial class ValidEndTimeOfDayForPurchaseField : NullableTimeSpanFieldExpression<Product>
+        {
+            #region constructors
+            public ValidEndTimeOfDayForPurchaseField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(TimeSpan value) => new AssignmentExpression(this, new LiteralExpression<TimeSpan>(value));
+            public AssignmentExpression Set(TimeSpanElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(TimeSpan? value) => new AssignmentExpression(this, new LiteralExpression<TimeSpan?>(value));
+            public AssignmentExpression Set(NullableTimeSpanElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeFieldExpression<Product>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date updated field expression
+        public partial class DateUpdatedField : DateTimeFieldExpression<Product>
+        {
+            #region constructors
+            public DateUpdatedField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
     #region purchase entity expression
+
     public partial class PurchaseEntity : EntityExpression<Purchase>
     {
         #region interface properties
-        public Int32FieldExpression<Purchase> Id { get; private set; }
-        public Int32FieldExpression<Purchase> PersonId { get; private set; }
-        public StringFieldExpression<Purchase> OrderNumber { get; private set; }
-        public Int32FieldExpression<Purchase> TotalPurchaseQuantity { get; private set; }
-        public DoubleFieldExpression<Purchase> TotalPurchaseAmount { get; private set; }
-        public DateTimeFieldExpression<Purchase> PurchaseDate { get; private set; }
-        public NullableDateTimeFieldExpression<Purchase> ShipDate { get; private set; }
-        public NullableDateTimeFieldExpression<Purchase> ExpectedDeliveryDate { get; private set; }
-        public NullableGuidFieldExpression<Purchase> TrackingIdentifier { get; private set; }
-        public EnumFieldExpression<Purchase, ServerSideBlazorApp.Data.PaymentMethodType> PaymentMethodType { get; private set; }
-        public NullableEnumFieldExpression<Purchase, ServerSideBlazorApp.Data.PaymentSourceType> PaymentSourceType { get; private set; }
-        public DateTimeFieldExpression<Purchase> DateCreated { get; private set; }
-        public DateTimeFieldExpression<Purchase> DateUpdated { get; private set; }
+        public IdField Id { get; private set; }
+        public PersonIdField PersonId { get; private set; }
+        public OrderNumberField OrderNumber { get; private set; }
+        public TotalPurchaseQuantityField TotalPurchaseQuantity { get; private set; }
+        public TotalPurchaseAmountField TotalPurchaseAmount { get; private set; }
+        public PurchaseDateField PurchaseDate { get; private set; }
+        public ShipDateField ShipDate { get; private set; }
+        public ExpectedDeliveryDateField ExpectedDeliveryDate { get; private set; }
+        public TrackingIdentifierField TrackingIdentifier { get; private set; }
+        public PaymentMethodTypeField PaymentMethodType { get; private set; }
+        public PaymentSourceTypeField PaymentSourceType { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
+        public DateUpdatedField DateUpdated { get; private set; }
         #endregion
 
         #region constructors
@@ -812,19 +1531,19 @@ namespace ServerSideBlazorApp.dboDataService
 
         private PurchaseEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<Purchase>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.PersonId", PersonId = new Int32FieldExpression<Purchase>($"{identifier}.PersonId", this));
-            Fields.Add($"{identifier}.OrderNumber", OrderNumber = new StringFieldExpression<Purchase>($"{identifier}.OrderNumber", this));
-            Fields.Add($"{identifier}.TotalPurchaseQuantity", TotalPurchaseQuantity = new Int32FieldExpression<Purchase>($"{identifier}.TotalPurchaseQuantity", this));
-            Fields.Add($"{identifier}.TotalPurchaseAmount", TotalPurchaseAmount = new DoubleFieldExpression<Purchase>($"{identifier}.TotalPurchaseAmount", this));
-            Fields.Add($"{identifier}.PurchaseDate", PurchaseDate = new DateTimeFieldExpression<Purchase>($"{identifier}.PurchaseDate", this));
-            Fields.Add($"{identifier}.ShipDate", ShipDate = new NullableDateTimeFieldExpression<Purchase>($"{identifier}.ShipDate", this));
-            Fields.Add($"{identifier}.ExpectedDeliveryDate", ExpectedDeliveryDate = new NullableDateTimeFieldExpression<Purchase>($"{identifier}.ExpectedDeliveryDate", this));
-            Fields.Add($"{identifier}.TrackingIdentifier", TrackingIdentifier = new NullableGuidFieldExpression<Purchase>($"{identifier}.TrackingIdentifier", this));
-            Fields.Add($"{identifier}.PaymentMethodType", PaymentMethodType = new EnumFieldExpression<Purchase, ServerSideBlazorApp.Data.PaymentMethodType>($"{identifier}.PaymentMethodType", this));
-            Fields.Add($"{identifier}.PaymentSourceType", PaymentSourceType = new NullableEnumFieldExpression<Purchase, ServerSideBlazorApp.Data.PaymentSourceType>($"{identifier}.PaymentSourceType", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeFieldExpression<Purchase>($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateTimeFieldExpression<Purchase>($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.PersonId", PersonId = new PersonIdField($"{identifier}.PersonId", this));
+            Fields.Add($"{identifier}.OrderNumber", OrderNumber = new OrderNumberField($"{identifier}.OrderNumber", this));
+            Fields.Add($"{identifier}.TotalPurchaseQuantity", TotalPurchaseQuantity = new TotalPurchaseQuantityField($"{identifier}.TotalPurchaseQuantity", this));
+            Fields.Add($"{identifier}.TotalPurchaseAmount", TotalPurchaseAmount = new TotalPurchaseAmountField($"{identifier}.TotalPurchaseAmount", this));
+            Fields.Add($"{identifier}.PurchaseDate", PurchaseDate = new PurchaseDateField($"{identifier}.PurchaseDate", this));
+            Fields.Add($"{identifier}.ShipDate", ShipDate = new ShipDateField($"{identifier}.ShipDate", this));
+            Fields.Add($"{identifier}.ExpectedDeliveryDate", ExpectedDeliveryDate = new ExpectedDeliveryDateField($"{identifier}.ExpectedDeliveryDate", this));
+            Fields.Add($"{identifier}.TrackingIdentifier", TrackingIdentifier = new TrackingIdentifierField($"{identifier}.TrackingIdentifier", this));
+            Fields.Add($"{identifier}.PaymentMethodType", PaymentMethodType = new PaymentMethodTypeField($"{identifier}.PaymentMethodType", this));
+            Fields.Add($"{identifier}.PaymentSourceType", PaymentSourceType = new PaymentSourceTypeField($"{identifier}.PaymentSourceType", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
         }
         #endregion
 
@@ -909,20 +1628,257 @@ namespace ServerSideBlazorApp.dboDataService
 			purchase.DateUpdated = reader.ReadField().GetValue<DateTime>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<Purchase>
+        {
+            #region constructors
+            public IdField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region person id field expression
+        public partial class PersonIdField : Int32FieldExpression<Purchase>
+        {
+            #region constructors
+            public PersonIdField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region order number field expression
+        public partial class OrderNumberField : StringFieldExpression<Purchase>
+        {
+            #region constructors
+            public OrderNumberField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region total purchase quantity field expression
+        public partial class TotalPurchaseQuantityField : Int32FieldExpression<Purchase>
+        {
+            #region constructors
+            public TotalPurchaseQuantityField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region total purchase amount field expression
+        public partial class TotalPurchaseAmountField : DoubleFieldExpression<Purchase>
+        {
+            #region constructors
+            public TotalPurchaseAmountField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(double value) => new AssignmentExpression(this, new LiteralExpression<double>(value));
+            public AssignmentExpression Set(DoubleElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region purchase date field expression
+        public partial class PurchaseDateField : DateTimeFieldExpression<Purchase>
+        {
+            #region constructors
+            public PurchaseDateField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region ship date field expression
+        public partial class ShipDateField : NullableDateTimeFieldExpression<Purchase>
+        {
+            #region constructors
+            public ShipDateField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DateTime? value) => new AssignmentExpression(this, new LiteralExpression<DateTime?>(value));
+            public AssignmentExpression Set(NullableDateTimeElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region expected delivery date field expression
+        public partial class ExpectedDeliveryDateField : NullableDateTimeFieldExpression<Purchase>
+        {
+            #region constructors
+            public ExpectedDeliveryDateField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DateTime? value) => new AssignmentExpression(this, new LiteralExpression<DateTime?>(value));
+            public AssignmentExpression Set(NullableDateTimeElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region tracking identifier field expression
+        public partial class TrackingIdentifierField : NullableGuidFieldExpression<Purchase>
+        {
+            #region constructors
+            public TrackingIdentifierField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(Guid value) => new AssignmentExpression(this, new LiteralExpression<Guid>(value));
+            public AssignmentExpression Set(GuidElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(Guid? value) => new AssignmentExpression(this, new LiteralExpression<Guid?>(value));
+            public AssignmentExpression Set(NullableGuidElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region payment method type field expression
+        public partial class PaymentMethodTypeField : EnumFieldExpression<Purchase, ServerSideBlazorApp.Data.PaymentMethodType>
+        {
+            #region constructors
+            public PaymentMethodTypeField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(ServerSideBlazorApp.Data.PaymentMethodType value) => new AssignmentExpression(this, new LiteralExpression<ServerSideBlazorApp.Data.PaymentMethodType>(value));
+            public AssignmentExpression Set(EnumElement<ServerSideBlazorApp.Data.PaymentMethodType> value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region payment source type field expression
+        public partial class PaymentSourceTypeField : NullableEnumFieldExpression<Purchase, ServerSideBlazorApp.Data.PaymentSourceType>
+        {
+            #region constructors
+            public PaymentSourceTypeField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(ServerSideBlazorApp.Data.PaymentSourceType value) => new AssignmentExpression(this, new LiteralExpression<ServerSideBlazorApp.Data.PaymentSourceType>(value));
+            public AssignmentExpression Set(EnumElement<ServerSideBlazorApp.Data.PaymentSourceType> value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(ServerSideBlazorApp.Data.PaymentSourceType? value) => new AssignmentExpression(this, new LiteralExpression<ServerSideBlazorApp.Data.PaymentSourceType?>(value));
+            public AssignmentExpression Set(NullableEnumElement<ServerSideBlazorApp.Data.PaymentSourceType> value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeFieldExpression<Purchase>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date updated field expression
+        public partial class DateUpdatedField : DateTimeFieldExpression<Purchase>
+        {
+            #region constructors
+            public DateUpdatedField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
     #region purchase line entity expression
+
     public partial class PurchaseLineEntity : EntityExpression<PurchaseLine>
     {
         #region interface properties
-        public Int32FieldExpression<PurchaseLine> Id { get; private set; }
-        public Int32FieldExpression<PurchaseLine> PurchaseId { get; private set; }
-        public Int32FieldExpression<PurchaseLine> ProductId { get; private set; }
-        public DecimalFieldExpression<PurchaseLine> PurchasePrice { get; private set; }
-        public Int32FieldExpression<PurchaseLine> Quantity { get; private set; }
-        public DateTimeFieldExpression<PurchaseLine> DateCreated { get; private set; }
-        public DateTimeFieldExpression<PurchaseLine> DateUpdated { get; private set; }
+        public IdField Id { get; private set; }
+        public PurchaseIdField PurchaseId { get; private set; }
+        public ProductIdField ProductId { get; private set; }
+        public PurchasePriceField PurchasePrice { get; private set; }
+        public QuantityField Quantity { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
+        public DateUpdatedField DateUpdated { get; private set; }
         #endregion
 
         #region constructors
@@ -936,13 +1892,13 @@ namespace ServerSideBlazorApp.dboDataService
 
         private PurchaseLineEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<PurchaseLine>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.PurchaseId", PurchaseId = new Int32FieldExpression<PurchaseLine>($"{identifier}.PurchaseId", this));
-            Fields.Add($"{identifier}.ProductId", ProductId = new Int32FieldExpression<PurchaseLine>($"{identifier}.ProductId", this));
-            Fields.Add($"{identifier}.PurchasePrice", PurchasePrice = new DecimalFieldExpression<PurchaseLine>($"{identifier}.PurchasePrice", this));
-            Fields.Add($"{identifier}.Quantity", Quantity = new Int32FieldExpression<PurchaseLine>($"{identifier}.Quantity", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeFieldExpression<PurchaseLine>($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateTimeFieldExpression<PurchaseLine>($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.PurchaseId", PurchaseId = new PurchaseIdField($"{identifier}.PurchaseId", this));
+            Fields.Add($"{identifier}.ProductId", ProductId = new ProductIdField($"{identifier}.ProductId", this));
+            Fields.Add($"{identifier}.PurchasePrice", PurchasePrice = new PurchasePriceField($"{identifier}.PurchasePrice", this));
+            Fields.Add($"{identifier}.Quantity", Quantity = new QuantityField($"{identifier}.Quantity", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
         }
         #endregion
 
@@ -1003,16 +1959,139 @@ namespace ServerSideBlazorApp.dboDataService
 			purchaseLine.DateUpdated = reader.ReadField().GetValue<DateTime>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public IdField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region purchase id field expression
+        public partial class PurchaseIdField : Int32FieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public PurchaseIdField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region product id field expression
+        public partial class ProductIdField : Int32FieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public ProductIdField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region purchase price field expression
+        public partial class PurchasePriceField : DecimalFieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public PurchasePriceField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(decimal value) => new AssignmentExpression(this, new LiteralExpression<decimal>(value));
+            public AssignmentExpression Set(DecimalElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region quantity field expression
+        public partial class QuantityField : Int32FieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public QuantityField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeFieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date updated field expression
+        public partial class DateUpdatedField : DateTimeFieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public DateUpdatedField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
     #region person total purchases view entity expression
+
     public partial class PersonTotalPurchasesViewEntity : EntityExpression<PersonTotalPurchasesView>
     {
         #region interface properties
-        public Int32FieldExpression<PersonTotalPurchasesView> Id { get; private set; }
-        public NullableDoubleFieldExpression<PersonTotalPurchasesView> TotalAmount { get; private set; }
-        public NullableInt32FieldExpression<PersonTotalPurchasesView> TotalCount { get; private set; }
+        public IdField Id { get; private set; }
+        public TotalAmountField TotalAmount { get; private set; }
+        public TotalCountField TotalCount { get; private set; }
         #endregion
 
         #region constructors
@@ -1026,9 +2105,9 @@ namespace ServerSideBlazorApp.dboDataService
 
         private PersonTotalPurchasesViewEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<PersonTotalPurchasesView>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.TotalAmount", TotalAmount = new NullableDoubleFieldExpression<PersonTotalPurchasesView>($"{identifier}.TotalAmount", this));
-            Fields.Add($"{identifier}.TotalCount", TotalCount = new NullableInt32FieldExpression<PersonTotalPurchasesView>($"{identifier}.TotalCount", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.TotalAmount", TotalAmount = new TotalAmountField($"{identifier}.TotalAmount", this));
+            Fields.Add($"{identifier}.TotalCount", TotalCount = new TotalCountField($"{identifier}.TotalCount", this));
         }
         #endregion
 
@@ -1074,6 +2153,66 @@ namespace ServerSideBlazorApp.dboDataService
 			personTotalPurchasesView.TotalCount = reader.ReadField().GetValue<int?>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<PersonTotalPurchasesView>
+        {
+            #region constructors
+            public IdField(string identifier, PersonTotalPurchasesViewEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region total amount field expression
+        public partial class TotalAmountField : NullableDoubleFieldExpression<PersonTotalPurchasesView>
+        {
+            #region constructors
+            public TotalAmountField(string identifier, PersonTotalPurchasesViewEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(double value) => new AssignmentExpression(this, new LiteralExpression<double>(value));
+            public AssignmentExpression Set(DoubleElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(double? value) => new AssignmentExpression(this, new LiteralExpression<double?>(value));
+            public AssignmentExpression Set(NullableDoubleElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region total count field expression
+        public partial class TotalCountField : NullableInt32FieldExpression<PersonTotalPurchasesView>
+        {
+            #region constructors
+            public TotalCountField(string identifier, PersonTotalPurchasesViewEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(int? value) => new AssignmentExpression(this, new LiteralExpression<int?>(value));
+            public AssignmentExpression Set(NullableInt32Element value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
@@ -1128,13 +2267,14 @@ namespace ServerSideBlazorApp.secDataService
     #endregion
 
     #region person entity expression
+
     public partial class PersonEntity : EntityExpression<Person>
     {
         #region interface properties
-        public Int32FieldExpression<Person> Id { get; private set; }
-        public StringFieldExpression<Person> SSN { get; private set; }
-        public DateTimeOffsetFieldExpression<Person> DateCreated { get; private set; }
-        public DateTimeOffsetFieldExpression<Person> DateUpdated { get; private set; }
+        public IdField Id { get; private set; }
+        public SSNField SSN { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
+        public DateUpdatedField DateUpdated { get; private set; }
         #endregion
 
         #region constructors
@@ -1148,10 +2288,10 @@ namespace ServerSideBlazorApp.secDataService
 
         private PersonEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<Person>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.SSN", SSN = new StringFieldExpression<Person>($"{identifier}.SSN", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeOffsetFieldExpression<Person>($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateTimeOffsetFieldExpression<Person>($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.SSN", SSN = new SSNField($"{identifier}.SSN", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
         }
         #endregion
 
@@ -1200,6 +2340,77 @@ namespace ServerSideBlazorApp.secDataService
 			person.DateUpdated = reader.ReadField().GetValue<DateTimeOffset>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<Person>
+        {
+            #region constructors
+            public IdField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region s s n field expression
+        public partial class SSNField : StringFieldExpression<Person>
+        {
+            #region constructors
+            public SSNField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeOffsetFieldExpression<Person>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTimeOffset value) => new AssignmentExpression(this, new LiteralExpression<DateTimeOffset>(value));
+            public AssignmentExpression Set(DateTimeOffsetElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date updated field expression
+        public partial class DateUpdatedField : DateTimeOffsetFieldExpression<Person>
+        {
+            #region constructors
+            public DateUpdatedField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTimeOffset value) => new AssignmentExpression(this, new LiteralExpression<DateTimeOffset>(value));
+            public AssignmentExpression Set(DateTimeOffsetElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_GetDate/GetDateFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_GetDate/GetDateFunctionExpression.generated.cs
@@ -7,13 +7,6 @@ namespace HatTrick.DbEx.MsSql.Expression
     {
         #region implicit operators
         public static implicit operator DateTimeExpressionMediator(GetDateFunctionExpression a) => new DateTimeExpressionMediator(a);
-        public static implicit operator OrderByExpression(GetDateFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(GetDateFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_GetUtcDate/GetUtcDateFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_GetUtcDate/GetUtcDateFunctionExpression.generated.cs
@@ -7,13 +7,6 @@ namespace HatTrick.DbEx.MsSql.Expression
     {
         #region implicit operators
         public static implicit operator DateTimeExpressionMediator(GetUtcDateFunctionExpression a) => new DateTimeExpressionMediator(a);
-        public static implicit operator OrderByExpression(GetUtcDateFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(GetUtcDateFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_NewId/NewIdFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_NewId/NewIdFunctionExpression.generated.cs
@@ -7,13 +7,6 @@ namespace HatTrick.DbEx.MsSql.Expression
     {
         #region implicit operators
         public static implicit operator GuidExpressionMediator(NewIdFunctionExpression a) => new GuidExpressionMediator(a);
-        public static implicit operator OrderByExpression(NewIdFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NewIdFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_SysDateTime/SysDateTimeFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_SysDateTime/SysDateTimeFunctionExpression.generated.cs
@@ -7,13 +7,6 @@ namespace HatTrick.DbEx.MsSql.Expression
     {
         #region implicit operators
         public static implicit operator DateTimeExpressionMediator(SysDateTimeFunctionExpression a) => new DateTimeExpressionMediator(a);
-        public static implicit operator OrderByExpression(SysDateTimeFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(SysDateTimeFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_SysDateTimeOffset/SysDateTimeOffsetFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_SysDateTimeOffset/SysDateTimeOffsetFunctionExpression.generated.cs
@@ -7,13 +7,6 @@ namespace HatTrick.DbEx.MsSql.Expression
     {
         #region implicit operators
         public static implicit operator DateTimeOffsetExpressionMediator(SysDateTimeOffsetFunctionExpression a) => new DateTimeOffsetExpressionMediator(a);
-        public static implicit operator OrderByExpression(SysDateTimeOffsetFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(SysDateTimeOffsetFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_SysUtcDateTime/SysUtcDateTimeFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_SysUtcDateTime/SysUtcDateTimeFunctionExpression.generated.cs
@@ -7,13 +7,6 @@ namespace HatTrick.DbEx.MsSql.Expression
     {
         #region implicit operators
         public static implicit operator DateTimeExpressionMediator(SysUtcDateTimeFunctionExpression a) => new DateTimeExpressionMediator(a);
-        public static implicit operator OrderByExpression(SysUtcDateTimeFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(SysUtcDateTimeFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/BooleanFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/BooleanFieldExpression.generated.cs
@@ -10,21 +10,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<bool> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool>(this, new InExpression<bool>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(bool value) => new AssignmentExpression(this, new LiteralExpression<bool>(value));
-        public virtual AssignmentExpression Set(BooleanElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new BooleanExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new BooleanExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<bool>(BooleanFieldExpression a) => new SelectExpression<bool>(a);
         public static implicit operator BooleanExpressionMediator(BooleanFieldExpression a) => new BooleanExpressionMediator(a);
-        public static implicit operator OrderByExpression(BooleanFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(BooleanFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/ByteArrayFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/ByteArrayFieldExpression.cs
@@ -33,21 +33,9 @@ namespace HatTrick.DbEx.Sql.Expression
             => base.GetHashCode();
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(byte[] value) => new AssignmentExpression(this, new LiteralExpression<byte[]>(value));
-        public virtual AssignmentExpression Set(ByteArrayElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<byte[]>(ByteArrayFieldExpression a) => new SelectExpression<byte[]>(a);
         public static implicit operator ByteArrayExpressionMediator(ByteArrayFieldExpression a) => new ByteArrayExpressionMediator(a);
-        public static implicit operator OrderByExpression(ByteArrayFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(ByteArrayFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region filter operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/ByteArrayFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/ByteArrayFieldExpression{T}.cs
@@ -22,18 +22,9 @@ namespace HatTrick.DbEx.Sql.Expression
             => new ByteArrayFieldExpression<TEntity>(base.identifier, base.entity, alias);
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(byte[] value) => new AssignmentExpression(this, new LiteralExpression<byte[]>(value));
-        #endregion
-
         #region in value set
         public override FilterExpressionSet In(params byte[][] value) => value is object ? new FilterExpressionSet(new FilterExpression<bool>(this, new LiteralExpression<byte[][]>(value), FilterExpressionOperator.None)) : null;
         public override FilterExpressionSet In(IEnumerable<byte[]> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool>(this, new LiteralExpression<IEnumerable<byte[]>>(value), FilterExpressionOperator.None)) : null;
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/ByteFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/ByteFieldExpression.generated.cs
@@ -10,21 +10,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<byte> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool>(this, new InExpression<byte>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(byte value) => new AssignmentExpression(this, new LiteralExpression<byte>(value));
-        public virtual AssignmentExpression Set(ByteElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new ByteExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new ByteExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<byte>(ByteFieldExpression a) => new SelectExpression<byte>(a);
         public static implicit operator ByteExpressionMediator(ByteFieldExpression a) => new ByteExpressionMediator(a);
-        public static implicit operator OrderByExpression(ByteFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(ByteFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/DateTimeFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/DateTimeFieldExpression.generated.cs
@@ -10,21 +10,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<DateTime> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool>(this, new InExpression<DateTime>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
-        public virtual AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new DateTimeExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new DateTimeExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<DateTime>(DateTimeFieldExpression a) => new SelectExpression<DateTime>(a);
         public static implicit operator DateTimeExpressionMediator(DateTimeFieldExpression a) => new DateTimeExpressionMediator(a);
-        public static implicit operator OrderByExpression(DateTimeFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DateTimeFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/DateTimeOffsetFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/DateTimeOffsetFieldExpression.generated.cs
@@ -10,21 +10,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<DateTimeOffset> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool>(this, new InExpression<DateTimeOffset>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(DateTimeOffset value) => new AssignmentExpression(this, new LiteralExpression<DateTimeOffset>(value));
-        public virtual AssignmentExpression Set(DateTimeOffsetElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new DateTimeOffsetExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new DateTimeOffsetExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<DateTimeOffset>(DateTimeOffsetFieldExpression a) => new SelectExpression<DateTimeOffset>(a);
         public static implicit operator DateTimeOffsetExpressionMediator(DateTimeOffsetFieldExpression a) => new DateTimeOffsetExpressionMediator(a);
-        public static implicit operator OrderByExpression(DateTimeOffsetFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DateTimeOffsetFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/DecimalFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/DecimalFieldExpression.generated.cs
@@ -10,21 +10,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<decimal> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool>(this, new InExpression<decimal>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(decimal value) => new AssignmentExpression(this, new LiteralExpression<decimal>(value));
-        public virtual AssignmentExpression Set(DecimalElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new DecimalExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new DecimalExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<decimal>(DecimalFieldExpression a) => new SelectExpression<decimal>(a);
         public static implicit operator DecimalExpressionMediator(DecimalFieldExpression a) => new DecimalExpressionMediator(a);
-        public static implicit operator OrderByExpression(DecimalFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DecimalFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/DoubleFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/DoubleFieldExpression.generated.cs
@@ -10,21 +10,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<double> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool>(this, new InExpression<double>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(double value) => new AssignmentExpression(this, new LiteralExpression<double>(value));
-        public virtual AssignmentExpression Set(DoubleElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new DoubleExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new DoubleExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<double>(DoubleFieldExpression a) => new SelectExpression<double>(a);
         public static implicit operator DoubleExpressionMediator(DoubleFieldExpression a) => new DoubleExpressionMediator(a);
-        public static implicit operator OrderByExpression(DoubleFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DoubleFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/EnumFieldExpression{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/EnumFieldExpression{T,U}.cs
@@ -29,15 +29,6 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<TEnum> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool>(this, new InExpression<TEnum>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(TEnum value) => new AssignmentExpression(this, new LiteralExpression<TEnum>(value));
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
-        #endregion
-
         #region equals
         public bool Equals(EnumFieldExpression<TEntity, TEnum> obj)
             => obj is EnumFieldExpression<TEntity, TEnum> && base.Equals(obj);
@@ -52,8 +43,6 @@ namespace HatTrick.DbEx.Sql.Expression
         #region implicit operators
         public static implicit operator EnumExpressionMediator<TEnum>(EnumFieldExpression<TEntity, TEnum> a) => new EnumExpressionMediator<TEnum>(a);
         public static implicit operator SelectExpression<TEnum>(EnumFieldExpression<TEntity, TEnum> a) => new SelectExpression<TEnum>(a);
-        public static implicit operator OrderByExpression(EnumFieldExpression<TEntity, TEnum> a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(EnumFieldExpression<TEntity, TEnum> a) => new GroupByExpression(a);
         #endregion
 
         #region filter operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/FieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/FieldExpression.cs
@@ -53,22 +53,8 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region order
-        public abstract OrderByExpression Asc { get; }
-        public abstract OrderByExpression Desc { get; }
-        #endregion
-
-        #region operators
-        public static bool operator ==(FieldExpression obj1, FieldExpression obj2)
-        {
-            if (obj1 is null && obj2 is object) return false;
-            if (obj1 is object && obj2 is null) return false;
-            if (obj1 is null && obj2 is null) return true;
-
-            return obj1.Equals(obj2);
-        }
-
-        public static bool operator !=(FieldExpression obj1, FieldExpression obj2)
-            => !(obj1 == obj2);
+        public virtual OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
+        public virtual OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region equals
@@ -106,6 +92,22 @@ namespace HatTrick.DbEx.Sql.Expression
             }
         }
         #endregion
-    }
 
+        #region operators
+        public static implicit operator OrderByExpression(FieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
+        public static implicit operator GroupByExpression(FieldExpression a) => new GroupByExpression(a);
+
+        public static bool operator ==(FieldExpression obj1, FieldExpression obj2)
+        {
+            if (obj1 is null && obj2 is object) return false;
+            if (obj1 is object && obj2 is null) return false;
+            if (obj1 is null && obj2 is null) return true;
+
+            return obj1.Equals(obj2);
+        }
+
+        public static bool operator !=(FieldExpression obj1, FieldExpression obj2)
+            => !(obj1 == obj2);
+        #endregion
+    }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/FieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/FieldExpression{T}.cs
@@ -22,9 +22,5 @@ namespace HatTrick.DbEx.Sql.Expression
         public abstract FilterExpressionSet In(params TValue[] value);
         public abstract FilterExpressionSet In(IEnumerable<TValue> value);
         #endregion
-
-        #region set
-        public abstract AssignmentExpression Set(TValue value);
-        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/GuidFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/GuidFieldExpression.generated.cs
@@ -10,21 +10,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<Guid> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool>(this, new InExpression<Guid>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(Guid value) => new AssignmentExpression(this, new LiteralExpression<Guid>(value));
-        public virtual AssignmentExpression Set(GuidElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new GuidExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new GuidExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<Guid>(GuidFieldExpression a) => new SelectExpression<Guid>(a);
         public static implicit operator GuidExpressionMediator(GuidFieldExpression a) => new GuidExpressionMediator(a);
-        public static implicit operator OrderByExpression(GuidFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(GuidFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/Int16FieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/Int16FieldExpression.generated.cs
@@ -10,21 +10,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<short> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool>(this, new InExpression<short>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(short value) => new AssignmentExpression(this, new LiteralExpression<short>(value));
-        public virtual AssignmentExpression Set(Int16Element value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new Int16ExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new Int16ExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<short>(Int16FieldExpression a) => new SelectExpression<short>(a);
         public static implicit operator Int16ExpressionMediator(Int16FieldExpression a) => new Int16ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int16FieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int16FieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/Int32FieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/Int32FieldExpression.generated.cs
@@ -10,21 +10,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<int> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool>(this, new InExpression<int>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
-        public virtual AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new Int32ExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new Int32ExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<int>(Int32FieldExpression a) => new SelectExpression<int>(a);
         public static implicit operator Int32ExpressionMediator(Int32FieldExpression a) => new Int32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int32FieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int32FieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/Int64FieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/Int64FieldExpression.generated.cs
@@ -10,21 +10,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<long> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool>(this, new InExpression<long>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(long value) => new AssignmentExpression(this, new LiteralExpression<long>(value));
-        public virtual AssignmentExpression Set(Int64Element value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new Int64ExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new Int64ExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<long>(Int64FieldExpression a) => new SelectExpression<long>(a);
         public static implicit operator Int64ExpressionMediator(Int64FieldExpression a) => new Int64ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int64FieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int64FieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableBooleanFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableBooleanFieldExpression.generated.cs
@@ -12,24 +12,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<bool?> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool?>(this, new InExpression<bool?>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(bool value) => new AssignmentExpression(this, new LiteralExpression<bool>(value));
-        public virtual AssignmentExpression Set(BooleanElement value) => new AssignmentExpression(this, value);
-        public override AssignmentExpression Set(bool? value) => new AssignmentExpression(this, new LiteralExpression<bool?>(value));
-        public override AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<bool?>(DBNull.Value));
-        public virtual AssignmentExpression Set(NullableBooleanElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new NullableBooleanExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new NullableBooleanExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<bool?>(NullableBooleanFieldExpression a) => new SelectExpression<bool?>(a);
         public static implicit operator NullableBooleanExpressionMediator(NullableBooleanFieldExpression a) => new NullableBooleanExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableBooleanFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableBooleanFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableByteArrayFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableByteArrayFieldExpression.cs
@@ -41,21 +41,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<byte[]> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool>(this, new InExpression<byte[]>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(byte[] value) => new AssignmentExpression(this, new LiteralExpression<byte[]>(value));
-        public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<byte[]>(DBNull.Value));
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<byte[]>(NullableByteArrayFieldExpression a) => new SelectExpression<byte[]>(a);
         public static implicit operator NullableByteArrayExpressionMediator(NullableByteArrayFieldExpression a) => new NullableByteArrayExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableByteArrayFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableByteArrayFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region filter operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableByteFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableByteFieldExpression.generated.cs
@@ -12,24 +12,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<byte?> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool?>(this, new InExpression<byte?>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(byte value) => new AssignmentExpression(this, new LiteralExpression<byte>(value));
-        public virtual AssignmentExpression Set(ByteElement value) => new AssignmentExpression(this, value);
-        public override AssignmentExpression Set(byte? value) => new AssignmentExpression(this, new LiteralExpression<byte?>(value));
-        public override AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<byte?>(DBNull.Value));
-        public virtual AssignmentExpression Set(NullableByteElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new NullableByteExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new NullableByteExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<byte?>(NullableByteFieldExpression a) => new SelectExpression<byte?>(a);
         public static implicit operator NullableByteExpressionMediator(NullableByteFieldExpression a) => new NullableByteExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableByteFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableByteFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDateTimeFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDateTimeFieldExpression.generated.cs
@@ -12,24 +12,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<DateTime?> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool?>(this, new InExpression<DateTime?>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
-        public virtual AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
-        public override AssignmentExpression Set(DateTime? value) => new AssignmentExpression(this, new LiteralExpression<DateTime?>(value));
-        public override AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<DateTime?>(DBNull.Value));
-        public virtual AssignmentExpression Set(NullableDateTimeElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new NullableDateTimeExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new NullableDateTimeExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<DateTime?>(NullableDateTimeFieldExpression a) => new SelectExpression<DateTime?>(a);
         public static implicit operator NullableDateTimeExpressionMediator(NullableDateTimeFieldExpression a) => new NullableDateTimeExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDateTimeFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDateTimeFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDateTimeOffsetFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDateTimeOffsetFieldExpression.generated.cs
@@ -12,24 +12,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<DateTimeOffset?> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool?>(this, new InExpression<DateTimeOffset?>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(DateTimeOffset value) => new AssignmentExpression(this, new LiteralExpression<DateTimeOffset>(value));
-        public virtual AssignmentExpression Set(DateTimeOffsetElement value) => new AssignmentExpression(this, value);
-        public override AssignmentExpression Set(DateTimeOffset? value) => new AssignmentExpression(this, new LiteralExpression<DateTimeOffset?>(value));
-        public override AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<DateTimeOffset?>(DBNull.Value));
-        public virtual AssignmentExpression Set(NullableDateTimeOffsetElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new NullableDateTimeOffsetExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new NullableDateTimeOffsetExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<DateTimeOffset?>(NullableDateTimeOffsetFieldExpression a) => new SelectExpression<DateTimeOffset?>(a);
         public static implicit operator NullableDateTimeOffsetExpressionMediator(NullableDateTimeOffsetFieldExpression a) => new NullableDateTimeOffsetExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDateTimeOffsetFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDateTimeOffsetFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDecimalFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDecimalFieldExpression.generated.cs
@@ -12,24 +12,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<decimal?> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool?>(this, new InExpression<decimal?>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(decimal value) => new AssignmentExpression(this, new LiteralExpression<decimal>(value));
-        public virtual AssignmentExpression Set(DecimalElement value) => new AssignmentExpression(this, value);
-        public override AssignmentExpression Set(decimal? value) => new AssignmentExpression(this, new LiteralExpression<decimal?>(value));
-        public override AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<decimal?>(DBNull.Value));
-        public virtual AssignmentExpression Set(NullableDecimalElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new NullableDecimalExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new NullableDecimalExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<decimal?>(NullableDecimalFieldExpression a) => new SelectExpression<decimal?>(a);
         public static implicit operator NullableDecimalExpressionMediator(NullableDecimalFieldExpression a) => new NullableDecimalExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDecimalFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDecimalFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDoubleFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDoubleFieldExpression.generated.cs
@@ -12,24 +12,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<double?> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool?>(this, new InExpression<double?>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(double value) => new AssignmentExpression(this, new LiteralExpression<double>(value));
-        public virtual AssignmentExpression Set(DoubleElement value) => new AssignmentExpression(this, value);
-        public override AssignmentExpression Set(double? value) => new AssignmentExpression(this, new LiteralExpression<double?>(value));
-        public override AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<double?>(DBNull.Value));
-        public virtual AssignmentExpression Set(NullableDoubleElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new NullableDoubleExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new NullableDoubleExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<double?>(NullableDoubleFieldExpression a) => new SelectExpression<double?>(a);
         public static implicit operator NullableDoubleExpressionMediator(NullableDoubleFieldExpression a) => new NullableDoubleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDoubleFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDoubleFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableEnumFieldExpression{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableEnumFieldExpression{T,U}.cs
@@ -22,24 +22,11 @@ namespace HatTrick.DbEx.Sql.Expression
             => new NullableEnumFieldExpression<TEntity, TEnum>(base.identifier, base.entity, alias);
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(TEnum value) => new AssignmentExpression(this, new LiteralExpression<TEnum>(value));
-        public override AssignmentExpression Set(TEnum? value) => new AssignmentExpression(this, new LiteralExpression<TEnum?>(value));
-        public virtual AssignmentExpression Set(EnumElement<TEnum> value) => new AssignmentExpression(this, value);
-        public virtual AssignmentExpression Set(NullableEnumElement<TEnum> value) => new AssignmentExpression(this, value);
-        public override AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<TEnum?>(DBNull.Value));
-        #endregion
-
         #region in value set
         public override FilterExpressionSet In(params TEnum?[] value) => value is object ? new FilterExpressionSet(new FilterExpression<bool?>(this, new InExpression<TEnum?>(value), FilterExpressionOperator.None)) : null;
         public override FilterExpressionSet In(IEnumerable<TEnum?> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool?>(this, new InExpression<TEnum?>(value), FilterExpressionOperator.None)) : null;
         public override FilterExpressionSet In(params TEnum[] value) => value is object ? new FilterExpressionSet(new FilterExpression<bool>(this, new InExpression<TEnum>(value), FilterExpressionOperator.None)) : null;
         public override FilterExpressionSet In(IEnumerable<TEnum> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool>(this, new InExpression<TEnum>(value), FilterExpressionOperator.None)) : null;
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region equals
@@ -56,8 +43,6 @@ namespace HatTrick.DbEx.Sql.Expression
         #region implicit operators
         public static implicit operator SelectExpression<TEnum?>(NullableEnumFieldExpression<TEntity, TEnum> a) => new SelectExpression<TEnum?>(a);
         public static implicit operator NullableEnumExpressionMediator<TEnum>(NullableEnumFieldExpression<TEntity, TEnum> a) => new NullableEnumExpressionMediator<TEnum>(a);
-        public static implicit operator OrderByExpression(NullableEnumFieldExpression<TEntity, TEnum> a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableEnumFieldExpression<TEntity, TEnum> a) => new GroupByExpression(a);
         #endregion
 
         #region filter operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableFieldExpression{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableFieldExpression{T,U}.cs
@@ -24,12 +24,5 @@ namespace HatTrick.DbEx.Sql.Expression
         public abstract FilterExpressionSet In(params TNullableValue[] value);
         public abstract FilterExpressionSet In(IEnumerable<TNullableValue> value);
         #endregion
-
-        #region set
-        public abstract AssignmentExpression Set(TValue value);
-
-        public abstract AssignmentExpression Set(TNullableValue value);
-        public abstract AssignmentExpression Set(DBNull value);
-        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableGuidFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableGuidFieldExpression.generated.cs
@@ -12,24 +12,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<Guid?> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool?>(this, new InExpression<Guid?>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(Guid value) => new AssignmentExpression(this, new LiteralExpression<Guid>(value));
-        public virtual AssignmentExpression Set(GuidElement value) => new AssignmentExpression(this, value);
-        public override AssignmentExpression Set(Guid? value) => new AssignmentExpression(this, new LiteralExpression<Guid?>(value));
-        public override AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<Guid?>(DBNull.Value));
-        public virtual AssignmentExpression Set(NullableGuidElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new NullableGuidExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new NullableGuidExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<Guid?>(NullableGuidFieldExpression a) => new SelectExpression<Guid?>(a);
         public static implicit operator NullableGuidExpressionMediator(NullableGuidFieldExpression a) => new NullableGuidExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableGuidFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableGuidFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt16FieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt16FieldExpression.generated.cs
@@ -12,24 +12,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<short?> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool?>(this, new InExpression<short?>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(short value) => new AssignmentExpression(this, new LiteralExpression<short>(value));
-        public virtual AssignmentExpression Set(Int16Element value) => new AssignmentExpression(this, value);
-        public override AssignmentExpression Set(short? value) => new AssignmentExpression(this, new LiteralExpression<short?>(value));
-        public override AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<short?>(DBNull.Value));
-        public virtual AssignmentExpression Set(NullableInt16Element value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new NullableInt16ExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new NullableInt16ExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<short?>(NullableInt16FieldExpression a) => new SelectExpression<short?>(a);
         public static implicit operator NullableInt16ExpressionMediator(NullableInt16FieldExpression a) => new NullableInt16ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt16FieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt16FieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt32FieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt32FieldExpression.generated.cs
@@ -12,24 +12,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<int?> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool?>(this, new InExpression<int?>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
-        public virtual AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
-        public override AssignmentExpression Set(int? value) => new AssignmentExpression(this, new LiteralExpression<int?>(value));
-        public override AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<int?>(DBNull.Value));
-        public virtual AssignmentExpression Set(NullableInt32Element value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new NullableInt32ExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new NullableInt32ExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<int?>(NullableInt32FieldExpression a) => new SelectExpression<int?>(a);
         public static implicit operator NullableInt32ExpressionMediator(NullableInt32FieldExpression a) => new NullableInt32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt32FieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt32FieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt64FieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt64FieldExpression.generated.cs
@@ -12,24 +12,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<long?> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool?>(this, new InExpression<long?>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(long value) => new AssignmentExpression(this, new LiteralExpression<long>(value));
-        public virtual AssignmentExpression Set(Int64Element value) => new AssignmentExpression(this, value);
-        public override AssignmentExpression Set(long? value) => new AssignmentExpression(this, new LiteralExpression<long?>(value));
-        public override AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<long?>(DBNull.Value));
-        public virtual AssignmentExpression Set(NullableInt64Element value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new NullableInt64ExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new NullableInt64ExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<long?>(NullableInt64FieldExpression a) => new SelectExpression<long?>(a);
         public static implicit operator NullableInt64ExpressionMediator(NullableInt64FieldExpression a) => new NullableInt64ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt64FieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt64FieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableSingleFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableSingleFieldExpression.generated.cs
@@ -12,24 +12,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<float?> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool?>(this, new InExpression<float?>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(float value) => new AssignmentExpression(this, new LiteralExpression<float>(value));
-        public virtual AssignmentExpression Set(SingleElement value) => new AssignmentExpression(this, value);
-        public override AssignmentExpression Set(float? value) => new AssignmentExpression(this, new LiteralExpression<float?>(value));
-        public override AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<float?>(DBNull.Value));
-        public virtual AssignmentExpression Set(NullableSingleElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new NullableSingleExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new NullableSingleExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<float?>(NullableSingleFieldExpression a) => new SelectExpression<float?>(a);
         public static implicit operator NullableSingleExpressionMediator(NullableSingleFieldExpression a) => new NullableSingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableSingleFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableSingleFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableStringFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableStringFieldExpression.cs
@@ -24,10 +24,6 @@ namespace HatTrick.DbEx.Sql.Expression
         public abstract NullableStringElement As(string alias);
         #endregion
 
-        #region set
-        public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<string>(DBNull.Value));
-        #endregion
-
         #region equals
         public bool Equals(NullableStringFieldExpression obj)
             => obj is NullableStringFieldExpression && base.Equals(obj);

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableStringFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableStringFieldExpression.generated.cs
@@ -10,21 +10,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<string> value) => value is object ? new FilterExpression<bool>(this, new InExpression<string>(value), FilterExpressionOperator.None) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
-        public virtual AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new NullableStringExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new NullableStringExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<string>(NullableStringFieldExpression a) => new SelectExpression<string>(a);
         public static implicit operator NullableStringExpressionMediator(NullableStringFieldExpression a) => new NullableStringExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableStringFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableStringFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableTimeSpanFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableTimeSpanFieldExpression.generated.cs
@@ -12,24 +12,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<TimeSpan?> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool?>(this, new InExpression<TimeSpan?>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(TimeSpan value) => new AssignmentExpression(this, new LiteralExpression<TimeSpan>(value));
-        public virtual AssignmentExpression Set(TimeSpanElement value) => new AssignmentExpression(this, value);
-        public override AssignmentExpression Set(TimeSpan? value) => new AssignmentExpression(this, new LiteralExpression<TimeSpan?>(value));
-        public override AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<TimeSpan?>(DBNull.Value));
-        public virtual AssignmentExpression Set(NullableTimeSpanElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new NullableTimeSpanExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new NullableTimeSpanExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<TimeSpan?>(NullableTimeSpanFieldExpression a) => new SelectExpression<TimeSpan?>(a);
         public static implicit operator NullableTimeSpanExpressionMediator(NullableTimeSpanFieldExpression a) => new NullableTimeSpanExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableTimeSpanFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableTimeSpanFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/SingleFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/SingleFieldExpression.generated.cs
@@ -10,21 +10,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<float> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool>(this, new InExpression<float>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(float value) => new AssignmentExpression(this, new LiteralExpression<float>(value));
-        public virtual AssignmentExpression Set(SingleElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new SingleExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new SingleExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<float>(SingleFieldExpression a) => new SelectExpression<float>(a);
         public static implicit operator SingleExpressionMediator(SingleFieldExpression a) => new SingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(SingleFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(SingleFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/StringFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/StringFieldExpression.generated.cs
@@ -10,21 +10,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<string> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool>(this, new InExpression<string>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
-        public virtual AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new StringExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new StringExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<string>(StringFieldExpression a) => new SelectExpression<string>(a);
         public static implicit operator StringExpressionMediator(StringFieldExpression a) => new StringExpressionMediator(a);
-        public static implicit operator OrderByExpression(StringFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(StringFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/TimeSpanFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/TimeSpanFieldExpression.generated.cs
@@ -10,21 +10,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public override FilterExpressionSet In(IEnumerable<TimeSpan> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool>(this, new InExpression<TimeSpan>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set(TimeSpan value) => new AssignmentExpression(this, new LiteralExpression<TimeSpan>(value));
-        public virtual AssignmentExpression Set(TimeSpanElement value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new TimeSpanExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new TimeSpanExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<TimeSpan>(TimeSpanFieldExpression a) => new SelectExpression<TimeSpan>(a);
         public static implicit operator TimeSpanExpressionMediator(TimeSpanFieldExpression a) => new TimeSpanExpressionMediator(a);
-        public static implicit operator OrderByExpression(TimeSpanFieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(TimeSpanFieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/FunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/FunctionExpression.cs
@@ -34,8 +34,8 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region order
-        public abstract OrderByExpression Asc { get; }
-        public abstract OrderByExpression Desc { get; }
+        public OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
+        public OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region equals
@@ -67,6 +67,10 @@ namespace HatTrick.DbEx.Sql.Expression
                 return hash;
             }
         }
+        #endregion
+
+        #region implicit operators
+        public static implicit operator OrderByExpression(FunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
         #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/DecimalAverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/DecimalAverageFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DecimalExpressionMediator(DecimalAverageFunctionExpression a) => new DecimalExpressionMediator(a);
-        public static implicit operator OrderByExpression(DecimalAverageFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/DoubleAverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/DoubleAverageFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DoubleExpressionMediator(DoubleAverageFunctionExpression a) => new DoubleExpressionMediator(a);
-        public static implicit operator OrderByExpression(DoubleAverageFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/Int32AverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/Int32AverageFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int32ExpressionMediator(Int32AverageFunctionExpression a) => new Int32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int32AverageFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/Int64AverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/Int64AverageFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int64ExpressionMediator(Int64AverageFunctionExpression a) => new Int64ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int64AverageFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableDecimalAverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableDecimalAverageFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDecimalExpressionMediator(NullableDecimalAverageFunctionExpression a) => new NullableDecimalExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDecimalAverageFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableDoubleAverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableDoubleAverageFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDoubleExpressionMediator(NullableDoubleAverageFunctionExpression a) => new NullableDoubleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDoubleAverageFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableInt32AverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableInt32AverageFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt32ExpressionMediator(NullableInt32AverageFunctionExpression a) => new NullableInt32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt32AverageFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableInt64AverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableInt64AverageFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt64ExpressionMediator(NullableInt64AverageFunctionExpression a) => new NullableInt64ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt64AverageFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableSingleAverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableSingleAverageFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableSingleExpressionMediator(NullableSingleAverageFunctionExpression a) => new NullableSingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableSingleAverageFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/ObjectAverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/ObjectAverageFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator ObjectExpressionMediator(ObjectAverageFunctionExpression a) => new ObjectExpressionMediator(a);
-        public static implicit operator OrderByExpression(ObjectAverageFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/SingleAverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/SingleAverageFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SingleExpressionMediator(SingleAverageFunctionExpression a) => new SingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(SingleAverageFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Count/Int32CountFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Count/Int32CountFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int32ExpressionMediator(Int32CountFunctionExpression a) => new Int32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int32CountFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/ByteMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/ByteMaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator ByteExpressionMediator(ByteMaximumFunctionExpression a) => new ByteExpressionMediator(a);
-        public static implicit operator OrderByExpression(ByteMaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DateTimeMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DateTimeMaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DateTimeExpressionMediator(DateTimeMaximumFunctionExpression a) => new DateTimeExpressionMediator(a);
-        public static implicit operator OrderByExpression(DateTimeMaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DateTimeOffsetMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DateTimeOffsetMaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DateTimeOffsetExpressionMediator(DateTimeOffsetMaximumFunctionExpression a) => new DateTimeOffsetExpressionMediator(a);
-        public static implicit operator OrderByExpression(DateTimeOffsetMaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DecimalMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DecimalMaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DecimalExpressionMediator(DecimalMaximumFunctionExpression a) => new DecimalExpressionMediator(a);
-        public static implicit operator OrderByExpression(DecimalMaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DoubleMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DoubleMaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DoubleExpressionMediator(DoubleMaximumFunctionExpression a) => new DoubleExpressionMediator(a);
-        public static implicit operator OrderByExpression(DoubleMaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/GuidMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/GuidMaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator GuidExpressionMediator(GuidMaximumFunctionExpression a) => new GuidExpressionMediator(a);
-        public static implicit operator OrderByExpression(GuidMaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/Int16MaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/Int16MaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int16ExpressionMediator(Int16MaximumFunctionExpression a) => new Int16ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int16MaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/Int32MaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/Int32MaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int32ExpressionMediator(Int32MaximumFunctionExpression a) => new Int32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int32MaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/Int64MaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/Int64MaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int64ExpressionMediator(Int64MaximumFunctionExpression a) => new Int64ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int64MaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableByteMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableByteMaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableByteExpressionMediator(NullableByteMaximumFunctionExpression a) => new NullableByteExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableByteMaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDateTimeMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDateTimeMaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDateTimeExpressionMediator(NullableDateTimeMaximumFunctionExpression a) => new NullableDateTimeExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDateTimeMaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDateTimeOffsetMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDateTimeOffsetMaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDateTimeOffsetExpressionMediator(NullableDateTimeOffsetMaximumFunctionExpression a) => new NullableDateTimeOffsetExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDateTimeOffsetMaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDecimalMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDecimalMaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDecimalExpressionMediator(NullableDecimalMaximumFunctionExpression a) => new NullableDecimalExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDecimalMaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDoubleMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDoubleMaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDoubleExpressionMediator(NullableDoubleMaximumFunctionExpression a) => new NullableDoubleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDoubleMaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableGuidMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableGuidMaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableGuidExpressionMediator(NullableGuidMaximumFunctionExpression a) => new NullableGuidExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableGuidMaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableInt16MaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableInt16MaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt16ExpressionMediator(NullableInt16MaximumFunctionExpression a) => new NullableInt16ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt16MaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableInt32MaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableInt32MaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt32ExpressionMediator(NullableInt32MaximumFunctionExpression a) => new NullableInt32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt32MaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableInt64MaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableInt64MaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt64ExpressionMediator(NullableInt64MaximumFunctionExpression a) => new NullableInt64ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt64MaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableSingleMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableSingleMaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableSingleExpressionMediator(NullableSingleMaximumFunctionExpression a) => new NullableSingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableSingleMaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableTimeSpanMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableTimeSpanMaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableTimeSpanExpressionMediator(NullableTimeSpanMaximumFunctionExpression a) => new NullableTimeSpanExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableTimeSpanMaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/ObjectMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/ObjectMaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator ObjectExpressionMediator(ObjectMaximumFunctionExpression a) => new ObjectExpressionMediator(a);
-        public static implicit operator OrderByExpression(ObjectMaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/SingleMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/SingleMaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SingleExpressionMediator(SingleMaximumFunctionExpression a) => new SingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(SingleMaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/StringMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/StringMaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator StringExpressionMediator(StringMaximumFunctionExpression a) => new StringExpressionMediator(a);
-        public static implicit operator OrderByExpression(StringMaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/TimeSpanMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/TimeSpanMaximumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator TimeSpanExpressionMediator(TimeSpanMaximumFunctionExpression a) => new TimeSpanExpressionMediator(a);
-        public static implicit operator OrderByExpression(TimeSpanMaximumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/ByteMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/ByteMinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator ByteExpressionMediator(ByteMinimumFunctionExpression a) => new ByteExpressionMediator(a);
-        public static implicit operator OrderByExpression(ByteMinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DateTimeMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DateTimeMinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DateTimeExpressionMediator(DateTimeMinimumFunctionExpression a) => new DateTimeExpressionMediator(a);
-        public static implicit operator OrderByExpression(DateTimeMinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DateTimeOffsetMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DateTimeOffsetMinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DateTimeOffsetExpressionMediator(DateTimeOffsetMinimumFunctionExpression a) => new DateTimeOffsetExpressionMediator(a);
-        public static implicit operator OrderByExpression(DateTimeOffsetMinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DecimalMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DecimalMinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DecimalExpressionMediator(DecimalMinimumFunctionExpression a) => new DecimalExpressionMediator(a);
-        public static implicit operator OrderByExpression(DecimalMinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DoubleMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DoubleMinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DoubleExpressionMediator(DoubleMinimumFunctionExpression a) => new DoubleExpressionMediator(a);
-        public static implicit operator OrderByExpression(DoubleMinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/GuidMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/GuidMinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator GuidExpressionMediator(GuidMinimumFunctionExpression a) => new GuidExpressionMediator(a);
-        public static implicit operator OrderByExpression(GuidMinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/Int16MinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/Int16MinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int16ExpressionMediator(Int16MinimumFunctionExpression a) => new Int16ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int16MinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/Int32MinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/Int32MinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int32ExpressionMediator(Int32MinimumFunctionExpression a) => new Int32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int32MinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/Int64MinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/Int64MinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int64ExpressionMediator(Int64MinimumFunctionExpression a) => new Int64ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int64MinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableByteMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableByteMinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableByteExpressionMediator(NullableByteMinimumFunctionExpression a) => new NullableByteExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableByteMinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDateTimeMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDateTimeMinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDateTimeExpressionMediator(NullableDateTimeMinimumFunctionExpression a) => new NullableDateTimeExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDateTimeMinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDateTimeOffsetMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDateTimeOffsetMinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDateTimeOffsetExpressionMediator(NullableDateTimeOffsetMinimumFunctionExpression a) => new NullableDateTimeOffsetExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDateTimeOffsetMinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDecimalMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDecimalMinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDecimalExpressionMediator(NullableDecimalMinimumFunctionExpression a) => new NullableDecimalExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDecimalMinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDoubleMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDoubleMinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDoubleExpressionMediator(NullableDoubleMinimumFunctionExpression a) => new NullableDoubleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDoubleMinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableGuidMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableGuidMinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableGuidExpressionMediator(NullableGuidMinimumFunctionExpression a) => new NullableGuidExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableGuidMinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableInt16MinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableInt16MinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt16ExpressionMediator(NullableInt16MinimumFunctionExpression a) => new NullableInt16ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt16MinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableInt32MinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableInt32MinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt32ExpressionMediator(NullableInt32MinimumFunctionExpression a) => new NullableInt32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt32MinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableInt64MinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableInt64MinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt64ExpressionMediator(NullableInt64MinimumFunctionExpression a) => new NullableInt64ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt64MinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableSingleMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableSingleMinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableSingleExpressionMediator(NullableSingleMinimumFunctionExpression a) => new NullableSingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableSingleMinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableTimeSpanMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableTimeSpanMinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableTimeSpanExpressionMediator(NullableTimeSpanMinimumFunctionExpression a) => new NullableTimeSpanExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableTimeSpanMinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/ObjectMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/ObjectMinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator ObjectExpressionMediator(ObjectMinimumFunctionExpression a) => new ObjectExpressionMediator(a);
-        public static implicit operator OrderByExpression(ObjectMinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/SingleMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/SingleMinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SingleExpressionMediator(SingleMinimumFunctionExpression a) => new SingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(SingleMinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/StringMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/StringMinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator StringExpressionMediator(StringMinimumFunctionExpression a) => new StringExpressionMediator(a);
-        public static implicit operator OrderByExpression(StringMinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/TimeSpanMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/TimeSpanMinimumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator TimeSpanExpressionMediator(TimeSpanMinimumFunctionExpression a) => new TimeSpanExpressionMediator(a);
-        public static implicit operator OrderByExpression(TimeSpanMinimumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationStandardDeviation/NullableSinglePopulationStandardDeviationFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationStandardDeviation/NullableSinglePopulationStandardDeviationFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableSingleExpressionMediator(NullableSinglePopulationStandardDeviationFunctionExpression a) => new NullableSingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableSinglePopulationStandardDeviationFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationStandardDeviation/ObjectPopulationStandardDeviationFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationStandardDeviation/ObjectPopulationStandardDeviationFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator ObjectExpressionMediator(ObjectPopulationStandardDeviationFunctionExpression a) => new ObjectExpressionMediator(a);
-        public static implicit operator OrderByExpression(ObjectPopulationStandardDeviationFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationStandardDeviation/SinglePopulationStandardDeviationFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationStandardDeviation/SinglePopulationStandardDeviationFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SingleExpressionMediator(SinglePopulationStandardDeviationFunctionExpression a) => new SingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(SinglePopulationStandardDeviationFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationVariance/NullableSinglePopulationVarianceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationVariance/NullableSinglePopulationVarianceFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableSingleExpressionMediator(NullableSinglePopulationVarianceFunctionExpression a) => new NullableSingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableSinglePopulationVarianceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationVariance/ObjectPopulationVarianceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationVariance/ObjectPopulationVarianceFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator ObjectExpressionMediator(ObjectPopulationVarianceFunctionExpression a) => new ObjectExpressionMediator(a);
-        public static implicit operator OrderByExpression(ObjectPopulationVarianceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationVariance/SinglePopulationVarianceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationVariance/SinglePopulationVarianceFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SingleExpressionMediator(SinglePopulationVarianceFunctionExpression a) => new SingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(SinglePopulationVarianceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_StandardDeviation/NullableSingleStandardDeviationFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_StandardDeviation/NullableSingleStandardDeviationFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableSingleExpressionMediator(NullableSingleStandardDeviationFunctionExpression a) => new NullableSingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableSingleStandardDeviationFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_StandardDeviation/ObjectStandardDeviationFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_StandardDeviation/ObjectStandardDeviationFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator ObjectExpressionMediator(ObjectStandardDeviationFunctionExpression a) => new ObjectExpressionMediator(a);
-        public static implicit operator OrderByExpression(ObjectStandardDeviationFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_StandardDeviation/SingleStandardDeviationFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_StandardDeviation/SingleStandardDeviationFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SingleExpressionMediator(SingleStandardDeviationFunctionExpression a) => new SingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(SingleStandardDeviationFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/DecimalSumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/DecimalSumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DecimalExpressionMediator(DecimalSumFunctionExpression a) => new DecimalExpressionMediator(a);
-        public static implicit operator OrderByExpression(DecimalSumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/DoubleSumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/DoubleSumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DoubleExpressionMediator(DoubleSumFunctionExpression a) => new DoubleExpressionMediator(a);
-        public static implicit operator OrderByExpression(DoubleSumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/Int32SumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/Int32SumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int32ExpressionMediator(Int32SumFunctionExpression a) => new Int32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int32SumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/Int64SumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/Int64SumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int64ExpressionMediator(Int64SumFunctionExpression a) => new Int64ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int64SumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableDecimalSumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableDecimalSumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDecimalExpressionMediator(NullableDecimalSumFunctionExpression a) => new NullableDecimalExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDecimalSumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableDoubleSumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableDoubleSumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDoubleExpressionMediator(NullableDoubleSumFunctionExpression a) => new NullableDoubleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDoubleSumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableInt32SumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableInt32SumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt32ExpressionMediator(NullableInt32SumFunctionExpression a) => new NullableInt32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt32SumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableInt64SumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableInt64SumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt64ExpressionMediator(NullableInt64SumFunctionExpression a) => new NullableInt64ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt64SumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableSingleSumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableSingleSumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableSingleExpressionMediator(NullableSingleSumFunctionExpression a) => new NullableSingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableSingleSumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/ObjectSumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/ObjectSumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator ObjectExpressionMediator(ObjectSumFunctionExpression a) => new ObjectExpressionMediator(a);
-        public static implicit operator OrderByExpression(ObjectSumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/SingleSumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/SingleSumFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SingleExpressionMediator(SingleSumFunctionExpression a) => new SingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(SingleSumFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Variance/NullableSingleVarianceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Variance/NullableSingleVarianceFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableSingleExpressionMediator(NullableSingleVarianceFunctionExpression a) => new NullableSingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableSingleVarianceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Variance/ObjectVarianceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Variance/ObjectVarianceFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator ObjectExpressionMediator(ObjectVarianceFunctionExpression a) => new ObjectExpressionMediator(a);
-        public static implicit operator OrderByExpression(ObjectVarianceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Variance/SingleVarianceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Variance/SingleVarianceFunctionExpression.generated.cs
@@ -6,12 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SingleExpressionMediator(SingleVarianceFunctionExpression a) => new SingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(SingleVarianceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/ConversionFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/ConversionFunctionExpression.cs
@@ -12,5 +12,9 @@ namespace HatTrick.DbEx.Sql.Expression
 
         }
         #endregion
+
+        #region implicit operators
+        public static implicit operator GroupByExpression(ConversionFunctionExpression a) => new GroupByExpression(a);
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/BooleanCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/BooleanCastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator BooleanExpressionMediator(BooleanCastFunctionExpression a) => new BooleanExpressionMediator(a);
-        public static implicit operator OrderByExpression(BooleanCastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(BooleanCastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/ByteCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/ByteCastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator ByteExpressionMediator(ByteCastFunctionExpression a) => new ByteExpressionMediator(a);
-        public static implicit operator OrderByExpression(ByteCastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(ByteCastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/DateTimeCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/DateTimeCastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DateTimeExpressionMediator(DateTimeCastFunctionExpression a) => new DateTimeExpressionMediator(a);
-        public static implicit operator OrderByExpression(DateTimeCastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DateTimeCastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/DateTimeOffsetCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/DateTimeOffsetCastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DateTimeOffsetExpressionMediator(DateTimeOffsetCastFunctionExpression a) => new DateTimeOffsetExpressionMediator(a);
-        public static implicit operator OrderByExpression(DateTimeOffsetCastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DateTimeOffsetCastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/DecimalCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/DecimalCastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DecimalExpressionMediator(DecimalCastFunctionExpression a) => new DecimalExpressionMediator(a);
-        public static implicit operator OrderByExpression(DecimalCastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DecimalCastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/DoubleCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/DoubleCastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DoubleExpressionMediator(DoubleCastFunctionExpression a) => new DoubleExpressionMediator(a);
-        public static implicit operator OrderByExpression(DoubleCastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DoubleCastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/GuidCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/GuidCastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator GuidExpressionMediator(GuidCastFunctionExpression a) => new GuidExpressionMediator(a);
-        public static implicit operator OrderByExpression(GuidCastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(GuidCastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/Int16CastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/Int16CastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int16ExpressionMediator(Int16CastFunctionExpression a) => new Int16ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int16CastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int16CastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/Int32CastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/Int32CastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int32ExpressionMediator(Int32CastFunctionExpression a) => new Int32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int32CastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int32CastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/Int64CastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/Int64CastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int64ExpressionMediator(Int64CastFunctionExpression a) => new Int64ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int64CastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int64CastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableBooleanCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableBooleanCastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableBooleanExpressionMediator(NullableBooleanCastFunctionExpression a) => new NullableBooleanExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableBooleanCastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableBooleanCastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableByteCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableByteCastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableByteExpressionMediator(NullableByteCastFunctionExpression a) => new NullableByteExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableByteCastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableByteCastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableDateTimeCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableDateTimeCastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDateTimeExpressionMediator(NullableDateTimeCastFunctionExpression a) => new NullableDateTimeExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDateTimeCastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDateTimeCastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableDateTimeOffsetCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableDateTimeOffsetCastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDateTimeOffsetExpressionMediator(NullableDateTimeOffsetCastFunctionExpression a) => new NullableDateTimeOffsetExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDateTimeOffsetCastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDateTimeOffsetCastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableDecimalCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableDecimalCastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDecimalExpressionMediator(NullableDecimalCastFunctionExpression a) => new NullableDecimalExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDecimalCastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDecimalCastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableDoubleCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableDoubleCastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDoubleExpressionMediator(NullableDoubleCastFunctionExpression a) => new NullableDoubleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDoubleCastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDoubleCastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableGuidCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableGuidCastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableGuidExpressionMediator(NullableGuidCastFunctionExpression a) => new NullableGuidExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableGuidCastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableGuidCastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableInt16CastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableInt16CastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt16ExpressionMediator(NullableInt16CastFunctionExpression a) => new NullableInt16ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt16CastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt16CastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableInt32CastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableInt32CastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt32ExpressionMediator(NullableInt32CastFunctionExpression a) => new NullableInt32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt32CastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt32CastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableInt64CastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableInt64CastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt64ExpressionMediator(NullableInt64CastFunctionExpression a) => new NullableInt64ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt64CastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt64CastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableSingleCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableSingleCastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableSingleExpressionMediator(NullableSingleCastFunctionExpression a) => new NullableSingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableSingleCastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableSingleCastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableTimeSpanCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableTimeSpanCastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableTimeSpanExpressionMediator(NullableTimeSpanCastFunctionExpression a) => new NullableTimeSpanExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableTimeSpanCastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableTimeSpanCastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/ObjectCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/ObjectCastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator ObjectExpressionMediator(ObjectCastFunctionExpression a) => new ObjectExpressionMediator(a);
-        public static implicit operator OrderByExpression(ObjectCastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(ObjectCastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/SingleCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/SingleCastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SingleExpressionMediator(SingleCastFunctionExpression a) => new SingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(SingleCastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(SingleCastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/StringCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/StringCastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator StringExpressionMediator(StringCastFunctionExpression a) => new StringExpressionMediator(a);
-        public static implicit operator OrderByExpression(StringCastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(StringCastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/TimeSpanCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/TimeSpanCastFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator TimeSpanExpressionMediator(TimeSpanCastFunctionExpression a) => new TimeSpanExpressionMediator(a);
-        public static implicit operator OrderByExpression(TimeSpanCastFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(TimeSpanCastFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_DateDiff/Int32DateDiffFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_DateDiff/Int32DateDiffFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int32ExpressionMediator(Int32DateDiffFunctionExpression a) => new Int32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int32DateDiffFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int32DateDiffFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_DateDiff/NullableInt32DateDiffFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_DateDiff/NullableInt32DateDiffFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt32ExpressionMediator(NullableInt32DateDiffFunctionExpression a) => new NullableInt32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt32DateDiffFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt32DateDiffFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_DatePart/Int32DatePartFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_DatePart/Int32DatePartFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int32ExpressionMediator(Int32DatePartFunctionExpression a) => new Int32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int32DatePartFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int32DatePartFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_DatePart/NullableInt32DatePartFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_DatePart/NullableInt32DatePartFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt32ExpressionMediator(NullableInt32DatePartFunctionExpression a) => new NullableInt32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt32DatePartFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt32DatePartFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/DataTypeFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/DataTypeFunctionExpression.cs
@@ -12,5 +12,9 @@ namespace HatTrick.DbEx.Sql.Expression
 
         }
         #endregion
+
+        #region implicit operators
+        public static implicit operator GroupByExpression(DataTypeFunctionExpression a) => new GroupByExpression(a);
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/ByteCeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/ByteCeilingFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator ByteExpressionMediator(ByteCeilingFunctionExpression a) => new ByteExpressionMediator(a);
-        public static implicit operator OrderByExpression(ByteCeilingFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(ByteCeilingFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/DecimalCeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/DecimalCeilingFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DecimalExpressionMediator(DecimalCeilingFunctionExpression a) => new DecimalExpressionMediator(a);
-        public static implicit operator OrderByExpression(DecimalCeilingFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DecimalCeilingFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/DoubleCeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/DoubleCeilingFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DoubleExpressionMediator(DoubleCeilingFunctionExpression a) => new DoubleExpressionMediator(a);
-        public static implicit operator OrderByExpression(DoubleCeilingFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DoubleCeilingFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/Int16CeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/Int16CeilingFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int16ExpressionMediator(Int16CeilingFunctionExpression a) => new Int16ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int16CeilingFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int16CeilingFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/Int32CeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/Int32CeilingFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int32ExpressionMediator(Int32CeilingFunctionExpression a) => new Int32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int32CeilingFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int32CeilingFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/Int64CeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/Int64CeilingFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int64ExpressionMediator(Int64CeilingFunctionExpression a) => new Int64ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int64CeilingFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int64CeilingFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/NullableByteCeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/NullableByteCeilingFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableByteExpressionMediator(NullableByteCeilingFunctionExpression a) => new NullableByteExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableByteCeilingFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableByteCeilingFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/NullableDecimalCeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/NullableDecimalCeilingFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDecimalExpressionMediator(NullableDecimalCeilingFunctionExpression a) => new NullableDecimalExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDecimalCeilingFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDecimalCeilingFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/NullableDoubleCeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/NullableDoubleCeilingFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDoubleExpressionMediator(NullableDoubleCeilingFunctionExpression a) => new NullableDoubleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDoubleCeilingFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDoubleCeilingFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/NullableInt16CeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/NullableInt16CeilingFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt16ExpressionMediator(NullableInt16CeilingFunctionExpression a) => new NullableInt16ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt16CeilingFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt16CeilingFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/NullableInt32CeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/NullableInt32CeilingFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt32ExpressionMediator(NullableInt32CeilingFunctionExpression a) => new NullableInt32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt32CeilingFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt32CeilingFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/NullableInt64CeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/NullableInt64CeilingFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt64ExpressionMediator(NullableInt64CeilingFunctionExpression a) => new NullableInt64ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt64CeilingFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt64CeilingFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/NullableSingleCeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/NullableSingleCeilingFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableSingleExpressionMediator(NullableSingleCeilingFunctionExpression a) => new NullableSingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableSingleCeilingFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableSingleCeilingFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/ObjectCeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/ObjectCeilingFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator ObjectExpressionMediator(ObjectCeilingFunctionExpression a) => new ObjectExpressionMediator(a);
-        public static implicit operator OrderByExpression(ObjectCeilingFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(ObjectCeilingFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/SingleCeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Ceil/SingleCeilingFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SingleExpressionMediator(SingleCeilingFunctionExpression a) => new SingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(SingleCeilingFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(SingleCeilingFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/BooleanCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/BooleanCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator BooleanExpressionMediator(BooleanCoalesceFunctionExpression a) => new BooleanExpressionMediator(a);
-        public static implicit operator OrderByExpression(BooleanCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(BooleanCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/ByteCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/ByteCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator ByteExpressionMediator(ByteCoalesceFunctionExpression a) => new ByteExpressionMediator(a);
-        public static implicit operator OrderByExpression(ByteCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(ByteCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/DateTimeCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/DateTimeCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DateTimeExpressionMediator(DateTimeCoalesceFunctionExpression a) => new DateTimeExpressionMediator(a);
-        public static implicit operator OrderByExpression(DateTimeCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DateTimeCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/DateTimeOffsetCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/DateTimeOffsetCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DateTimeOffsetExpressionMediator(DateTimeOffsetCoalesceFunctionExpression a) => new DateTimeOffsetExpressionMediator(a);
-        public static implicit operator OrderByExpression(DateTimeOffsetCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DateTimeOffsetCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/DecimalCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/DecimalCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DecimalExpressionMediator(DecimalCoalesceFunctionExpression a) => new DecimalExpressionMediator(a);
-        public static implicit operator OrderByExpression(DecimalCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DecimalCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/DoubleCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/DoubleCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DoubleExpressionMediator(DoubleCoalesceFunctionExpression a) => new DoubleExpressionMediator(a);
-        public static implicit operator OrderByExpression(DoubleCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DoubleCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/EnumCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/EnumCoalesceFunctionExpression.generated.cs
@@ -5,13 +5,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator EnumExpressionMediator<TEnum>(EnumCoalesceFunctionExpression<TEnum> a) => new EnumExpressionMediator<TEnum>(new EnumExpressionMediator<TEnum>(a));
-        public static implicit operator OrderByExpression(EnumCoalesceFunctionExpression<TEnum> a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(EnumCoalesceFunctionExpression<TEnum> a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region filter operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/GuidCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/GuidCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator GuidExpressionMediator(GuidCoalesceFunctionExpression a) => new GuidExpressionMediator(a);
-        public static implicit operator OrderByExpression(GuidCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(GuidCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/Int16CoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/Int16CoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int16ExpressionMediator(Int16CoalesceFunctionExpression a) => new Int16ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int16CoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int16CoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/Int32CoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/Int32CoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int32ExpressionMediator(Int32CoalesceFunctionExpression a) => new Int32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int32CoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int32CoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/Int64CoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/Int64CoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int64ExpressionMediator(Int64CoalesceFunctionExpression a) => new Int64ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int64CoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int64CoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableBooleanCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableBooleanCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableBooleanExpressionMediator(NullableBooleanCoalesceFunctionExpression a) => new NullableBooleanExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableBooleanCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableBooleanCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableByteCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableByteCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableByteExpressionMediator(NullableByteCoalesceFunctionExpression a) => new NullableByteExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableByteCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableByteCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableDateTimeCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableDateTimeCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDateTimeExpressionMediator(NullableDateTimeCoalesceFunctionExpression a) => new NullableDateTimeExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDateTimeCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDateTimeCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableDateTimeOffsetCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableDateTimeOffsetCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDateTimeOffsetExpressionMediator(NullableDateTimeOffsetCoalesceFunctionExpression a) => new NullableDateTimeOffsetExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDateTimeOffsetCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDateTimeOffsetCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableDecimalCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableDecimalCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDecimalExpressionMediator(NullableDecimalCoalesceFunctionExpression a) => new NullableDecimalExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDecimalCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDecimalCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableDoubleCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableDoubleCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDoubleExpressionMediator(NullableDoubleCoalesceFunctionExpression a) => new NullableDoubleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDoubleCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDoubleCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableEnumCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableEnumCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableEnumExpressionMediator<TEnum>(NullableEnumCoalesceFunctionExpression<TEnum> a) => new NullableEnumExpressionMediator<TEnum>(new NullableEnumExpressionMediator<TEnum>(a));
-        public static implicit operator OrderByExpression(NullableEnumCoalesceFunctionExpression<TEnum> a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableEnumCoalesceFunctionExpression<TEnum> a) => new GroupByExpression(a);
-        #endregion
-        
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
         
         #region filter operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableGuidCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableGuidCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableGuidExpressionMediator(NullableGuidCoalesceFunctionExpression a) => new NullableGuidExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableGuidCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableGuidCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableInt16CoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableInt16CoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt16ExpressionMediator(NullableInt16CoalesceFunctionExpression a) => new NullableInt16ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt16CoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt16CoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableInt32CoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableInt32CoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt32ExpressionMediator(NullableInt32CoalesceFunctionExpression a) => new NullableInt32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt32CoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt32CoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableInt64CoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableInt64CoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt64ExpressionMediator(NullableInt64CoalesceFunctionExpression a) => new NullableInt64ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt64CoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt64CoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableSingleCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableSingleCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableSingleExpressionMediator(NullableSingleCoalesceFunctionExpression a) => new NullableSingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableSingleCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableSingleCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableStringCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableStringCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableStringExpressionMediator(NullableStringCoalesceFunctionExpression a) => new NullableStringExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableStringCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableStringCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableTimeSpanCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/NullableTimeSpanCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableTimeSpanExpressionMediator(NullableTimeSpanCoalesceFunctionExpression a) => new NullableTimeSpanExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableTimeSpanCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableTimeSpanCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/ObjectCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/ObjectCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator ObjectExpressionMediator(ObjectCoalesceFunctionExpression a) => new ObjectExpressionMediator(a);
-        public static implicit operator OrderByExpression(ObjectCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(ObjectCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/SingleCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/SingleCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SingleExpressionMediator(SingleCoalesceFunctionExpression a) => new SingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(SingleCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(SingleCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/StringCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/StringCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator StringExpressionMediator(StringCoalesceFunctionExpression a) => new StringExpressionMediator(a);
-        public static implicit operator OrderByExpression(StringCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(StringCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/TimeSpanCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Coalesce/TimeSpanCoalesceFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator TimeSpanExpressionMediator(TimeSpanCoalesceFunctionExpression a) => new TimeSpanExpressionMediator(a);
-        public static implicit operator OrderByExpression(TimeSpanCoalesceFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(TimeSpanCoalesceFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Concat/StringConcatFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Concat/StringConcatFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator StringExpressionMediator(StringConcatFunctionExpression a) => new StringExpressionMediator(a);
-        public static implicit operator OrderByExpression(StringConcatFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(StringConcatFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_CurrentTimestamp/CurrentTimestampFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_CurrentTimestamp/CurrentTimestampFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DateTimeExpressionMediator(CurrentTimestampFunctionExpression a) => new DateTimeExpressionMediator(a);
-        public static implicit operator OrderByExpression(CurrentTimestampFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(CurrentTimestampFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_DateAdd/DateTimeDateAddFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_DateAdd/DateTimeDateAddFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DateTimeExpressionMediator(DateTimeDateAddFunctionExpression a) => new DateTimeExpressionMediator(a);
-        public static implicit operator OrderByExpression(DateTimeDateAddFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DateTimeDateAddFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_DateAdd/DateTimeOffsetDateAddFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_DateAdd/DateTimeOffsetDateAddFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DateTimeOffsetExpressionMediator(DateTimeOffsetDateAddFunctionExpression a) => new DateTimeOffsetExpressionMediator(a);
-        public static implicit operator OrderByExpression(DateTimeOffsetDateAddFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DateTimeOffsetDateAddFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_DateAdd/NullableDateTimeDateAddFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_DateAdd/NullableDateTimeDateAddFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDateTimeExpressionMediator(NullableDateTimeDateAddFunctionExpression a) => new NullableDateTimeExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDateTimeDateAddFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDateTimeDateAddFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_DateAdd/NullableDateTimeOffsetDateAddFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_DateAdd/NullableDateTimeOffsetDateAddFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDateTimeOffsetExpressionMediator(NullableDateTimeOffsetDateAddFunctionExpression a) => new NullableDateTimeOffsetExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDateTimeOffsetDateAddFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDateTimeOffsetDateAddFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/ByteFloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/ByteFloorFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator ByteExpressionMediator(ByteFloorFunctionExpression a) => new ByteExpressionMediator(a);
-        public static implicit operator OrderByExpression(ByteFloorFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(ByteFloorFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/DecimalFloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/DecimalFloorFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DecimalExpressionMediator(DecimalFloorFunctionExpression a) => new DecimalExpressionMediator(a);
-        public static implicit operator OrderByExpression(DecimalFloorFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DecimalFloorFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/DoubleFloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/DoubleFloorFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DoubleExpressionMediator(DoubleFloorFunctionExpression a) => new DoubleExpressionMediator(a);
-        public static implicit operator OrderByExpression(DoubleFloorFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DoubleFloorFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/Int16FloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/Int16FloorFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int16ExpressionMediator(Int16FloorFunctionExpression a) => new Int16ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int16FloorFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int16FloorFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/Int32FloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/Int32FloorFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int32ExpressionMediator(Int32FloorFunctionExpression a) => new Int32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int32FloorFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int32FloorFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/Int64FloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/Int64FloorFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int64ExpressionMediator(Int64FloorFunctionExpression a) => new Int64ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int64FloorFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int64FloorFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/NullableByteFloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/NullableByteFloorFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableByteExpressionMediator(NullableByteFloorFunctionExpression a) => new NullableByteExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableByteFloorFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableByteFloorFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/NullableDecimalFloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/NullableDecimalFloorFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDecimalExpressionMediator(NullableDecimalFloorFunctionExpression a) => new NullableDecimalExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDecimalFloorFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDecimalFloorFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/NullableDoubleFloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/NullableDoubleFloorFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDoubleExpressionMediator(NullableDoubleFloorFunctionExpression a) => new NullableDoubleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDoubleFloorFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDoubleFloorFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/NullableInt16FloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/NullableInt16FloorFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt16ExpressionMediator(NullableInt16FloorFunctionExpression a) => new NullableInt16ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt16FloorFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt16FloorFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/NullableInt32FloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/NullableInt32FloorFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt32ExpressionMediator(NullableInt32FloorFunctionExpression a) => new NullableInt32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt32FloorFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt32FloorFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/NullableInt64FloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/NullableInt64FloorFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt64ExpressionMediator(NullableInt64FloorFunctionExpression a) => new NullableInt64ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt64FloorFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt64FloorFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/NullableSingleFloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/NullableSingleFloorFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableSingleExpressionMediator(NullableSingleFloorFunctionExpression a) => new NullableSingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableSingleFloorFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableSingleFloorFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/ObjectFloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/ObjectFloorFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator ObjectExpressionMediator(ObjectFloorFunctionExpression a) => new ObjectExpressionMediator(a);
-        public static implicit operator OrderByExpression(ObjectFloorFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(ObjectFloorFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/SingleFloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Floor/SingleFloorFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SingleExpressionMediator(SingleFloorFunctionExpression a) => new SingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(SingleFloorFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(SingleFloorFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/BooleanIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/BooleanIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator BooleanExpressionMediator(BooleanIsNullFunctionExpression a) => new BooleanExpressionMediator(a);
-        public static implicit operator OrderByExpression(BooleanIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(BooleanIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/ByteIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/ByteIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator ByteExpressionMediator(ByteIsNullFunctionExpression a) => new ByteExpressionMediator(a);
-        public static implicit operator OrderByExpression(ByteIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(ByteIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/DateTimeIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/DateTimeIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DateTimeExpressionMediator(DateTimeIsNullFunctionExpression a) => new DateTimeExpressionMediator(a);
-        public static implicit operator OrderByExpression(DateTimeIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DateTimeIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/DateTimeOffsetIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/DateTimeOffsetIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DateTimeOffsetExpressionMediator(DateTimeOffsetIsNullFunctionExpression a) => new DateTimeOffsetExpressionMediator(a);
-        public static implicit operator OrderByExpression(DateTimeOffsetIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DateTimeOffsetIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/DecimalIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/DecimalIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DecimalExpressionMediator(DecimalIsNullFunctionExpression a) => new DecimalExpressionMediator(a);
-        public static implicit operator OrderByExpression(DecimalIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DecimalIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/DoubleIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/DoubleIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator DoubleExpressionMediator(DoubleIsNullFunctionExpression a) => new DoubleExpressionMediator(a);
-        public static implicit operator OrderByExpression(DoubleIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DoubleIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/EnumIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/EnumIsNullFunctionExpression.generated.cs
@@ -5,13 +5,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator EnumExpressionMediator<TEnum>(EnumIsNullFunctionExpression<TEnum> a) => new EnumExpressionMediator<TEnum>(new EnumExpressionMediator<TEnum>(a));
-        public static implicit operator OrderByExpression(EnumIsNullFunctionExpression<TEnum> a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(EnumIsNullFunctionExpression<TEnum> a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region filter operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/GuidIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/GuidIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator GuidExpressionMediator(GuidIsNullFunctionExpression a) => new GuidExpressionMediator(a);
-        public static implicit operator OrderByExpression(GuidIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(GuidIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/Int16IsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/Int16IsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int16ExpressionMediator(Int16IsNullFunctionExpression a) => new Int16ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int16IsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int16IsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/Int32IsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/Int32IsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int32ExpressionMediator(Int32IsNullFunctionExpression a) => new Int32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int32IsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int32IsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/Int64IsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/Int64IsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator Int64ExpressionMediator(Int64IsNullFunctionExpression a) => new Int64ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Int64IsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int64IsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableBooleanIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableBooleanIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableBooleanExpressionMediator(NullableBooleanIsNullFunctionExpression a) => new NullableBooleanExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableBooleanIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableBooleanIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableByteIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableByteIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableByteExpressionMediator(NullableByteIsNullFunctionExpression a) => new NullableByteExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableByteIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableByteIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableDateTimeIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableDateTimeIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDateTimeExpressionMediator(NullableDateTimeIsNullFunctionExpression a) => new NullableDateTimeExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDateTimeIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDateTimeIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableDateTimeOffsetIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableDateTimeOffsetIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDateTimeOffsetExpressionMediator(NullableDateTimeOffsetIsNullFunctionExpression a) => new NullableDateTimeOffsetExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDateTimeOffsetIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDateTimeOffsetIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableDecimalIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableDecimalIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDecimalExpressionMediator(NullableDecimalIsNullFunctionExpression a) => new NullableDecimalExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDecimalIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDecimalIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableDoubleIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableDoubleIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableDoubleExpressionMediator(NullableDoubleIsNullFunctionExpression a) => new NullableDoubleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableDoubleIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDoubleIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableEnumIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableEnumIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableEnumExpressionMediator<TEnum>(NullableEnumIsNullFunctionExpression<TEnum> a) => new NullableEnumExpressionMediator<TEnum>(new NullableEnumExpressionMediator<TEnum>(a));
-        public static implicit operator OrderByExpression(NullableEnumIsNullFunctionExpression<TEnum> a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableEnumIsNullFunctionExpression<TEnum> a) => new GroupByExpression(a);
-        #endregion
-        
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
         
         #region filter operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableGuidIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableGuidIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableGuidExpressionMediator(NullableGuidIsNullFunctionExpression a) => new NullableGuidExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableGuidIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableGuidIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableInt16IsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableInt16IsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt16ExpressionMediator(NullableInt16IsNullFunctionExpression a) => new NullableInt16ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt16IsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt16IsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableInt32IsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableInt32IsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt32ExpressionMediator(NullableInt32IsNullFunctionExpression a) => new NullableInt32ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt32IsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt32IsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableInt64IsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableInt64IsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableInt64ExpressionMediator(NullableInt64IsNullFunctionExpression a) => new NullableInt64ExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableInt64IsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt64IsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableSingleIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableSingleIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableSingleExpressionMediator(NullableSingleIsNullFunctionExpression a) => new NullableSingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableSingleIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableSingleIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableStringIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableStringIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableStringExpressionMediator(NullableStringIsNullFunctionExpression a) => new NullableStringExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableStringIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableStringIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableTimeSpanIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/NullableTimeSpanIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator NullableTimeSpanExpressionMediator(NullableTimeSpanIsNullFunctionExpression a) => new NullableTimeSpanExpressionMediator(a);
-        public static implicit operator OrderByExpression(NullableTimeSpanIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableTimeSpanIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/ObjectIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/ObjectIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator ObjectExpressionMediator(ObjectIsNullFunctionExpression a) => new ObjectExpressionMediator(a);
-        public static implicit operator OrderByExpression(ObjectIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(ObjectIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/SingleIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/SingleIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SingleExpressionMediator(SingleIsNullFunctionExpression a) => new SingleExpressionMediator(a);
-        public static implicit operator OrderByExpression(SingleIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(SingleIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/StringIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/StringIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator StringExpressionMediator(StringIsNullFunctionExpression a) => new StringExpressionMediator(a);
-        public static implicit operator OrderByExpression(StringIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(StringIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/TimeSpanIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_IsNull/TimeSpanIsNullFunctionExpression.generated.cs
@@ -6,13 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator TimeSpanExpressionMediator(TimeSpanIsNullFunctionExpression a) => new TimeSpanExpressionMediator(a);
-        public static implicit operator OrderByExpression(TimeSpanIsNullFunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(TimeSpanIsNullFunctionExpression a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/BooleanExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/BooleanExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<bool>(BooleanExpressionMediator a) => new SelectExpression<bool>(a);
-        public static implicit operator OrderByExpression(BooleanExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(BooleanExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/ByteArrayExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/ByteArrayExpressionMediator.cs
@@ -40,8 +40,6 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region implicit operators
         public static implicit operator SelectExpression<byte[]>(ByteArrayExpressionMediator a) => new SelectExpression<byte[]>(a);
-        public static implicit operator OrderByExpression(ByteArrayExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(ByteArrayExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region filter operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/ByteExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/ByteExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<byte>(ByteExpressionMediator a) => new SelectExpression<byte>(a);
-        public static implicit operator OrderByExpression(ByteExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(ByteExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/DateTimeExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/DateTimeExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<DateTime>(DateTimeExpressionMediator a) => new SelectExpression<DateTime>(a);
-        public static implicit operator OrderByExpression(DateTimeExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DateTimeExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/DateTimeOffsetExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/DateTimeOffsetExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<DateTimeOffset>(DateTimeOffsetExpressionMediator a) => new SelectExpression<DateTimeOffset>(a);
-        public static implicit operator OrderByExpression(DateTimeOffsetExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DateTimeOffsetExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/DecimalExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/DecimalExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<decimal>(DecimalExpressionMediator a) => new SelectExpression<decimal>(a);
-        public static implicit operator OrderByExpression(DecimalExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DecimalExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/DoubleExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/DoubleExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<double>(DoubleExpressionMediator a) => new SelectExpression<double>(a);
-        public static implicit operator OrderByExpression(DoubleExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(DoubleExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/EnumExpressionMediator{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/EnumExpressionMediator{T}.cs
@@ -50,8 +50,6 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region implicit operators
         public static implicit operator SelectExpression<TEnum>(EnumExpressionMediator<TEnum> a) => new SelectExpression<TEnum>(a);
-        public static implicit operator OrderByExpression(EnumExpressionMediator<TEnum> a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(EnumExpressionMediator<TEnum> a) => new GroupByExpression(a);
         #endregion
 
         #region filter operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/ExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/ExpressionMediator.cs
@@ -82,5 +82,10 @@ namespace HatTrick.DbEx.Sql.Expression
             }
         }
         #endregion
+
+        #region implicit operators
+        public static implicit operator OrderByExpression(ExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
+        public static implicit operator GroupByExpression(ExpressionMediator a) => new GroupByExpression(a);
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/GuidExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/GuidExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<Guid>(GuidExpressionMediator a) => new SelectExpression<Guid>(a);
-        public static implicit operator OrderByExpression(GuidExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(GuidExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int16ExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int16ExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<short>(Int16ExpressionMediator a) => new SelectExpression<short>(a);
-        public static implicit operator OrderByExpression(Int16ExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int16ExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int32ExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int32ExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<int>(Int32ExpressionMediator a) => new SelectExpression<int>(a);
-        public static implicit operator OrderByExpression(Int32ExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int32ExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int64ExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int64ExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<long>(Int64ExpressionMediator a) => new SelectExpression<long>(a);
-        public static implicit operator OrderByExpression(Int64ExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Int64ExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableBooleanExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableBooleanExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<bool?>(NullableBooleanExpressionMediator a) => new SelectExpression<bool?>(a);
-        public static implicit operator OrderByExpression(NullableBooleanExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableBooleanExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators 

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableByteArrayExpressionMediator.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableByteArrayExpressionMediator.cs
@@ -40,8 +40,6 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region implicit operators
         public static implicit operator SelectExpression<byte[]>(NullableByteArrayExpressionMediator a) => new SelectExpression<byte[]>(a);
-        public static implicit operator OrderByExpression(NullableByteArrayExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableByteArrayExpressionMediator a) => new GroupByExpression(a);
         #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableByteExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableByteExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<byte?>(NullableByteExpressionMediator a) => new SelectExpression<byte?>(a);
-        public static implicit operator OrderByExpression(NullableByteExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableByteExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators 

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDateTimeExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDateTimeExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<DateTime?>(NullableDateTimeExpressionMediator a) => new SelectExpression<DateTime?>(a);
-        public static implicit operator OrderByExpression(NullableDateTimeExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDateTimeExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators 

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDateTimeOffsetExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDateTimeOffsetExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<DateTimeOffset?>(NullableDateTimeOffsetExpressionMediator a) => new SelectExpression<DateTimeOffset?>(a);
-        public static implicit operator OrderByExpression(NullableDateTimeOffsetExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDateTimeOffsetExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators 

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDecimalExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDecimalExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<decimal?>(NullableDecimalExpressionMediator a) => new SelectExpression<decimal?>(a);
-        public static implicit operator OrderByExpression(NullableDecimalExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDecimalExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators 

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDoubleExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDoubleExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<double?>(NullableDoubleExpressionMediator a) => new SelectExpression<double?>(a);
-        public static implicit operator OrderByExpression(NullableDoubleExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableDoubleExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators 

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableEnumExpressionMediator{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableEnumExpressionMediator{T}.cs
@@ -46,8 +46,6 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region implicit operators
         public static implicit operator SelectExpression<TEnum>(NullableEnumExpressionMediator<TEnum> a) => new SelectExpression<TEnum>(new NullableEnumExpressionMediator<TEnum>(a));
-        public static implicit operator OrderByExpression(NullableEnumExpressionMediator<TEnum> a) => new OrderByExpression(new NullableEnumExpressionMediator<TEnum>(a), OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableEnumExpressionMediator<TEnum> a) => new GroupByExpression(new NullableEnumExpressionMediator<TEnum>(a));
         #endregion
 
         #region filter operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableGuidExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableGuidExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<Guid?>(NullableGuidExpressionMediator a) => new SelectExpression<Guid?>(a);
-        public static implicit operator OrderByExpression(NullableGuidExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableGuidExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators 

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt16ExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt16ExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<short?>(NullableInt16ExpressionMediator a) => new SelectExpression<short?>(a);
-        public static implicit operator OrderByExpression(NullableInt16ExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt16ExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators 

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt32ExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt32ExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<int?>(NullableInt32ExpressionMediator a) => new SelectExpression<int?>(a);
-        public static implicit operator OrderByExpression(NullableInt32ExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt32ExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators 

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt64ExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt64ExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<long?>(NullableInt64ExpressionMediator a) => new SelectExpression<long?>(a);
-        public static implicit operator OrderByExpression(NullableInt64ExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableInt64ExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators 

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableSingleExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableSingleExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<float?>(NullableSingleExpressionMediator a) => new SelectExpression<float?>(a);
-        public static implicit operator OrderByExpression(NullableSingleExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableSingleExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators 

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableStringExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableStringExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<string>(NullableStringExpressionMediator a) => new SelectExpression<string>(a);
-        public static implicit operator OrderByExpression(NullableStringExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableStringExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators 

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableTimeSpanExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableTimeSpanExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<TimeSpan?>(NullableTimeSpanExpressionMediator a) => new SelectExpression<TimeSpan?>(a);
-        public static implicit operator OrderByExpression(NullableTimeSpanExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(NullableTimeSpanExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators 

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/ObjectExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/ObjectExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<object>(ObjectExpressionMediator a) => new SelectExpression<object>(a);
-        public static implicit operator OrderByExpression(ObjectExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(ObjectExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/SingleExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/SingleExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<float>(SingleExpressionMediator a) => new SelectExpression<float>(a);
-        public static implicit operator OrderByExpression(SingleExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(SingleExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/StringExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/StringExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<string>(StringExpressionMediator a) => new SelectExpression<string>(a);
-        public static implicit operator OrderByExpression(StringExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(StringExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/TimeSpanExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/TimeSpanExpressionMediator.generated.cs
@@ -6,8 +6,6 @@ namespace HatTrick.DbEx.Sql.Expression
     {
         #region implicit operators
         public static implicit operator SelectExpression<TimeSpan>(TimeSpanExpressionMediator a) => new SelectExpression<TimeSpan>(a);
-        public static implicit operator OrderByExpression(TimeSpanExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(TimeSpanExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/test/HatTrick.DbEx.MsSql.Test.Code/Builder/SelectExpressionBuilderTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Code/Builder/SelectExpressionBuilderTests.cs
@@ -29,11 +29,10 @@ namespace HatTrick.DbEx.MsSql.Test.Builder
 
             //then
             expressionSet.Select.Expressions.Should().ContainSingle()
-                .Which.Expression.Should().BeOfType<Int32FieldExpression<Person>>();
+                .Which.Expression.Should().BeOfType<PersonEntity.IdField>();
 
             expressionSet.BaseEntity.Should().NotBeNull()
-                .And.BeAssignableTo<EntityExpression<Person>>()
-                .And.Equals(sec.Person);
+                .And.BeOfType<PersonEntity>();
         }
 
         [Theory]
@@ -56,14 +55,13 @@ namespace HatTrick.DbEx.MsSql.Test.Builder
             expressionSet.Select.Expressions.Should().HaveCount(2);
 
             expressionSet.Select.Expressions.Should().Contain(x => x.Expression.Equals(sec.Person.Id))
-                .Which.Expression.Should().BeOfType<Int32FieldExpression<Person>>();
+                .Which.Expression.Should().BeOfType<PersonEntity.IdField>();
 
             expressionSet.Select.Expressions.Should().ContainSingle(x => x.Expression.Equals(sec.Person.DateCreated))
-                .Which.Expression.Should().BeOfType<DateTimeOffsetFieldExpression<Person>>();
+                .Which.Expression.Should().BeOfType<PersonEntity.DateCreatedField>();
 
             expressionSet.BaseEntity.Should().NotBeNull()
-                .And.BeAssignableTo<EntityExpression<Person>>()
-                .And.Equals(sec.Person);
+                .And.BeOfType<PersonEntity>();
         }
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Code/Builder/SelectManyExpressionBuilderTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Code/Builder/SelectManyExpressionBuilderTests.cs
@@ -28,11 +28,10 @@ namespace HatTrick.DbEx.MsSql.Test.Builder
 
             //then
             expressionSet.Select.Expressions.Should().ContainSingle(x => x.Expression.Equals(sec.Person.Id))
-                .Which.Expression.Should().BeOfType<Int32FieldExpression<Person>>();
+                .Which.Expression.Should().BeOfType<PersonEntity.IdField>();
 
             expressionSet.BaseEntity.Should().NotBeNull()
-                .And.BeAssignableTo<EntityExpression<Person>>()
-                .And.Equals(sec.Person);
+                .And.BeOfType<PersonEntity>();
         }
 
         [Theory]
@@ -55,14 +54,13 @@ namespace HatTrick.DbEx.MsSql.Test.Builder
             expressionSet.Select.Expressions.Should().HaveCount(2);
 
             expressionSet.Select.Expressions.Should().ContainSingle(x => x.Expression.Equals(sec.Person.Id))
-                .Which.Expression.Should().BeOfType<Int32FieldExpression<Person>>();
+                .Which.Expression.Should().BeOfType<PersonEntity.IdField>();
 
             expressionSet.Select.Expressions.Should().ContainSingle(x => x.Expression.Equals(sec.Person.DateCreated))
-                .Which.Expression.Should().BeOfType<DateTimeOffsetFieldExpression<Person>>();
+                .Which.Expression.Should().BeOfType<PersonEntity.DateCreatedField>();
 
             expressionSet.BaseEntity.Should().NotBeNull()
-                .And.BeAssignableTo<EntityExpression<Person>>()
-                .And.Equals(sec.Person);
+                .And.BeOfType<PersonEntity>();
         }
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Code/Builder/WhereClauseExpressionBuilderTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Code/Builder/WhereClauseExpressionBuilderTests.cs
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.MsSql.Test.Builder
 
             idFilter.LeftArg
                 .Should().NotBeNull()
-                .And.BeOfType<Int32FieldExpression<Person>>()
+                .And.BeOfType<PersonEntity.IdField>()
                 .And.Be(sec.Person.Id);
 
             idFilter.RightArg
@@ -75,7 +75,7 @@ namespace HatTrick.DbEx.MsSql.Test.Builder
 
             idFilter.LeftArg
                 .Should().NotBeNull()
-                .And.BeOfType<Int32FieldExpression<Person>>()
+                .And.BeOfType<PersonEntity.IdField>()
                 .And.Be(sec.Person.Id);
 
             idFilter.RightArg
@@ -86,7 +86,7 @@ namespace HatTrick.DbEx.MsSql.Test.Builder
 
             ssnFilter.LeftArg
                 .Should().NotBeNull()
-                .And.BeOfType<StringFieldExpression<Person>>()
+                .And.BeOfType<PersonEntity.SSNField>()
                 .And.Be(sec.Person.SSN);
 
             ssnFilter.RightArg
@@ -127,7 +127,7 @@ namespace HatTrick.DbEx.MsSql.Test.Builder
 
             idFilter.LeftArg
                 .Should().NotBeNull()
-                .And.BeOfType<Int32FieldExpression<Person>>()
+                .And.BeOfType<PersonEntity.IdField>()
                 .And.Be(sec.Person.Id);
 
             idFilter.RightArg
@@ -138,7 +138,7 @@ namespace HatTrick.DbEx.MsSql.Test.Builder
 
             ssnFilter.LeftArg
                 .Should().NotBeNull()
-                .And.BeOfType<StringFieldExpression<Person>>()
+                .And.BeOfType<PersonEntity.SSNField>()
                 .And.Be(sec.Person.SSN);
 
             ssnFilter.RightArg
@@ -149,7 +149,7 @@ namespace HatTrick.DbEx.MsSql.Test.Builder
 
             dateCreatedFilter.LeftArg
                 .Should().NotBeNull()
-                .And.BeOfType<DateTimeOffsetFieldExpression<Person>>()
+                .And.BeOfType<PersonEntity.DateCreatedField>()
                 .And.Be(sec.Person.DateCreated);
 
             dateCreatedFilter.RightArg

--- a/test/HatTrick.DbEx.MsSql.Test/Generated/DbExDataService.generated.cs
+++ b/test/HatTrick.DbEx.MsSql.Test/Generated/DbExDataService.generated.cs
@@ -341,18 +341,19 @@ namespace DbEx.dboDataService
     #endregion
 
     #region address entity expression
+
     public partial class AddressEntity : EntityExpression<Address>
     {
         #region interface properties
-        public Int32FieldExpression<Address> Id { get; private set; }
-        public NullableEnumFieldExpression<Address, DbEx.Data.AddressType> AddressType { get; private set; }
-        public StringFieldExpression<Address> Line1 { get; private set; }
-        public NullableStringFieldExpression<Address> Line2 { get; private set; }
-        public StringFieldExpression<Address> City { get; private set; }
-        public StringFieldExpression<Address> State { get; private set; }
-        public StringFieldExpression<Address> Zip { get; private set; }
-        public DateTimeFieldExpression<Address> DateCreated { get; private set; }
-        public DateTimeFieldExpression<Address> DateUpdated { get; private set; }
+        public IdField Id { get; private set; }
+        public AddressTypeField AddressType { get; private set; }
+        public Line1Field Line1 { get; private set; }
+        public Line2Field Line2 { get; private set; }
+        public CityField City { get; private set; }
+        public StateField State { get; private set; }
+        public ZipField Zip { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
+        public DateUpdatedField DateUpdated { get; private set; }
         #endregion
 
         #region constructors
@@ -366,15 +367,15 @@ namespace DbEx.dboDataService
 
         private AddressEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<Address>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.AddressType", AddressType = new NullableEnumFieldExpression<Address, DbEx.Data.AddressType>($"{identifier}.AddressType", this));
-            Fields.Add($"{identifier}.Line1", Line1 = new StringFieldExpression<Address>($"{identifier}.Line1", this));
-            Fields.Add($"{identifier}.Line2", Line2 = new NullableStringFieldExpression<Address>($"{identifier}.Line2", this));
-            Fields.Add($"{identifier}.City", City = new StringFieldExpression<Address>($"{identifier}.City", this));
-            Fields.Add($"{identifier}.State", State = new StringFieldExpression<Address>($"{identifier}.State", this));
-            Fields.Add($"{identifier}.Zip", Zip = new StringFieldExpression<Address>($"{identifier}.Zip", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeFieldExpression<Address>($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateTimeFieldExpression<Address>($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.AddressType", AddressType = new AddressTypeField($"{identifier}.AddressType", this));
+            Fields.Add($"{identifier}.Line1", Line1 = new Line1Field($"{identifier}.Line1", this));
+            Fields.Add($"{identifier}.Line2", Line2 = new Line2Field($"{identifier}.Line2", this));
+            Fields.Add($"{identifier}.City", City = new CityField($"{identifier}.City", this));
+            Fields.Add($"{identifier}.State", State = new StateField($"{identifier}.State", this));
+            Fields.Add($"{identifier}.Zip", Zip = new ZipField($"{identifier}.Zip", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
         }
         #endregion
 
@@ -443,22 +444,184 @@ namespace DbEx.dboDataService
 			address.DateUpdated = reader.ReadField().GetValue<DateTime>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<Address>
+        {
+            #region constructors
+            public IdField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region address type field expression
+        public partial class AddressTypeField : NullableEnumFieldExpression<Address, DbEx.Data.AddressType>
+        {
+            #region constructors
+            public AddressTypeField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DbEx.Data.AddressType value) => new AssignmentExpression(this, new LiteralExpression<DbEx.Data.AddressType>(value));
+            public AssignmentExpression Set(EnumElement<DbEx.Data.AddressType> value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DbEx.Data.AddressType? value) => new AssignmentExpression(this, new LiteralExpression<DbEx.Data.AddressType?>(value));
+            public AssignmentExpression Set(NullableEnumElement<DbEx.Data.AddressType> value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region line1 field expression
+        public partial class Line1Field : StringFieldExpression<Address>
+        {
+            #region constructors
+            public Line1Field(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region line2 field expression
+        public partial class Line2Field : NullableStringFieldExpression<Address>
+        {
+            #region constructors
+            public Line2Field(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(NullableStringElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region city field expression
+        public partial class CityField : StringFieldExpression<Address>
+        {
+            #region constructors
+            public CityField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region state field expression
+        public partial class StateField : StringFieldExpression<Address>
+        {
+            #region constructors
+            public StateField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region zip field expression
+        public partial class ZipField : StringFieldExpression<Address>
+        {
+            #region constructors
+            public ZipField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeFieldExpression<Address>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date updated field expression
+        public partial class DateUpdatedField : DateTimeFieldExpression<Address>
+        {
+            #region constructors
+            public DateUpdatedField(string identifier, AddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
     #region person entity expression
+
     public partial class PersonEntity : EntityExpression<Person>
     {
         #region interface properties
-        public Int32FieldExpression<Person> Id { get; private set; }
-        public StringFieldExpression<Person> FirstName { get; private set; }
-        public StringFieldExpression<Person> LastName { get; private set; }
-        public NullableDateTimeFieldExpression<Person> BirthDate { get; private set; }
-        public EnumFieldExpression<Person, DbEx.Data.GenderType> GenderType { get; private set; }
-        public NullableInt32FieldExpression<Person> CreditLimit { get; private set; }
-        public NullableInt32FieldExpression<Person> YearOfLastCreditLimitReview { get; private set; }
-        public DateTimeFieldExpression<Person> DateCreated { get; private set; }
-        public DateTimeFieldExpression<Person> DateUpdated { get; private set; }
+        public IdField Id { get; private set; }
+        public FirstNameField FirstName { get; private set; }
+        public LastNameField LastName { get; private set; }
+        public BirthDateField BirthDate { get; private set; }
+        public GenderTypeField GenderType { get; private set; }
+        public CreditLimitField CreditLimit { get; private set; }
+        public YearOfLastCreditLimitReviewField YearOfLastCreditLimitReview { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
+        public DateUpdatedField DateUpdated { get; private set; }
         #endregion
 
         #region constructors
@@ -472,15 +635,15 @@ namespace DbEx.dboDataService
 
         private PersonEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<Person>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.FirstName", FirstName = new StringFieldExpression<Person>($"{identifier}.FirstName", this));
-            Fields.Add($"{identifier}.LastName", LastName = new StringFieldExpression<Person>($"{identifier}.LastName", this));
-            Fields.Add($"{identifier}.BirthDate", BirthDate = new NullableDateTimeFieldExpression<Person>($"{identifier}.BirthDate", this));
-            Fields.Add($"{identifier}.GenderType", GenderType = new EnumFieldExpression<Person, DbEx.Data.GenderType>($"{identifier}.GenderType", this));
-            Fields.Add($"{identifier}.CreditLimit", CreditLimit = new NullableInt32FieldExpression<Person>($"{identifier}.CreditLimit", this));
-            Fields.Add($"{identifier}.YearOfLastCreditLimitReview", YearOfLastCreditLimitReview = new NullableInt32FieldExpression<Person>($"{identifier}.YearOfLastCreditLimitReview", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeFieldExpression<Person>($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateTimeFieldExpression<Person>($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.FirstName", FirstName = new FirstNameField($"{identifier}.FirstName", this));
+            Fields.Add($"{identifier}.LastName", LastName = new LastNameField($"{identifier}.LastName", this));
+            Fields.Add($"{identifier}.BirthDate", BirthDate = new BirthDateField($"{identifier}.BirthDate", this));
+            Fields.Add($"{identifier}.GenderType", GenderType = new GenderTypeField($"{identifier}.GenderType", this));
+            Fields.Add($"{identifier}.CreditLimit", CreditLimit = new CreditLimitField($"{identifier}.CreditLimit", this));
+            Fields.Add($"{identifier}.YearOfLastCreditLimitReview", YearOfLastCreditLimitReview = new YearOfLastCreditLimitReviewField($"{identifier}.YearOfLastCreditLimitReview", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
         }
         #endregion
 
@@ -549,17 +712,183 @@ namespace DbEx.dboDataService
 			person.DateUpdated = reader.ReadField().GetValue<DateTime>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<Person>
+        {
+            #region constructors
+            public IdField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region first name field expression
+        public partial class FirstNameField : StringFieldExpression<Person>
+        {
+            #region constructors
+            public FirstNameField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region last name field expression
+        public partial class LastNameField : StringFieldExpression<Person>
+        {
+            #region constructors
+            public LastNameField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region birth date field expression
+        public partial class BirthDateField : NullableDateTimeFieldExpression<Person>
+        {
+            #region constructors
+            public BirthDateField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DateTime? value) => new AssignmentExpression(this, new LiteralExpression<DateTime?>(value));
+            public AssignmentExpression Set(NullableDateTimeElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region gender type field expression
+        public partial class GenderTypeField : EnumFieldExpression<Person, DbEx.Data.GenderType>
+        {
+            #region constructors
+            public GenderTypeField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DbEx.Data.GenderType value) => new AssignmentExpression(this, new LiteralExpression<DbEx.Data.GenderType>(value));
+            public AssignmentExpression Set(EnumElement<DbEx.Data.GenderType> value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region credit limit field expression
+        public partial class CreditLimitField : NullableInt32FieldExpression<Person>
+        {
+            #region constructors
+            public CreditLimitField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(int? value) => new AssignmentExpression(this, new LiteralExpression<int?>(value));
+            public AssignmentExpression Set(NullableInt32Element value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region year of last credit limit review field expression
+        public partial class YearOfLastCreditLimitReviewField : NullableInt32FieldExpression<Person>
+        {
+            #region constructors
+            public YearOfLastCreditLimitReviewField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(int? value) => new AssignmentExpression(this, new LiteralExpression<int?>(value));
+            public AssignmentExpression Set(NullableInt32Element value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeFieldExpression<Person>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date updated field expression
+        public partial class DateUpdatedField : DateTimeFieldExpression<Person>
+        {
+            #region constructors
+            public DateUpdatedField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
     #region person address entity expression
+
     public partial class PersonAddressEntity : EntityExpression<PersonAddress>
     {
         #region interface properties
-        public Int32FieldExpression<PersonAddress> Id { get; private set; }
-        public Int32FieldExpression<PersonAddress> PersonId { get; private set; }
-        public Int32FieldExpression<PersonAddress> AddressId { get; private set; }
-        public DateTimeFieldExpression<PersonAddress> DateCreated { get; private set; }
+        public IdField Id { get; private set; }
+        public PersonIdField PersonId { get; private set; }
+        public AddressIdField AddressId { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
         #endregion
 
         #region constructors
@@ -573,10 +902,10 @@ namespace DbEx.dboDataService
 
         private PersonAddressEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<PersonAddress>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.PersonId", PersonId = new Int32FieldExpression<PersonAddress>($"{identifier}.PersonId", this));
-            Fields.Add($"{identifier}.AddressId", AddressId = new Int32FieldExpression<PersonAddress>($"{identifier}.AddressId", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeFieldExpression<PersonAddress>($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.PersonId", PersonId = new PersonIdField($"{identifier}.PersonId", this));
+            Fields.Add($"{identifier}.AddressId", AddressId = new AddressIdField($"{identifier}.AddressId", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
         }
         #endregion
 
@@ -625,30 +954,102 @@ namespace DbEx.dboDataService
 			personAddress.DateCreated = reader.ReadField().GetValue<DateTime>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<PersonAddress>
+        {
+            #region constructors
+            public IdField(string identifier, PersonAddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region person id field expression
+        public partial class PersonIdField : Int32FieldExpression<PersonAddress>
+        {
+            #region constructors
+            public PersonIdField(string identifier, PersonAddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region address id field expression
+        public partial class AddressIdField : Int32FieldExpression<PersonAddress>
+        {
+            #region constructors
+            public AddressIdField(string identifier, PersonAddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeFieldExpression<PersonAddress>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, PersonAddressEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
     #region product entity expression
+
     public partial class ProductEntity : EntityExpression<Product>
     {
         #region interface properties
-        public Int32FieldExpression<Product> Id { get; private set; }
-        public NullableEnumFieldExpression<Product, DbEx.Data.ProductCategoryType> ProductCategoryType { get; private set; }
-        public StringFieldExpression<Product> Name { get; private set; }
-        public NullableStringFieldExpression<Product> Description { get; private set; }
-        public DoubleFieldExpression<Product> ListPrice { get; private set; }
-        public DoubleFieldExpression<Product> Price { get; private set; }
-        public Int32FieldExpression<Product> Quantity { get; private set; }
-        public NullableByteArrayFieldExpression<Product> Image { get; private set; }
-        public NullableDecimalFieldExpression<Product> Height { get; private set; }
-        public NullableDecimalFieldExpression<Product> Width { get; private set; }
-        public NullableDecimalFieldExpression<Product> Depth { get; private set; }
-        public NullableDecimalFieldExpression<Product> Weight { get; private set; }
-        public DecimalFieldExpression<Product> ShippingWeight { get; private set; }
-        public NullableTimeSpanFieldExpression<Product> ValidStartTimeOfDayForPurchase { get; private set; }
-        public NullableTimeSpanFieldExpression<Product> ValidEndTimeOfDayForPurchase { get; private set; }
-        public DateTimeFieldExpression<Product> DateCreated { get; private set; }
-        public DateTimeFieldExpression<Product> DateUpdated { get; private set; }
+        public IdField Id { get; private set; }
+        public ProductCategoryTypeField ProductCategoryType { get; private set; }
+        public NameField Name { get; private set; }
+        public DescriptionField Description { get; private set; }
+        public ListPriceField ListPrice { get; private set; }
+        public PriceField Price { get; private set; }
+        public QuantityField Quantity { get; private set; }
+        public ImageField Image { get; private set; }
+        public HeightField Height { get; private set; }
+        public WidthField Width { get; private set; }
+        public DepthField Depth { get; private set; }
+        public WeightField Weight { get; private set; }
+        public ShippingWeightField ShippingWeight { get; private set; }
+        public ValidStartTimeOfDayForPurchaseField ValidStartTimeOfDayForPurchase { get; private set; }
+        public ValidEndTimeOfDayForPurchaseField ValidEndTimeOfDayForPurchase { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
+        public DateUpdatedField DateUpdated { get; private set; }
         #endregion
 
         #region constructors
@@ -662,23 +1063,23 @@ namespace DbEx.dboDataService
 
         private ProductEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<Product>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.ProductCategoryType", ProductCategoryType = new NullableEnumFieldExpression<Product, DbEx.Data.ProductCategoryType>($"{identifier}.ProductCategoryType", this));
-            Fields.Add($"{identifier}.Name", Name = new StringFieldExpression<Product>($"{identifier}.Name", this));
-            Fields.Add($"{identifier}.Description", Description = new NullableStringFieldExpression<Product>($"{identifier}.Description", this));
-            Fields.Add($"{identifier}.ListPrice", ListPrice = new DoubleFieldExpression<Product>($"{identifier}.ListPrice", this));
-            Fields.Add($"{identifier}.Price", Price = new DoubleFieldExpression<Product>($"{identifier}.Price", this));
-            Fields.Add($"{identifier}.Quantity", Quantity = new Int32FieldExpression<Product>($"{identifier}.Quantity", this));
-            Fields.Add($"{identifier}.Image", Image = new NullableByteArrayFieldExpression<Product>($"{identifier}.Image", this));
-            Fields.Add($"{identifier}.Height", Height = new NullableDecimalFieldExpression<Product>($"{identifier}.Height", this));
-            Fields.Add($"{identifier}.Width", Width = new NullableDecimalFieldExpression<Product>($"{identifier}.Width", this));
-            Fields.Add($"{identifier}.Depth", Depth = new NullableDecimalFieldExpression<Product>($"{identifier}.Depth", this));
-            Fields.Add($"{identifier}.Weight", Weight = new NullableDecimalFieldExpression<Product>($"{identifier}.Weight", this));
-            Fields.Add($"{identifier}.ShippingWeight", ShippingWeight = new DecimalFieldExpression<Product>($"{identifier}.ShippingWeight", this));
-            Fields.Add($"{identifier}.ValidStartTimeOfDayForPurchase", ValidStartTimeOfDayForPurchase = new NullableTimeSpanFieldExpression<Product>($"{identifier}.ValidStartTimeOfDayForPurchase", this));
-            Fields.Add($"{identifier}.ValidEndTimeOfDayForPurchase", ValidEndTimeOfDayForPurchase = new NullableTimeSpanFieldExpression<Product>($"{identifier}.ValidEndTimeOfDayForPurchase", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeFieldExpression<Product>($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateTimeFieldExpression<Product>($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.ProductCategoryType", ProductCategoryType = new ProductCategoryTypeField($"{identifier}.ProductCategoryType", this));
+            Fields.Add($"{identifier}.Name", Name = new NameField($"{identifier}.Name", this));
+            Fields.Add($"{identifier}.Description", Description = new DescriptionField($"{identifier}.Description", this));
+            Fields.Add($"{identifier}.ListPrice", ListPrice = new ListPriceField($"{identifier}.ListPrice", this));
+            Fields.Add($"{identifier}.Price", Price = new PriceField($"{identifier}.Price", this));
+            Fields.Add($"{identifier}.Quantity", Quantity = new QuantityField($"{identifier}.Quantity", this));
+            Fields.Add($"{identifier}.Image", Image = new ImageField($"{identifier}.Image", this));
+            Fields.Add($"{identifier}.Height", Height = new HeightField($"{identifier}.Height", this));
+            Fields.Add($"{identifier}.Width", Width = new WidthField($"{identifier}.Width", this));
+            Fields.Add($"{identifier}.Depth", Depth = new DepthField($"{identifier}.Depth", this));
+            Fields.Add($"{identifier}.Weight", Weight = new WeightField($"{identifier}.Weight", this));
+            Fields.Add($"{identifier}.ShippingWeight", ShippingWeight = new ShippingWeightField($"{identifier}.ShippingWeight", this));
+            Fields.Add($"{identifier}.ValidStartTimeOfDayForPurchase", ValidStartTimeOfDayForPurchase = new ValidStartTimeOfDayForPurchaseField($"{identifier}.ValidStartTimeOfDayForPurchase", this));
+            Fields.Add($"{identifier}.ValidEndTimeOfDayForPurchase", ValidEndTimeOfDayForPurchase = new ValidEndTimeOfDayForPurchaseField($"{identifier}.ValidEndTimeOfDayForPurchase", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
         }
         #endregion
 
@@ -779,26 +1180,344 @@ namespace DbEx.dboDataService
 			product.DateUpdated = reader.ReadField().GetValue<DateTime>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<Product>
+        {
+            #region constructors
+            public IdField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region product category type field expression
+        public partial class ProductCategoryTypeField : NullableEnumFieldExpression<Product, DbEx.Data.ProductCategoryType>
+        {
+            #region constructors
+            public ProductCategoryTypeField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DbEx.Data.ProductCategoryType value) => new AssignmentExpression(this, new LiteralExpression<DbEx.Data.ProductCategoryType>(value));
+            public AssignmentExpression Set(EnumElement<DbEx.Data.ProductCategoryType> value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DbEx.Data.ProductCategoryType? value) => new AssignmentExpression(this, new LiteralExpression<DbEx.Data.ProductCategoryType?>(value));
+            public AssignmentExpression Set(NullableEnumElement<DbEx.Data.ProductCategoryType> value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region name field expression
+        public partial class NameField : StringFieldExpression<Product>
+        {
+            #region constructors
+            public NameField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region description field expression
+        public partial class DescriptionField : NullableStringFieldExpression<Product>
+        {
+            #region constructors
+            public DescriptionField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(NullableStringElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region list price field expression
+        public partial class ListPriceField : DoubleFieldExpression<Product>
+        {
+            #region constructors
+            public ListPriceField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(double value) => new AssignmentExpression(this, new LiteralExpression<double>(value));
+            public AssignmentExpression Set(DoubleElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region price field expression
+        public partial class PriceField : DoubleFieldExpression<Product>
+        {
+            #region constructors
+            public PriceField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(double value) => new AssignmentExpression(this, new LiteralExpression<double>(value));
+            public AssignmentExpression Set(DoubleElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region quantity field expression
+        public partial class QuantityField : Int32FieldExpression<Product>
+        {
+            #region constructors
+            public QuantityField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region image field expression
+        public partial class ImageField : NullableByteArrayFieldExpression<Product>
+        {
+            #region constructors
+            public ImageField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(byte[] value) => new AssignmentExpression(this, new LiteralExpression<byte[]>(value));
+            public AssignmentExpression Set(ByteArrayElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(NullableByteArrayElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region height field expression
+        public partial class HeightField : NullableDecimalFieldExpression<Product>
+        {
+            #region constructors
+            public HeightField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(decimal value) => new AssignmentExpression(this, new LiteralExpression<decimal>(value));
+            public AssignmentExpression Set(DecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(decimal? value) => new AssignmentExpression(this, new LiteralExpression<decimal?>(value));
+            public AssignmentExpression Set(NullableDecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region width field expression
+        public partial class WidthField : NullableDecimalFieldExpression<Product>
+        {
+            #region constructors
+            public WidthField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(decimal value) => new AssignmentExpression(this, new LiteralExpression<decimal>(value));
+            public AssignmentExpression Set(DecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(decimal? value) => new AssignmentExpression(this, new LiteralExpression<decimal?>(value));
+            public AssignmentExpression Set(NullableDecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region depth field expression
+        public partial class DepthField : NullableDecimalFieldExpression<Product>
+        {
+            #region constructors
+            public DepthField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(decimal value) => new AssignmentExpression(this, new LiteralExpression<decimal>(value));
+            public AssignmentExpression Set(DecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(decimal? value) => new AssignmentExpression(this, new LiteralExpression<decimal?>(value));
+            public AssignmentExpression Set(NullableDecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region weight field expression
+        public partial class WeightField : NullableDecimalFieldExpression<Product>
+        {
+            #region constructors
+            public WeightField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(decimal value) => new AssignmentExpression(this, new LiteralExpression<decimal>(value));
+            public AssignmentExpression Set(DecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(decimal? value) => new AssignmentExpression(this, new LiteralExpression<decimal?>(value));
+            public AssignmentExpression Set(NullableDecimalElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region shipping weight field expression
+        public partial class ShippingWeightField : DecimalFieldExpression<Product>
+        {
+            #region constructors
+            public ShippingWeightField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(decimal value) => new AssignmentExpression(this, new LiteralExpression<decimal>(value));
+            public AssignmentExpression Set(DecimalElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region valid start time of day for purchase field expression
+        public partial class ValidStartTimeOfDayForPurchaseField : NullableTimeSpanFieldExpression<Product>
+        {
+            #region constructors
+            public ValidStartTimeOfDayForPurchaseField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(TimeSpan value) => new AssignmentExpression(this, new LiteralExpression<TimeSpan>(value));
+            public AssignmentExpression Set(TimeSpanElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(TimeSpan? value) => new AssignmentExpression(this, new LiteralExpression<TimeSpan?>(value));
+            public AssignmentExpression Set(NullableTimeSpanElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region valid end time of day for purchase field expression
+        public partial class ValidEndTimeOfDayForPurchaseField : NullableTimeSpanFieldExpression<Product>
+        {
+            #region constructors
+            public ValidEndTimeOfDayForPurchaseField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(TimeSpan value) => new AssignmentExpression(this, new LiteralExpression<TimeSpan>(value));
+            public AssignmentExpression Set(TimeSpanElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(TimeSpan? value) => new AssignmentExpression(this, new LiteralExpression<TimeSpan?>(value));
+            public AssignmentExpression Set(NullableTimeSpanElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeFieldExpression<Product>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date updated field expression
+        public partial class DateUpdatedField : DateTimeFieldExpression<Product>
+        {
+            #region constructors
+            public DateUpdatedField(string identifier, ProductEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
     #region purchase entity expression
+
     public partial class PurchaseEntity : EntityExpression<Purchase>
     {
         #region interface properties
-        public Int32FieldExpression<Purchase> Id { get; private set; }
-        public Int32FieldExpression<Purchase> PersonId { get; private set; }
-        public StringFieldExpression<Purchase> OrderNumber { get; private set; }
-        public StringFieldExpression<Purchase> TotalPurchaseQuantity { get; private set; }
-        public DoubleFieldExpression<Purchase> TotalPurchaseAmount { get; private set; }
-        public DateTimeFieldExpression<Purchase> PurchaseDate { get; private set; }
-        public NullableDateTimeFieldExpression<Purchase> ShipDate { get; private set; }
-        public NullableDateTimeFieldExpression<Purchase> ExpectedDeliveryDate { get; private set; }
-        public NullableGuidFieldExpression<Purchase> TrackingIdentifier { get; private set; }
-        public EnumFieldExpression<Purchase, DbEx.Data.PaymentMethodType> PaymentMethodType { get; private set; }
-        public NullableEnumFieldExpression<Purchase, DbEx.Data.PaymentSourceType> PaymentSourceType { get; private set; }
-        public DateTimeFieldExpression<Purchase> DateCreated { get; private set; }
-        public DateTimeFieldExpression<Purchase> DateUpdated { get; private set; }
+        public IdField Id { get; private set; }
+        public PersonIdField PersonId { get; private set; }
+        public OrderNumberField OrderNumber { get; private set; }
+        public TotalPurchaseQuantityField TotalPurchaseQuantity { get; private set; }
+        public TotalPurchaseAmountField TotalPurchaseAmount { get; private set; }
+        public PurchaseDateField PurchaseDate { get; private set; }
+        public ShipDateField ShipDate { get; private set; }
+        public ExpectedDeliveryDateField ExpectedDeliveryDate { get; private set; }
+        public TrackingIdentifierField TrackingIdentifier { get; private set; }
+        public PaymentMethodTypeField PaymentMethodType { get; private set; }
+        public PaymentSourceTypeField PaymentSourceType { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
+        public DateUpdatedField DateUpdated { get; private set; }
         #endregion
 
         #region constructors
@@ -812,19 +1531,19 @@ namespace DbEx.dboDataService
 
         private PurchaseEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<Purchase>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.PersonId", PersonId = new Int32FieldExpression<Purchase>($"{identifier}.PersonId", this));
-            Fields.Add($"{identifier}.OrderNumber", OrderNumber = new StringFieldExpression<Purchase>($"{identifier}.OrderNumber", this));
-            Fields.Add($"{identifier}.TotalPurchaseQuantity", TotalPurchaseQuantity = new StringFieldExpression<Purchase>($"{identifier}.TotalPurchaseQuantity", this));
-            Fields.Add($"{identifier}.TotalPurchaseAmount", TotalPurchaseAmount = new DoubleFieldExpression<Purchase>($"{identifier}.TotalPurchaseAmount", this));
-            Fields.Add($"{identifier}.PurchaseDate", PurchaseDate = new DateTimeFieldExpression<Purchase>($"{identifier}.PurchaseDate", this));
-            Fields.Add($"{identifier}.ShipDate", ShipDate = new NullableDateTimeFieldExpression<Purchase>($"{identifier}.ShipDate", this));
-            Fields.Add($"{identifier}.ExpectedDeliveryDate", ExpectedDeliveryDate = new NullableDateTimeFieldExpression<Purchase>($"{identifier}.ExpectedDeliveryDate", this));
-            Fields.Add($"{identifier}.TrackingIdentifier", TrackingIdentifier = new NullableGuidFieldExpression<Purchase>($"{identifier}.TrackingIdentifier", this));
-            Fields.Add($"{identifier}.PaymentMethodType", PaymentMethodType = new EnumFieldExpression<Purchase, DbEx.Data.PaymentMethodType>($"{identifier}.PaymentMethodType", this));
-            Fields.Add($"{identifier}.PaymentSourceType", PaymentSourceType = new NullableEnumFieldExpression<Purchase, DbEx.Data.PaymentSourceType>($"{identifier}.PaymentSourceType", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeFieldExpression<Purchase>($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateTimeFieldExpression<Purchase>($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.PersonId", PersonId = new PersonIdField($"{identifier}.PersonId", this));
+            Fields.Add($"{identifier}.OrderNumber", OrderNumber = new OrderNumberField($"{identifier}.OrderNumber", this));
+            Fields.Add($"{identifier}.TotalPurchaseQuantity", TotalPurchaseQuantity = new TotalPurchaseQuantityField($"{identifier}.TotalPurchaseQuantity", this));
+            Fields.Add($"{identifier}.TotalPurchaseAmount", TotalPurchaseAmount = new TotalPurchaseAmountField($"{identifier}.TotalPurchaseAmount", this));
+            Fields.Add($"{identifier}.PurchaseDate", PurchaseDate = new PurchaseDateField($"{identifier}.PurchaseDate", this));
+            Fields.Add($"{identifier}.ShipDate", ShipDate = new ShipDateField($"{identifier}.ShipDate", this));
+            Fields.Add($"{identifier}.ExpectedDeliveryDate", ExpectedDeliveryDate = new ExpectedDeliveryDateField($"{identifier}.ExpectedDeliveryDate", this));
+            Fields.Add($"{identifier}.TrackingIdentifier", TrackingIdentifier = new TrackingIdentifierField($"{identifier}.TrackingIdentifier", this));
+            Fields.Add($"{identifier}.PaymentMethodType", PaymentMethodType = new PaymentMethodTypeField($"{identifier}.PaymentMethodType", this));
+            Fields.Add($"{identifier}.PaymentSourceType", PaymentSourceType = new PaymentSourceTypeField($"{identifier}.PaymentSourceType", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
         }
         #endregion
 
@@ -909,20 +1628,257 @@ namespace DbEx.dboDataService
 			purchase.DateUpdated = reader.ReadField().GetValue<DateTime>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<Purchase>
+        {
+            #region constructors
+            public IdField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region person id field expression
+        public partial class PersonIdField : Int32FieldExpression<Purchase>
+        {
+            #region constructors
+            public PersonIdField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region order number field expression
+        public partial class OrderNumberField : StringFieldExpression<Purchase>
+        {
+            #region constructors
+            public OrderNumberField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region total purchase quantity field expression
+        public partial class TotalPurchaseQuantityField : StringFieldExpression<Purchase>
+        {
+            #region constructors
+            public TotalPurchaseQuantityField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region total purchase amount field expression
+        public partial class TotalPurchaseAmountField : DoubleFieldExpression<Purchase>
+        {
+            #region constructors
+            public TotalPurchaseAmountField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(double value) => new AssignmentExpression(this, new LiteralExpression<double>(value));
+            public AssignmentExpression Set(DoubleElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region purchase date field expression
+        public partial class PurchaseDateField : DateTimeFieldExpression<Purchase>
+        {
+            #region constructors
+            public PurchaseDateField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region ship date field expression
+        public partial class ShipDateField : NullableDateTimeFieldExpression<Purchase>
+        {
+            #region constructors
+            public ShipDateField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DateTime? value) => new AssignmentExpression(this, new LiteralExpression<DateTime?>(value));
+            public AssignmentExpression Set(NullableDateTimeElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region expected delivery date field expression
+        public partial class ExpectedDeliveryDateField : NullableDateTimeFieldExpression<Purchase>
+        {
+            #region constructors
+            public ExpectedDeliveryDateField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DateTime? value) => new AssignmentExpression(this, new LiteralExpression<DateTime?>(value));
+            public AssignmentExpression Set(NullableDateTimeElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region tracking identifier field expression
+        public partial class TrackingIdentifierField : NullableGuidFieldExpression<Purchase>
+        {
+            #region constructors
+            public TrackingIdentifierField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(Guid value) => new AssignmentExpression(this, new LiteralExpression<Guid>(value));
+            public AssignmentExpression Set(GuidElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(Guid? value) => new AssignmentExpression(this, new LiteralExpression<Guid?>(value));
+            public AssignmentExpression Set(NullableGuidElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region payment method type field expression
+        public partial class PaymentMethodTypeField : EnumFieldExpression<Purchase, DbEx.Data.PaymentMethodType>
+        {
+            #region constructors
+            public PaymentMethodTypeField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DbEx.Data.PaymentMethodType value) => new AssignmentExpression(this, new LiteralExpression<DbEx.Data.PaymentMethodType>(value));
+            public AssignmentExpression Set(EnumElement<DbEx.Data.PaymentMethodType> value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region payment source type field expression
+        public partial class PaymentSourceTypeField : NullableEnumFieldExpression<Purchase, DbEx.Data.PaymentSourceType>
+        {
+            #region constructors
+            public PaymentSourceTypeField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DbEx.Data.PaymentSourceType value) => new AssignmentExpression(this, new LiteralExpression<DbEx.Data.PaymentSourceType>(value));
+            public AssignmentExpression Set(EnumElement<DbEx.Data.PaymentSourceType> value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DbEx.Data.PaymentSourceType? value) => new AssignmentExpression(this, new LiteralExpression<DbEx.Data.PaymentSourceType?>(value));
+            public AssignmentExpression Set(NullableEnumElement<DbEx.Data.PaymentSourceType> value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeFieldExpression<Purchase>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date updated field expression
+        public partial class DateUpdatedField : DateTimeFieldExpression<Purchase>
+        {
+            #region constructors
+            public DateUpdatedField(string identifier, PurchaseEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
     #region purchase line entity expression
+
     public partial class PurchaseLineEntity : EntityExpression<PurchaseLine>
     {
         #region interface properties
-        public Int32FieldExpression<PurchaseLine> Id { get; private set; }
-        public Int32FieldExpression<PurchaseLine> PurchaseId { get; private set; }
-        public Int32FieldExpression<PurchaseLine> ProductId { get; private set; }
-        public DecimalFieldExpression<PurchaseLine> PurchasePrice { get; private set; }
-        public Int32FieldExpression<PurchaseLine> Quantity { get; private set; }
-        public DateTimeFieldExpression<PurchaseLine> DateCreated { get; private set; }
-        public DateTimeFieldExpression<PurchaseLine> DateUpdated { get; private set; }
+        public IdField Id { get; private set; }
+        public PurchaseIdField PurchaseId { get; private set; }
+        public ProductIdField ProductId { get; private set; }
+        public PurchasePriceField PurchasePrice { get; private set; }
+        public QuantityField Quantity { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
+        public DateUpdatedField DateUpdated { get; private set; }
         #endregion
 
         #region constructors
@@ -936,13 +1892,13 @@ namespace DbEx.dboDataService
 
         private PurchaseLineEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<PurchaseLine>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.PurchaseId", PurchaseId = new Int32FieldExpression<PurchaseLine>($"{identifier}.PurchaseId", this));
-            Fields.Add($"{identifier}.ProductId", ProductId = new Int32FieldExpression<PurchaseLine>($"{identifier}.ProductId", this));
-            Fields.Add($"{identifier}.PurchasePrice", PurchasePrice = new DecimalFieldExpression<PurchaseLine>($"{identifier}.PurchasePrice", this));
-            Fields.Add($"{identifier}.Quantity", Quantity = new Int32FieldExpression<PurchaseLine>($"{identifier}.Quantity", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeFieldExpression<PurchaseLine>($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateTimeFieldExpression<PurchaseLine>($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.PurchaseId", PurchaseId = new PurchaseIdField($"{identifier}.PurchaseId", this));
+            Fields.Add($"{identifier}.ProductId", ProductId = new ProductIdField($"{identifier}.ProductId", this));
+            Fields.Add($"{identifier}.PurchasePrice", PurchasePrice = new PurchasePriceField($"{identifier}.PurchasePrice", this));
+            Fields.Add($"{identifier}.Quantity", Quantity = new QuantityField($"{identifier}.Quantity", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
         }
         #endregion
 
@@ -1003,16 +1959,139 @@ namespace DbEx.dboDataService
 			purchaseLine.DateUpdated = reader.ReadField().GetValue<DateTime>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public IdField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region purchase id field expression
+        public partial class PurchaseIdField : Int32FieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public PurchaseIdField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region product id field expression
+        public partial class ProductIdField : Int32FieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public ProductIdField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region purchase price field expression
+        public partial class PurchasePriceField : DecimalFieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public PurchasePriceField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(decimal value) => new AssignmentExpression(this, new LiteralExpression<decimal>(value));
+            public AssignmentExpression Set(DecimalElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region quantity field expression
+        public partial class QuantityField : Int32FieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public QuantityField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeFieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date updated field expression
+        public partial class DateUpdatedField : DateTimeFieldExpression<PurchaseLine>
+        {
+            #region constructors
+            public DateUpdatedField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTime value) => new AssignmentExpression(this, new LiteralExpression<DateTime>(value));
+            public AssignmentExpression Set(DateTimeElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
     #region person total purchases view entity expression
+
     public partial class PersonTotalPurchasesViewEntity : EntityExpression<PersonTotalPurchasesView>
     {
         #region interface properties
-        public Int32FieldExpression<PersonTotalPurchasesView> Id { get; private set; }
-        public NullableDoubleFieldExpression<PersonTotalPurchasesView> TotalAmount { get; private set; }
-        public NullableInt32FieldExpression<PersonTotalPurchasesView> TotalCount { get; private set; }
+        public IdField Id { get; private set; }
+        public TotalAmountField TotalAmount { get; private set; }
+        public TotalCountField TotalCount { get; private set; }
         #endregion
 
         #region constructors
@@ -1026,9 +2105,9 @@ namespace DbEx.dboDataService
 
         private PersonTotalPurchasesViewEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<PersonTotalPurchasesView>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.TotalAmount", TotalAmount = new NullableDoubleFieldExpression<PersonTotalPurchasesView>($"{identifier}.TotalAmount", this));
-            Fields.Add($"{identifier}.TotalCount", TotalCount = new NullableInt32FieldExpression<PersonTotalPurchasesView>($"{identifier}.TotalCount", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.TotalAmount", TotalAmount = new TotalAmountField($"{identifier}.TotalAmount", this));
+            Fields.Add($"{identifier}.TotalCount", TotalCount = new TotalCountField($"{identifier}.TotalCount", this));
         }
         #endregion
 
@@ -1074,6 +2153,66 @@ namespace DbEx.dboDataService
 			personTotalPurchasesView.TotalCount = reader.ReadField().GetValue<int?>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<PersonTotalPurchasesView>
+        {
+            #region constructors
+            public IdField(string identifier, PersonTotalPurchasesViewEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region total amount field expression
+        public partial class TotalAmountField : NullableDoubleFieldExpression<PersonTotalPurchasesView>
+        {
+            #region constructors
+            public TotalAmountField(string identifier, PersonTotalPurchasesViewEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(double value) => new AssignmentExpression(this, new LiteralExpression<double>(value));
+            public AssignmentExpression Set(DoubleElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(double? value) => new AssignmentExpression(this, new LiteralExpression<double?>(value));
+            public AssignmentExpression Set(NullableDoubleElement value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #region total count field expression
+        public partial class TotalCountField : NullableInt32FieldExpression<PersonTotalPurchasesView>
+        {
+            #region constructors
+            public TotalCountField(string identifier, PersonTotalPurchasesViewEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(int? value) => new AssignmentExpression(this, new LiteralExpression<int?>(value));
+            public AssignmentExpression Set(NullableInt32Element value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 
@@ -1128,13 +2267,14 @@ namespace DbEx.secDataService
     #endregion
 
     #region person entity expression
+
     public partial class PersonEntity : EntityExpression<Person>
     {
         #region interface properties
-        public Int32FieldExpression<Person> Id { get; private set; }
-        public StringFieldExpression<Person> SSN { get; private set; }
-        public DateTimeOffsetFieldExpression<Person> DateCreated { get; private set; }
-        public DateTimeOffsetFieldExpression<Person> DateUpdated { get; private set; }
+        public IdField Id { get; private set; }
+        public SSNField SSN { get; private set; }
+        public DateCreatedField DateCreated { get; private set; }
+        public DateUpdatedField DateUpdated { get; private set; }
         #endregion
 
         #region constructors
@@ -1148,10 +2288,10 @@ namespace DbEx.secDataService
 
         private PersonEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new Int32FieldExpression<Person>($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.SSN", SSN = new StringFieldExpression<Person>($"{identifier}.SSN", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateTimeOffsetFieldExpression<Person>($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateTimeOffsetFieldExpression<Person>($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
+            Fields.Add($"{identifier}.SSN", SSN = new SSNField($"{identifier}.SSN", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
         }
         #endregion
 
@@ -1200,6 +2340,77 @@ namespace DbEx.secDataService
 			person.DateUpdated = reader.ReadField().GetValue<DateTimeOffset>();
         }
 		#endregion
+
+        #region classes
+        #region id field expression
+        public partial class IdField : Int32FieldExpression<Person>
+        {
+            #region constructors
+            public IdField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(int value) => new AssignmentExpression(this, new LiteralExpression<int>(value));
+            public AssignmentExpression Set(Int32Element value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region s s n field expression
+        public partial class SSNField : StringFieldExpression<Person>
+        {
+            #region constructors
+            public SSNField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(string value) => new AssignmentExpression(this, new LiteralExpression<string>(value));
+            public AssignmentExpression Set(StringElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date created field expression
+        public partial class DateCreatedField : DateTimeOffsetFieldExpression<Person>
+        {
+            #region constructors
+            public DateCreatedField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTimeOffset value) => new AssignmentExpression(this, new LiteralExpression<DateTimeOffset>(value));
+            public AssignmentExpression Set(DateTimeOffsetElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #region date updated field expression
+        public partial class DateUpdatedField : DateTimeOffsetFieldExpression<Person>
+        {
+            #region constructors
+            public DateUpdatedField(string identifier, PersonEntity entity) : base(identifier, entity)
+            {
+
+            }
+            #endregion
+
+            #region set
+            public AssignmentExpression Set(DateTimeOffset value) => new AssignmentExpression(this, new LiteralExpression<DateTimeOffset>(value));
+            public AssignmentExpression Set(DateTimeOffsetElement value) => new AssignmentExpression(this, value);
+            #endregion
+        }
+        #endregion
+
+        #endregion
     }
     #endregion
 

--- a/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Field/NullableTypedFieldExpression.htt
+++ b/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Field/NullableTypedFieldExpression.htt
@@ -18,26 +18,9 @@ namespace {Namespace}
         {-/if-}
         #endregion
 
-        #region set
-        public override AssignmentExpression Set({:fieldExpressionType.Alias} value) => new AssignmentExpression(this, new LiteralExpression<{:fieldExpressionType.Alias}>(value));
-        public virtual AssignmentExpression Set({:fieldExpressionType.Name}Element value) => new AssignmentExpression(this, value);
-        {-#if :fieldExpressionType.IsNullable-}
-        public override AssignmentExpression Set({:fieldExpressionType.NullableAlias} value) => new AssignmentExpression(this, new LiteralExpression<{:fieldExpressionType.NullableAlias}>(value));
-        public override AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<{:fieldExpressionType.NullableAlias}>(DBNull.Value));
-        public virtual AssignmentExpression Set(Nullable{:fieldExpressionType.Name}Element value) => new AssignmentExpression(this, value);
-        {-/if-}
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new Nullable{:fieldExpressionType.Name}ExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new Nullable{:fieldExpressionType.Name}ExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<{:fieldExpressionType.NullableAlias}>(Nullable{:fieldExpressionType.Name}FieldExpression a) => new SelectExpression<{:fieldExpressionType.NullableAlias}>(a);
         public static implicit operator Nullable{:fieldExpressionType.Name}ExpressionMediator(Nullable{:fieldExpressionType.Name}FieldExpression a) => new Nullable{:fieldExpressionType.Name}ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Nullable{:fieldExpressionType.Name}FieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Nullable{:fieldExpressionType.Name}FieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Field/TypedFieldExpression.htt
+++ b/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Field/TypedFieldExpression.htt
@@ -11,21 +11,9 @@ namespace {Namespace}
         public override FilterExpressionSet In(IEnumerable<{:fieldExpressionType.Alias}> value) => value is object ? new FilterExpressionSet(new FilterExpression<bool>(this, new InExpression<{:fieldExpressionType.Alias}>(value), FilterExpressionOperator.None)) : null;
         #endregion
 
-        #region set
-        public override AssignmentExpression Set({:fieldExpressionType.Alias} value) => new AssignmentExpression(this, new LiteralExpression<{:fieldExpressionType.Alias}>(value));
-        public virtual AssignmentExpression Set({:fieldExpressionType.Name}Element value) => new AssignmentExpression(this, value);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(new {:fieldExpressionType.Name}ExpressionMediator(this), OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(new {:fieldExpressionType.Name}ExpressionMediator(this), OrderExpressionDirection.DESC);
-        #endregion
-
         #region implicit operators
         public static implicit operator SelectExpression<{:fieldExpressionType.Alias}>({:fieldExpressionType.Name}FieldExpression a) => new SelectExpression<{:fieldExpressionType.Alias}>(a);
         public static implicit operator {:fieldExpressionType.Name}ExpressionMediator({:fieldExpressionType.Name}FieldExpression a) => new {:fieldExpressionType.Name}ExpressionMediator(a);
-        public static implicit operator OrderByExpression({:fieldExpressionType.Name}FieldExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression({:fieldExpressionType.Name}FieldExpression a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Function/EnumFunctionExpression.htt
+++ b/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Function/EnumFunctionExpression.htt
@@ -9,13 +9,6 @@ namespace {Namespace}
     {{
         #region implicit operators
         public static implicit operator EnumExpressionMediator<TEnum>(Enum{:functionName}FunctionExpression<TEnum> a) => new EnumExpressionMediator<TEnum>(new EnumExpressionMediator<TEnum>(a));
-        public static implicit operator OrderByExpression(Enum{:functionName}FunctionExpression<TEnum> a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Enum{:functionName}FunctionExpression<TEnum> a) => new GroupByExpression(a);
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region filter operators

--- a/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Function/FunctionExpression.htt
+++ b/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Function/FunctionExpression.htt
@@ -11,15 +11,6 @@ namespace {Namespace}
     {{
         #region implicit operators
         public static implicit operator {:mediatorType.Name}ExpressionMediator({:functionName}FunctionExpression a) => new {:mediatorType.Name}ExpressionMediator(a);
-        public static implicit operator OrderByExpression({:functionName}FunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        {-#if !IsAggregateFunction-}
-        public static implicit operator GroupByExpression({:functionName}FunctionExpression a) => new GroupByExpression(a);
-        {-/if-}
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Function/NullableEnumFunctionExpression.htt
+++ b/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Function/NullableEnumFunctionExpression.htt
@@ -10,15 +10,6 @@ namespace {Namespace}
     {{
         #region implicit operators
         public static implicit operator NullableEnumExpressionMediator<TEnum>(NullableEnum{:functionName}FunctionExpression<TEnum> a) => new NullableEnumExpressionMediator<TEnum>(new NullableEnumExpressionMediator<TEnum>(a));
-        public static implicit operator OrderByExpression(NullableEnum{:functionName}FunctionExpression<TEnum> a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        {-#if !IsAggregateFunction-}
-        public static implicit operator GroupByExpression(NullableEnum{:functionName}FunctionExpression<TEnum> a) => new GroupByExpression(a);
-        {-/if-}
-        #endregion
-        
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
         
         #region filter operators

--- a/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Function/NullableTypedFunctionExpression.htt
+++ b/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Function/NullableTypedFunctionExpression.htt
@@ -11,15 +11,6 @@ namespace {Namespace}
     {{
         #region implicit operators
         public static implicit operator Nullable{:dataType.Name}ExpressionMediator(Nullable{:dataType.Name}{:functionName}FunctionExpression a) => new Nullable{:dataType.Name}ExpressionMediator(a);
-        public static implicit operator OrderByExpression(Nullable{:dataType.Name}{:functionName}FunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        {-#if !IsAggregateFunction-}
-        public static implicit operator GroupByExpression(Nullable{:dataType.Name}{:functionName}FunctionExpression a) => new GroupByExpression(a);
-        {-/if-}
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Function/TypedFunctionExpression.htt
+++ b/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Function/TypedFunctionExpression.htt
@@ -11,15 +11,6 @@ namespace {Namespace}
     {{
         #region implicit operators
         public static implicit operator {:dataType.Name}ExpressionMediator({:dataType.Name}{:functionName}FunctionExpression a) => new {:dataType.Name}ExpressionMediator(a);
-        public static implicit operator OrderByExpression({:dataType.Name}{:functionName}FunctionExpression a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        {-#if !IsAggregateFunction-}
-        public static implicit operator GroupByExpression({:dataType.Name}{:functionName}FunctionExpression a) => new GroupByExpression(a);
-        {-/if-}
-        #endregion
-
-        #region order
-        public override OrderByExpression Asc => new OrderByExpression(this, OrderExpressionDirection.ASC);
-        public override OrderByExpression Desc => new OrderByExpression(this, OrderExpressionDirection.DESC);
         #endregion
 
         #region arithmetic operators

--- a/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Mediator/NullableTypedExpressionMediator.htt
+++ b/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Mediator/NullableTypedExpressionMediator.htt
@@ -10,8 +10,6 @@ namespace {Namespace}
     {{
         #region implicit operators
         public static implicit operator SelectExpression<{:mediatorType.Alias}{#if :mediatorType.IsNullable}?{/if}>(Nullable{:mediatorType.Name}ExpressionMediator a) => new SelectExpression<{:mediatorType.Alias}{#if :mediatorType.IsNullable}?{/if}>(a);
-        public static implicit operator OrderByExpression(Nullable{:mediatorType.Name}ExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression(Nullable{:mediatorType.Name}ExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators 

--- a/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Mediator/TypedExpressionMediator.htt
+++ b/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Mediator/TypedExpressionMediator.htt
@@ -10,8 +10,6 @@ namespace {Namespace}
     {{
         #region implicit operators
         public static implicit operator SelectExpression<{:mediatorType.Alias}>({:mediatorType.Name}ExpressionMediator a) => new SelectExpression<{:mediatorType.Alias}>(a);
-        public static implicit operator OrderByExpression({:mediatorType.Name}ExpressionMediator a) => new OrderByExpression(a, OrderExpressionDirection.ASC);
-        public static implicit operator GroupByExpression({:mediatorType.Name}ExpressionMediator a) => new GroupByExpression(a);
         #endregion
 
         #region arithmetic operators

--- a/tools/HatTrick.DbEx.Tools/HatTrick.DbEx.Tools.csproj
+++ b/tools/HatTrick.DbEx.Tools/HatTrick.DbEx.Tools.csproj
@@ -17,6 +17,7 @@
     <None Remove="Resources\Templates\Partials\DbMetadata.htt" />
     <None Remove="Resources\Templates\Partials\EntityExpression.htt" />
     <None Remove="Resources\Templates\Partials\EntityMetadata.htt" />
+    <None Remove="Resources\Templates\Partials\FieldExpression.htt" />
     <None Remove="Resources\Templates\Partials\Fx.htt" />
     <None Remove="Resources\Templates\Partials\RuntimeDb.htt" />
     <None Remove="Resources\Templates\Partials\RuntimeEnvironmentDb.htt" />
@@ -35,6 +36,7 @@
     <EmbeddedResource Include="Resources\Templates\Partials\DbMetadata.htt" />
     <EmbeddedResource Include="Resources\Templates\Partials\EntityExpression.htt" />
     <EmbeddedResource Include="Resources\Templates\Partials\EntityMetadata.htt" />
+    <EmbeddedResource Include="Resources\Templates\Partials\FieldExpression.htt" />
     <EmbeddedResource Include="Resources\Templates\Partials\Fx.htt" />
     <EmbeddedResource Include="Resources\Templates\Partials\RuntimeDb.htt" />
     <EmbeddedResource Include="Resources\Templates\Partials\RuntimeEnvironmentDb.htt" />

--- a/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/EntityExpression.htt
+++ b/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/EntityExpression.htt
@@ -2,13 +2,14 @@
     {?var:table = $}
     {?var:tableName = ($) => ResolveName}
     {?var:columns = Columns.Values}
+
     public partial class {:tableName}Entity : EntityExpression<{:tableName}>
     {{
         #region interface properties
 		{#each Columns.Values}
 		{#if !($) => IsIgnored}
         {?var:columnName = ($) => ResolveName}
-        public {($, $.IsNullable) => ResolveFieldExpressionTypeName}<{:tableName}{#if ($) => IsEnum}, {($, false) => ResolveClrTypeName} {/if}> {:columnName} {{ get; private set; }}
+        public {:columnName}Field {:columnName} {{ get; private set; }}
 		{/if}
 		{/each}
         #endregion
@@ -27,7 +28,7 @@
 			{#each Columns.Values}
 			{#if !($) => IsIgnored}
             {?var:columnName = ($) => ResolveName}
-            Fields.Add($"{{identifier}}.{$.Name}", {:columnName} = new {($, $.IsNullable) => ResolveFieldExpressionTypeName}<{:tableName}{#if ($) => IsEnum}, {($, false) => ResolveClrTypeName} {/if}>($"{{identifier}}.{$.Name}", this));
+            Fields.Add($"{{identifier}}.{$.Name}", {:columnName} = new {:columnName}Field($"{{identifier}}.{$.Name}", this));
 			{/if}
 			{/each}
         }}
@@ -85,5 +86,11 @@
 			{/each}
         }}
 		#endregion
+
+        #region classes
+        {#each Columns.Values}
+	    {>("FieldExpression") => GetTemplatePartial+}
+	    {/each}
+        #endregion
     }}
     #endregion

--- a/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/FieldExpression.htt
+++ b/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/FieldExpression.htt
@@ -1,0 +1,28 @@
+﻿        {#if !($) => IsIgnored}
+        {?var:columnName = ($) => ResolveName}
+        {?var:nullableClrTypeName = ($, $.IsNullable) => ResolveClrTypeName}
+        {?var:clrTypeName = ($, false) => ResolveClrTypeName}
+        #region {($) => InsertSpaceOnCapitalizationAndToLower} field expression
+        public partial class {:columnName}Field : {($, $.IsNullable) => ResolveFieldExpressionTypeName}<{:tableName}{#if ($) => IsEnum}, {:clrTypeName} {/if}>
+        {{
+            #region constructors
+            public {:columnName}Field(string identifier, {:tableName}Entity entity) : base(identifier, entity)
+            {{
+
+            }}
+            #endregion
+
+            #region set
+            public AssignmentExpression Set({:clrTypeName} value) => new AssignmentExpression(this, new LiteralExpression<{:clrTypeName}>(value));
+            public AssignmentExpression Set({($) => ResolveElementTypeName} value) => new AssignmentExpression(this, value);
+            {#if $.IsNullable}
+            {#if ($) => IsNullableType}
+            public AssignmentExpression Set({:nullableClrTypeName} value) => new AssignmentExpression(this, new LiteralExpression<{:nullableClrTypeName}>(value));
+            {/if}
+            public AssignmentExpression Set(Nullable{($) => ResolveElementTypeName} value) => new AssignmentExpression(this, value);
+            public AssignmentExpression Set(DBNull value) => new AssignmentExpression(this, new LiteralExpression<object>(DBNull.Value));
+            {/if}
+            #endregion
+        }}
+        #endregion
+        {/if}

--- a/tools/HatTrick.DbEx.Tools/Service/Command/Execution/CodeGeneration/CodeGenerateExecutionContext.cs
+++ b/tools/HatTrick.DbEx.Tools/Service/Command/Execution/CodeGeneration/CodeGenerateExecutionContext.cs
@@ -570,6 +570,7 @@ namespace HatTrick.DbEx.Tools.Service
             repo.Register(nameof(helpers.ResolveClrTypeName), (Func<MsSqlColumn, bool, string>)helpers.ResolveClrTypeName);
             repo.Register(nameof(helpers.ResolveStrictAssemblyTypeName), (Func<MsSqlColumn, string>)helpers.ResolveStrictAssemblyTypeName);
             repo.Register(nameof(helpers.ResolveFieldExpressionTypeName), (Func<MsSqlColumn, bool, string>)helpers.ResolveFieldExpressionTypeName);
+            repo.Register(nameof(helpers.ResolveElementTypeName), (Func<MsSqlColumn, string>)helpers.ResolveElementTypeName);
             repo.Register(nameof(helpers.IsLast), (Func<IEnumerable<MsSqlColumn>, MsSqlColumn, bool>)helpers.IsLast);
             repo.Register(nameof(helpers.ResolveConsolidatedTablesAndViews), (Func<MsSqlSchema, IList<INamedMeta>>)helpers.ResolveConsolidatedTablesAndViews);
             repo.Register(nameof(helpers.IsMsSqlTable), (Func<INamedMeta, bool>)helpers.IsMsSqlTable);
@@ -577,6 +578,7 @@ namespace HatTrick.DbEx.Tools.Service
             repo.Register(nameof(helpers.GetTemplatePartial), (Func<string, string>)helpers.GetTemplatePartial);
             repo.Register(nameof(helpers.ResolveRootNamespace), (Func<string>)helpers.ResolveRootNamespace);
             repo.Register(nameof(helpers.ResolveAppliedInterfaces), (Func<INamedMeta, string[]>)helpers.ResolveAppliedInterfaces);
+            repo.Register(nameof(helpers.IsNullableType), (Func<MsSqlColumn, bool>)helpers.IsNullableType);
 
             string output = null;
             try

--- a/tools/HatTrick.DbEx.Tools/Service/Command/Execution/CodeGeneration/CodeGenerationHelpers.cs
+++ b/tools/HatTrick.DbEx.Tools/Service/Command/Execution/CodeGeneration/CodeGenerationHelpers.cs
@@ -143,6 +143,23 @@ namespace HatTrick.DbEx.Tools.Service
         }
         #endregion
 
+        #region is nullable type
+        public bool IsNullableType(MsSqlColumn column)
+        {
+            string name = null;
+            if (this.IsEnum(column))
+            {
+                name = this.ResolveClrTypeName(column, column.IsNullable);
+                return name.EndsWith("?");
+            }
+            else
+            {
+                name = svc.TypeMap.GetAssemblyTypeShortName(column.SqlType, column.IsNullable);
+            }
+            return name.EndsWith("?");
+        }
+        #endregion
+
         #region resolve field expression type name
         public string ResolveFieldExpressionTypeName(MsSqlColumn column, bool allowNullableType)
         {
@@ -153,9 +170,25 @@ namespace HatTrick.DbEx.Tools.Service
             }
             else if (this.HasClrTypeOverride(column, out string dataTypeOverride))
             {
-                return svc.TypeMap.GetFieldExpressionTypeName(dataTypeOverride, column.IsNullable);
+                return $"{svc.TypeMap.GetTypeName(dataTypeOverride, column.IsNullable)}FieldExpression";
             }
-            return svc.TypeMap.GetFieldExpressionTypeName(column.SqlType, column.IsNullable);
+            return $"{svc.TypeMap.GetTypeName(column.SqlType, column.IsNullable)}FieldExpression";
+        }
+        #endregion
+
+        #region resolve element type name
+        public string ResolveElementTypeName(MsSqlColumn column)
+        {
+            if (this.IsEnum(column))
+            {
+                var name = this.ResolveClrTypeName(column, false);
+                return $"{(name.EndsWith("?") ? "Nullable" : string.Empty)}EnumElement<{this.ResolveClrTypeName(column, false)}>";
+            }
+            else if (this.HasClrTypeOverride(column, out string dataTypeOverride))
+            {
+                return $"{svc.TypeMap.GetTypeName(dataTypeOverride, false)}Element";
+            }
+            return $"{svc.TypeMap.GetTypeName(column.SqlType, false)}Element";
         }
         #endregion
 

--- a/tools/HatTrick.DbEx.Tools/Service/TypeMap/TypeMapService.cs
+++ b/tools/HatTrick.DbEx.Tools/Service/TypeMap/TypeMapService.cs
@@ -150,9 +150,9 @@ namespace HatTrick.DbEx.Tools.Service
         #endregion
 
         #region resolve field expression name
-        public string GetFieldExpressionTypeName(SqlDbType sqlDbType, bool isNullable)
+        public string GetTypeName(SqlDbType sqlDbType, bool isNullable)
         {
-            string format(string name) => isNullable ? $"Nullable{name}FieldExpression" : $"{name}FieldExpression";
+            string format(string name) => isNullable ? $"Nullable{name}" : name;
 
             switch (sqlDbType)
             {
@@ -209,9 +209,9 @@ namespace HatTrick.DbEx.Tools.Service
         #endregion
 
         #region resolve field expression name
-        public string GetFieldExpressionTypeName(string alias, bool isNullable)
+        public string GetTypeName(string alias, bool isNullable)
         {
-            string format(string name) => isNullable ? $"Nullable{name}FieldExpression" : $"{name}FieldExpression";
+            string format(string name) => isNullable ? $"Nullable{name}" : name;
 
             switch (alias)
             {


### PR DESCRIPTION
- Created field expression classes within entities to provide more concrete versions of fields
- Moved Set operations (for building assignment expressions) into the new field expression classes
- Moved OrderByExpression implicit operators to base classes
- Moved GroupByExpression implicit operators to base classes