### PR TITLE
Moved aliasing from generated code to a dbex class; use is now dbex.a…

### DIFF
--- a/samples/mssql/NetCoreConsoleApp/Data/_Generated/DbExDataService.generated.cs
+++ b/samples/mssql/NetCoreConsoleApp/Data/_Generated/DbExDataService.generated.cs
@@ -989,11 +989,6 @@ namespace SimpleConsole.DataService
         {
         }
         #endregion
-
-        #region alias
-        public static AliasExpression alias(string tableName, string fieldName)
-            => new AliasExpression(tableName, fieldName);
-        #endregion
     }
     #endregion
 
@@ -1199,6 +1194,9 @@ namespace SimpleConsole.dboDataService
         /// <item>
         /// <term>allow null</term><description>no</description>
         /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
+        /// </item>
         /// </list>
         /// </para>
         /// </summary>
@@ -1217,6 +1215,9 @@ namespace SimpleConsole.dboDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -1707,6 +1708,9 @@ namespace SimpleConsole.dboDataService
         /// <item>
         /// <term>allow null</term><description>no</description>
         /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
+        /// </item>
         /// </list>
         /// </para>
         /// </summary>
@@ -1725,6 +1729,9 @@ namespace SimpleConsole.dboDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -2142,6 +2149,9 @@ namespace SimpleConsole.dboDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -2623,6 +2633,9 @@ namespace SimpleConsole.dboDataService
         /// <item>
         /// <term>allow null</term><description>no</description>
         /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
+        /// </item>
         /// </list>
         /// </para>
         /// </summary>
@@ -2641,6 +2654,9 @@ namespace SimpleConsole.dboDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -3484,7 +3500,7 @@ namespace SimpleConsole.dboDataService
         /// <term>allow null</term><description>no</description>
         /// </item>
         /// <item>
-        /// <term>default</term><description>(getutcdate())</description>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -3504,6 +3520,9 @@ namespace SimpleConsole.dboDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -4091,6 +4110,9 @@ namespace SimpleConsole.dboDataService
         /// <item>
         /// <term>allow null</term><description>no</description>
         /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
+        /// </item>
         /// </list>
         /// </para>
         /// </summary>
@@ -4109,6 +4131,9 @@ namespace SimpleConsole.dboDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -4834,6 +4859,9 @@ namespace SimpleConsole.secDataService
         /// <item>
         /// <term>allow null</term><description>no</description>
         /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
+        /// </item>
         /// </list>
         /// </para>
         /// </summary>
@@ -4852,6 +4880,9 @@ namespace SimpleConsole.secDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>

--- a/samples/mssql/NetCoreConsoleApp/Expressions/SelectExpressions.cs
+++ b/samples/mssql/NetCoreConsoleApp/Expressions/SelectExpressions.cs
@@ -516,7 +516,7 @@ namespace NetCoreConsoleApp
 			var rpt = db.SelectMany(
 					dbo.Person.Id.As("PersonId"),
 					db.fx.Concat(dbo.Person.LastName, ", ", dbo.Person.FirstName).As("FullName"),
-					db.fx.IsNull(db.alias("t0", "TotalPurchaseAmount"), 0).As("TotalPurchaseAmount"),
+					db.fx.IsNull(dbex.alias("t0", "TotalPurchaseAmount"), 0).As("TotalPurchaseAmount"),
 					dbo.Person.YearOfLastCreditLimitReview,
 					dbo.Person.CreditLimit
 				).From(dbo.Person)
@@ -528,7 +528,7 @@ namespace NetCoreConsoleApp
 					.From(dbo.Purchase)
 					.GroupBy(dbo.Purchase.PersonId))
 					.As("t0")
-				.On(db.alias("t0", "PersonId") == dbo.Person.Id)
+				.On(dbex.alias("t0", "PersonId") == dbo.Person.Id)
 				.OrderBy(dbo.Person.LastName.Asc)
 				.Execute();
 
@@ -561,8 +561,8 @@ namespace NetCoreConsoleApp
 
 			var vip = db.SelectMany(
 				dbo.Person.Id.As("PersonId"), 
-				db.alias("vips", "PurchaseCount"), 
-				db.alias("vips", "PurchaseYear"), 
+				dbex.alias("vips", "PurchaseCount"), 
+				dbex.alias("vips", "PurchaseYear"), 
 				(dbo.Person.FirstName + " " + dbo.Person.LastName).As("FullName"))
 				.From(dbo.Person)
 				.InnerJoin(
@@ -577,8 +577,8 @@ namespace NetCoreConsoleApp
 							db.fx.Count(dbo.Purchase.Id) >= purchaseCount 
 							& db.fx.DatePart(DateParts.Year, dbo.Purchase.PurchaseDate) == year)
 					).As("vips")
-				.On(dbo.Person.Id == db.alias("vips", "PersonId"))
-				.OrderBy(dbo.Person.Id.Asc, db.alias("vips", "PurchaseCount").Desc)
+				.On(dbo.Person.Id == dbex.alias("vips", "PersonId"))
+				.OrderBy(dbo.Person.Id.Asc, dbex.alias("vips", "PurchaseCount").Desc)
 				.Execute();
 
 			return vip;

--- a/samples/mssql/ServerSideBlazorApp/Data/_Generated/DbExDataService.generated.cs
+++ b/samples/mssql/ServerSideBlazorApp/Data/_Generated/DbExDataService.generated.cs
@@ -989,11 +989,6 @@ namespace ServerSideBlazorApp.DataService
         {
         }
         #endregion
-
-        #region alias
-        public static AliasExpression alias(string tableName, string fieldName)
-            => new AliasExpression(tableName, fieldName);
-        #endregion
     }
     #endregion
 
@@ -1199,6 +1194,9 @@ namespace ServerSideBlazorApp.dboDataService
         /// <item>
         /// <term>allow null</term><description>no</description>
         /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
+        /// </item>
         /// </list>
         /// </para>
         /// </summary>
@@ -1217,6 +1215,9 @@ namespace ServerSideBlazorApp.dboDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -1707,6 +1708,9 @@ namespace ServerSideBlazorApp.dboDataService
         /// <item>
         /// <term>allow null</term><description>no</description>
         /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
+        /// </item>
         /// </list>
         /// </para>
         /// </summary>
@@ -1725,6 +1729,9 @@ namespace ServerSideBlazorApp.dboDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -2142,6 +2149,9 @@ namespace ServerSideBlazorApp.dboDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -2623,6 +2633,9 @@ namespace ServerSideBlazorApp.dboDataService
         /// <item>
         /// <term>allow null</term><description>no</description>
         /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
+        /// </item>
         /// </list>
         /// </para>
         /// </summary>
@@ -2641,6 +2654,9 @@ namespace ServerSideBlazorApp.dboDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -3484,7 +3500,7 @@ namespace ServerSideBlazorApp.dboDataService
         /// <term>allow null</term><description>no</description>
         /// </item>
         /// <item>
-        /// <term>default</term><description>(getutcdate())</description>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -3504,6 +3520,9 @@ namespace ServerSideBlazorApp.dboDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -4091,6 +4110,9 @@ namespace ServerSideBlazorApp.dboDataService
         /// <item>
         /// <term>allow null</term><description>no</description>
         /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
+        /// </item>
         /// </list>
         /// </para>
         /// </summary>
@@ -4109,6 +4131,9 @@ namespace ServerSideBlazorApp.dboDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -4834,6 +4859,9 @@ namespace ServerSideBlazorApp.secDataService
         /// <item>
         /// <term>allow null</term><description>no</description>
         /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
+        /// </item>
         /// </list>
         /// </para>
         /// </summary>
@@ -4852,6 +4880,9 @@ namespace ServerSideBlazorApp.secDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>

--- a/samples/mssql/ServerSideBlazorApp/Service/CustomerService.cs
+++ b/samples/mssql/ServerSideBlazorApp/Service/CustomerService.cs
@@ -123,21 +123,21 @@ namespace ServerSideBlazorApp.Service
                     dbo.Customer.YearOfLastCreditLimitReview,
                     dbo.Customer.BirthDate,
                     db.fx.Floor(db.fx.DateDiff(DateParts.Day, dbo.Customer.BirthDate, db.fx.GetUtcDate()) / 365.25).As("CurrentAge"),
-                    db.alias(mailingAddress, nameof(dbo.Address.Line1)),
-                    db.alias(mailingAddress, nameof(dbo.Address.Line2)),
-                    db.alias(mailingAddress, nameof(dbo.Address.City)),
-                    db.alias(mailingAddress, nameof(dbo.Address.State)),
-                    db.alias(mailingAddress, nameof(dbo.Address.Zip)),
-                    db.alias(billingAddress, nameof(dbo.Address.Line1)),
-                    db.alias(billingAddress, nameof(dbo.Address.Line2)),
-                    db.alias(billingAddress, nameof(dbo.Address.City)),
-                    db.alias(billingAddress, nameof(dbo.Address.State)),
-                    db.alias(billingAddress, nameof(dbo.Address.Zip)),
-                    db.alias(shippingAddress, nameof(dbo.Address.Line1)),
-                    db.alias(shippingAddress, nameof(dbo.Address.Line2)),
-                    db.alias(shippingAddress, nameof(dbo.Address.City)),
-                    db.alias(shippingAddress, nameof(dbo.Address.State)),
-                    db.alias(shippingAddress, nameof(dbo.Address.Zip))
+                    dbex.alias(mailingAddress, nameof(dbo.Address.Line1)),
+                    dbex.alias(mailingAddress, nameof(dbo.Address.Line2)),
+                    dbex.alias(mailingAddress, nameof(dbo.Address.City)),
+                    dbex.alias(mailingAddress, nameof(dbo.Address.State)),
+                    dbex.alias(mailingAddress, nameof(dbo.Address.Zip)),
+                    dbex.alias(billingAddress, nameof(dbo.Address.Line1)),
+                    dbex.alias(billingAddress, nameof(dbo.Address.Line2)),
+                    dbex.alias(billingAddress, nameof(dbo.Address.City)),
+                    dbex.alias(billingAddress, nameof(dbo.Address.State)),
+                    dbex.alias(billingAddress, nameof(dbo.Address.Zip)),
+                    dbex.alias(shippingAddress, nameof(dbo.Address.Line1)),
+                    dbex.alias(shippingAddress, nameof(dbo.Address.Line2)),
+                    dbex.alias(shippingAddress, nameof(dbo.Address.City)),
+                    dbex.alias(shippingAddress, nameof(dbo.Address.State)),
+                    dbex.alias(shippingAddress, nameof(dbo.Address.Zip))
                 )
                 .From(dbo.Customer)
                 .LeftJoin(dbo.PersonTotalPurchasesView).On(dbo.Customer.Id == dbo.PersonTotalPurchasesView.Id)
@@ -153,7 +153,7 @@ namespace ServerSideBlazorApp.Service
                     .From(dbo.Address)
                     .InnerJoin(dbo.CustomerAddress).On(dbo.CustomerAddress.AddressId == dbo.Address.Id)
                     .Where(dbo.CustomerAddress.PersonId == customerId & dbo.Address.AddressType == AddressType.Mailing)
-                ).As(nameof(CustomerDetailModel.MailingAddress)).On(dbo.Customer.Id == db.alias(nameof(CustomerDetailModel.MailingAddress), nameof(dbo.CustomerAddress.PersonId)))
+                ).As(nameof(CustomerDetailModel.MailingAddress)).On(dbo.Customer.Id == dbex.alias(nameof(CustomerDetailModel.MailingAddress), nameof(dbo.CustomerAddress.PersonId)))
                 .LeftJoin(
                     db.SelectOne(
                         dbo.CustomerAddress.PersonId,
@@ -166,7 +166,7 @@ namespace ServerSideBlazorApp.Service
                     .From(dbo.Address)
                     .InnerJoin(dbo.CustomerAddress).On(dbo.CustomerAddress.AddressId == dbo.Address.Id)
                     .Where(dbo.CustomerAddress.PersonId == customerId & dbo.Address.AddressType == AddressType.Billing)
-                ).As(nameof(CustomerDetailModel.BillingAddress)).On(dbo.Customer.Id == db.alias(nameof(CustomerDetailModel.BillingAddress), nameof(dbo.CustomerAddress.PersonId)))
+                ).As(nameof(CustomerDetailModel.BillingAddress)).On(dbo.Customer.Id == dbex.alias(nameof(CustomerDetailModel.BillingAddress), nameof(dbo.CustomerAddress.PersonId)))
                 .LeftJoin(
                     db.SelectOne(
                         dbo.CustomerAddress.PersonId,
@@ -179,7 +179,7 @@ namespace ServerSideBlazorApp.Service
                     .From(dbo.Address)
                     .InnerJoin(dbo.CustomerAddress).On(dbo.CustomerAddress.AddressId == dbo.Address.Id)
                     .Where(dbo.CustomerAddress.PersonId == customerId & dbo.Address.AddressType == AddressType.Shipping)
-                ).As(nameof(CustomerDetailModel.ShippingAddress)).On(dbo.Customer.Id == db.alias(nameof(CustomerDetailModel.ShippingAddress), nameof(dbo.CustomerAddress.PersonId)))
+                ).As(nameof(CustomerDetailModel.ShippingAddress)).On(dbo.Customer.Id == dbex.alias(nameof(CustomerDetailModel.ShippingAddress), nameof(dbo.CustomerAddress.PersonId)))
                 .Where(dbo.Customer.Id == customerId)
                 .ExecuteAsync(
                     sqlRow => 

--- a/samples/mssql/ServerSideBlazorApp/Service/OrderService.cs
+++ b/samples/mssql/ServerSideBlazorApp/Service/OrderService.cs
@@ -133,16 +133,16 @@ namespace ServerSideBlazorApp.Service
                 dbo.Purchase.PaymentMethodType,
                 dbo.Purchase.ExpectedDeliveryDate,
                 dbo.Purchase.TrackingIdentifier,
-                db.alias(billingAddress, nameof(dbo.Address.Line1)),
-                db.alias(billingAddress, nameof(dbo.Address.Line2)),
-                db.alias(billingAddress, nameof(dbo.Address.City)),
-                db.alias(billingAddress, nameof(dbo.Address.State)),
-                db.alias(billingAddress, nameof(dbo.Address.Zip)),
-                db.alias(shippingAddress, nameof(dbo.Address.Line1)),
-                db.alias(shippingAddress, nameof(dbo.Address.Line2)),
-                db.alias(shippingAddress, nameof(dbo.Address.City)),
-                db.alias(shippingAddress, nameof(dbo.Address.State)),
-                db.alias(shippingAddress, nameof(dbo.Address.Zip))
+                dbex.alias(billingAddress, nameof(dbo.Address.Line1)),
+                dbex.alias(billingAddress, nameof(dbo.Address.Line2)),
+                dbex.alias(billingAddress, nameof(dbo.Address.City)),
+                dbex.alias(billingAddress, nameof(dbo.Address.State)),
+                dbex.alias(billingAddress, nameof(dbo.Address.Zip)),
+                dbex.alias(shippingAddress, nameof(dbo.Address.Line1)),
+                dbex.alias(shippingAddress, nameof(dbo.Address.Line2)),
+                dbex.alias(shippingAddress, nameof(dbo.Address.City)),
+                dbex.alias(shippingAddress, nameof(dbo.Address.State)),
+                dbex.alias(shippingAddress, nameof(dbo.Address.Zip))
             )
             .From(dbo.Purchase)
             .InnerJoin(dbo.Customer).On(dbo.Purchase.PersonId == dbo.Customer.Id)
@@ -160,7 +160,7 @@ namespace ServerSideBlazorApp.Service
                 .InnerJoin(dbo.CustomerAddress).On(dbo.CustomerAddress.AddressId == dbo.Address.Id)
                 .InnerJoin(dbo.Purchase).On(dbo.CustomerAddress.PersonId == dbo.Purchase.PersonId)
                 .Where(dbo.Purchase.Id == orderId & dbo.Address.AddressType == AddressType.Billing)
-            ).As(billingAddress).On(dbo.Customer.Id == db.alias(billingAddress, nameof(dbo.CustomerAddress.PersonId)))
+            ).As(billingAddress).On(dbo.Customer.Id == dbex.alias(billingAddress, nameof(dbo.CustomerAddress.PersonId)))
             .LeftJoin(
                 db.SelectOne(
                     dbo.CustomerAddress.PersonId,
@@ -174,7 +174,7 @@ namespace ServerSideBlazorApp.Service
                 .InnerJoin(dbo.CustomerAddress).On(dbo.CustomerAddress.AddressId == dbo.Address.Id)
                 .InnerJoin(dbo.Purchase).On(dbo.CustomerAddress.PersonId == dbo.Purchase.PersonId)
                 .Where(dbo.Purchase.Id == orderId & dbo.Address.AddressType == AddressType.Shipping)
-            ).As(shippingAddress).On(dbo.Customer.Id == db.alias(shippingAddress, nameof(dbo.CustomerAddress.PersonId)))
+            ).As(shippingAddress).On(dbo.Customer.Id == dbex.alias(shippingAddress, nameof(dbo.CustomerAddress.PersonId)))
             .Where(dbo.Purchase.Id == orderId)
             .ExecuteAsync(
                 row => new OrderDetailModel

--- a/src/HatTrick.DbEx.Sql/_api/JoinOnWithAlias{T}.cs
+++ b/src/HatTrick.DbEx.Sql/_api/JoinOnWithAlias{T}.cs
@@ -11,7 +11,7 @@ namespace HatTrick.DbEx.Sql
         /// <para>
         /// Use the <paramref name="alias"/> value from this operation as the 'tableName' parameter when creating an <see cref="AliasExpression"/> 
         /// (for the joined sql SELECT query expression) for use with outer expressions:
-        /// <code>db.alias({tableName}, {fieldName})</code>
+        /// <code>dbex.alias({tableName}, {fieldName})</code>
         /// </para>
         /// <para>
         /// <see href="https://docs.microsoft.com/en-us/sql/relational-databases/performance/joins">Microsoft docs on JOINS</see>

--- a/src/HatTrick.DbEx.Sql/dbex.cs
+++ b/src/HatTrick.DbEx.Sql/dbex.cs
@@ -1,0 +1,12 @@
+﻿using HatTrick.DbEx.Sql.Expression;
+
+namespace HatTrick.DbEx.Sql
+{
+#pragma warning disable IDE1006 // Naming Styles
+    public static class dbex
+    {
+        public static AliasExpression alias(string tableName, string fieldName)
+            => new AliasExpression(tableName, fieldName);
+    }
+#pragma warning restore IDE1006 // Naming Styles
+}

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/Aliasing.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/Aliasing.cs
@@ -31,8 +31,8 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
 
             var vipStatistics = db.SelectMany(
                 dbo.Person.Id.As("PersonId"),
-                db.alias("vips", "PurchaseCount"),
-                db.alias("vips", "PurchaseYear"),
+                dbex.alias("vips", "PurchaseCount"),
+                dbex.alias("vips", "PurchaseYear"),
                 (dbo.Person.FirstName + " " + dbo.Person.LastName).As("FullName")
             )
             .From(dbo.Person)
@@ -51,10 +51,10 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
                     db.fx.Count(dbo.Purchase.PurchaseDate) >= purchaseCount
                     & db.fx.DatePart(DateParts.Year, dbo.Purchase.PurchaseDate) == year
                 )
-            ).As("vips").On(dbo.Person.Id == db.alias("vips", "PersonId"))
+            ).As("vips").On(dbo.Person.Id == dbex.alias("vips", "PersonId"))
             .OrderBy(
                 (dbo.Person.Id + dbo.Person.Id).Asc,
-                db.alias("vips", "PurchaseCount").Desc
+                dbex.alias("vips", "PurchaseCount").Desc
             )
             .Execute();
 
@@ -81,8 +81,8 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
 
             var vipStatistics = db.SelectMany(
                 dbo.Person.Id.As("PersonId"),
-                (db.alias("vips", "PurchaseCount") + dbo.Person.Id).As("PurchaseCount"),
-                db.alias("vips", "PurchaseYear"),
+                (dbex.alias("vips", "PurchaseCount") + dbo.Person.Id).As("PurchaseCount"),
+                dbex.alias("vips", "PurchaseYear"),
                 (dbo.Person.FirstName + " " + dbo.Person.LastName).As("FullName")
             )
             .From(dbo.Person)
@@ -101,10 +101,10 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
                     db.fx.Count(dbo.Purchase.PurchaseDate) >= purchaseCount
                     & db.fx.DatePart(DateParts.Year, dbo.Purchase.PurchaseDate) == year
                 )
-            ).As("vips").On(dbo.Person.Id == db.alias("vips", "PersonId"))
+            ).As("vips").On(dbo.Person.Id == dbex.alias("vips", "PersonId"))
             .OrderBy(
                 (dbo.Person.Id + dbo.Person.Id).Asc,
-                db.alias("vips", "PurchaseCount").Desc
+                dbex.alias("vips", "PurchaseCount").Desc
             )
             .Execute();
 
@@ -131,7 +131,7 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
 
             var vipStatistics = db.SelectMany(
                 dbo.Person.Id.As("PersonId"),
-                db.alias("vips", "PurchaseCount"),
+                dbex.alias("vips", "PurchaseCount"),
                 (dbo.Person.FirstName + " " + dbo.Person.LastName).As("FullName")
             )
             .From(dbo.Person)
@@ -150,10 +150,10 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
                     db.fx.Count(dbo.Purchase.PurchaseDate) >= purchaseCount
                     & db.fx.DatePart(DateParts.Year, dbo.Purchase.PurchaseDate) == year
                 )
-            ).As("vips").On(dbo.Person.Id == db.alias("vips", "PersonId"))
+            ).As("vips").On(dbo.Person.Id == dbex.alias("vips", "PersonId"))
             .OrderBy(
                 (dbo.Person.Id + dbo.Person.Id).Asc,
-                db.alias("vips", "PurchaseCount").Desc
+                dbex.alias("vips", "PurchaseCount").Desc
             )
             .Execute();
 
@@ -178,7 +178,7 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
 
             var vipStatistics = db.SelectMany(
                 dbo.Person.Id.As("PersonId"),
-                db.fx.Coalesce(db.alias("vips", "PurchaseCount"), db.alias("not_vips", "PurchaseCount"), 1).As("PurchaseCount"),
+                db.fx.Coalesce(dbex.alias("vips", "PurchaseCount"), dbex.alias("not_vips", "PurchaseCount"), 1).As("PurchaseCount"),
                 (dbo.Person.FirstName + " " + dbo.Person.LastName).As("FullName")
             )
             .From(dbo.Person)
@@ -197,7 +197,7 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
                     db.fx.Count(dbo.Purchase.PurchaseDate) >= purchaseCount
                     & db.fx.DatePart(DateParts.Year, dbo.Purchase.PurchaseDate) == year
                 )
-            ).As("vips").On(dbo.Person.Id == db.alias("vips", "PersonId"))
+            ).As("vips").On(dbo.Person.Id == dbex.alias("vips", "PersonId"))
             .LeftJoin(
                 db.SelectMany(
                     dbo.Purchase.PersonId,
@@ -213,10 +213,10 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
                     db.fx.Count(dbo.Purchase.PurchaseDate) < purchaseCount
                     & db.fx.DatePart(DateParts.Year, dbo.Purchase.PurchaseDate) == year
                 )
-            ).As("not_vips").On(dbo.Person.Id == db.alias("not_vips", "PersonId"))
+            ).As("not_vips").On(dbo.Person.Id == dbex.alias("not_vips", "PersonId"))
             .OrderBy(
                 (dbo.Person.Id + dbo.Person.Id).Asc,
-                db.alias("vips", "PurchaseCount").Desc
+                dbex.alias("vips", "PurchaseCount").Desc
             )
             .Execute();
 
@@ -235,7 +235,7 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
 
             var vipStatistics = db.SelectOne(
                 dbo.Person.Id.As("PersonId"),
-                db.alias("vips", "PurchaseCount").As("Result")
+                dbex.alias("vips", "PurchaseCount").As("Result")
             )
             .From(dbo.Person)
             .LeftJoin(
@@ -247,8 +247,8 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
                 .GroupBy(
                     dbo.Purchase.PersonId
                 )
-            ).As("vips").On(dbo.Person.Id == db.alias("vips", "PersonId"))
-            .Where(db.alias("vips", "PurchaseCount") == expected)
+            ).As("vips").On(dbo.Person.Id == dbex.alias("vips", "PersonId"))
+            .Where(dbex.alias("vips", "PurchaseCount") == expected)
             .Execute();
 
             //then
@@ -266,7 +266,7 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             var persons = db.SelectMany(
                 dbo.Person.Id,
                 (dbo.Person.FirstName + " " + dbo.Person.LastName).As("CustomerName"),
-                (db.alias("person_address", "Id") + 2).As("AddressId")
+                (dbex.alias("person_address", "Id") + 2).As("AddressId")
             )
             .From(dbo.Person)
             .LeftJoin(
@@ -277,7 +277,7 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
                 .From(dbo.Address)
                 .InnerJoin(dbo.PersonAddress).On(dbo.Address.Id == dbo.PersonAddress.AddressId)
                 .Where(dbo.Address.AddressType == AddressType.Mailing)
-            ).As("person_address").On(db.alias("person_address", "PersonId") == dbo.Person.Id)
+            ).As("person_address").On(dbex.alias("person_address", "PersonId") == dbo.Person.Id)
             .Execute();
 
             //then
@@ -294,7 +294,7 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             ConfigureForMsSqlVersion(version);
 
             var persons = db.SelectMany(
-                db.alias("person_address", "Id").As("Foo")
+                dbex.alias("person_address", "Id").As("Foo")
             )
             .From(dbo.Person)
             .LeftJoin(
@@ -305,7 +305,7 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
                 .From(dbo.Address)
                 .InnerJoin(dbo.PersonAddress).On(dbo.Address.Id == dbo.PersonAddress.AddressId)
                 .Where(dbo.Address.AddressType == AddressType.Mailing)
-            ).As("person_address").On(db.alias("person_address", "PersonId") == dbo.Person.Id)
+            ).As("person_address").On(dbex.alias("person_address", "PersonId") == dbo.Person.Id)
             .Execute();
 
             //then
@@ -331,7 +331,7 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
                 .From(dbo.Address)
                 .InnerJoin(dbo.PersonAddress).On(dbo.Address.Id == dbo.PersonAddress.AddressId)
                 .Where(dbo.Address.AddressType == AddressType.Mailing)
-            ).As("person_address").On(db.alias("person_address", "PersonId") == dbo.Person.Id)
+            ).As("person_address").On(dbex.alias("person_address", "PersonId") == dbo.Person.Id)
             .Execute();
 
             //then
@@ -349,7 +349,7 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             int purchaseCount = 3;  //any person making 3 or more purchases (in a calendar year are considered VIP customers
 
             IList<object> values = db.SelectMany(
-                db.fx.Coalesce(db.alias("vips", "PurchaseCount"), db.alias("not_vips", "PurchaseCount"), 1).As("PurchaseCount")
+                db.fx.Coalesce(dbex.alias("vips", "PurchaseCount"), dbex.alias("not_vips", "PurchaseCount"), 1).As("PurchaseCount")
             )
             .From(dbo.Person)
             .LeftJoin(
@@ -365,7 +365,7 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
                 ).Having(
                     db.fx.Count(dbo.Purchase.PurchaseDate) >= purchaseCount
                 )
-            ).As("vips").On(dbo.Person.Id == db.alias("vips", "PersonId"))
+            ).As("vips").On(dbo.Person.Id == dbex.alias("vips", "PersonId"))
             .LeftJoin(
                 db.SelectMany(
                     dbo.Purchase.PersonId,
@@ -379,10 +379,10 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
                 ).Having(
                     db.fx.Count(dbo.Purchase.PurchaseDate) < purchaseCount
                 )
-            ).As("not_vips").On(dbo.Person.Id == db.alias("not_vips", "PersonId"))
+            ).As("not_vips").On(dbo.Person.Id == dbex.alias("not_vips", "PersonId"))
             .OrderBy(
                 (dbo.Person.Id + dbo.Person.Id).Asc,
-                db.alias("vips", "PurchaseCount").Desc
+                dbex.alias("vips", "PurchaseCount").Desc
             )
             .Execute();
 
@@ -402,7 +402,7 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
 
             var values = db.SelectMany(
                 dbo.Person.Id,
-                db.fx.Coalesce(db.alias("vips", "PurchaseCount"), db.alias("not_vips", "PurchaseCount"), int.MinValue)
+                db.fx.Coalesce(dbex.alias("vips", "PurchaseCount"), dbex.alias("not_vips", "PurchaseCount"), int.MinValue)
             )
             .From(dbo.Person)
             .LeftJoin(
@@ -418,7 +418,7 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
                 ).Having(
                     db.fx.Count(dbo.Purchase.PurchaseDate) >= purchaseCount
                 )
-            ).As("vips").On(dbo.Person.Id == db.alias("vips", "PersonId"))
+            ).As("vips").On(dbo.Person.Id == dbex.alias("vips", "PersonId"))
             .LeftJoin(
                 db.SelectMany(
                     dbo.Purchase.PersonId,
@@ -432,10 +432,10 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
                 ).Having(
                     db.fx.Count(dbo.Purchase.PurchaseDate) < purchaseCount
                 )
-            ).As("not_vips").On(dbo.Person.Id == db.alias("not_vips", "PersonId"))
+            ).As("not_vips").On(dbo.Person.Id == dbex.alias("not_vips", "PersonId"))
             .OrderBy(
                 (dbo.Person.Id + dbo.Person.Id).Asc,
-                db.alias("vips", "PurchaseCount").Desc
+                dbex.alias("vips", "PurchaseCount").Desc
             )
             .Execute(row =>
                 {

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/Join.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/Join.cs
@@ -38,9 +38,9 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             //given
             ConfigureForMsSqlVersion(version);
 
-            var exp = db.SelectMany(db.alias("joined", "Id"))
+            var exp = db.SelectMany(dbex.alias("joined", "Id"))
                 .From(dbo.Person)
-                .InnerJoin(dbo.Person.As("joined")).On(dbo.Person.FirstName == db.alias("joined", "FirstName") & dbo.Person.LastName == db.alias("joined", "LastName"));
+                .InnerJoin(dbo.Person.As("joined")).On(dbo.Person.FirstName == dbex.alias("joined", "FirstName") & dbo.Person.LastName == dbex.alias("joined", "LastName"));
 
             //when               
             var persons = exp.Execute();
@@ -57,9 +57,9 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             //given
             ConfigureForMsSqlVersion(version);
 
-            var exp = db.SelectMany(db.alias("joined", "Id"))
+            var exp = db.SelectMany(dbex.alias("joined", "Id"))
                 .From(dbo.Person)
-                .InnerJoin(dbo.Person.As("joined")).On(dbo.Person.FirstName == db.alias("joined", "FirstName") & dbo.Person.LastName == db.alias("joined", "LastName"))
+                .InnerJoin(dbo.Person.As("joined")).On(dbo.Person.FirstName == dbex.alias("joined", "FirstName") & dbo.Person.LastName == dbex.alias("joined", "LastName"))
                 .Where(dbo.Person.FirstName == firstName);
 
             //when               

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/Mapping.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/Mapping.cs
@@ -317,21 +317,21 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             await db.SelectOne(
                     dbo.Person.Id,
                     dbo.Person.GenderType,
-                    db.alias(nameof(Customer.MailingAddress), nameof(dbo.Address.Line1)),
-                    db.alias(nameof(Customer.MailingAddress), nameof(dbo.Address.Line2)),
-                    db.alias(nameof(Customer.MailingAddress), nameof(dbo.Address.City)),
-                    db.alias(nameof(Customer.MailingAddress), nameof(dbo.Address.State)),
-                    db.alias(nameof(Customer.MailingAddress), nameof(dbo.Address.Zip)),
-                    db.alias(nameof(Customer.BillingAddress), nameof(dbo.Address.Line1)),
-                    db.alias(nameof(Customer.BillingAddress), nameof(dbo.Address.Line2)),
-                    db.alias(nameof(Customer.BillingAddress), nameof(dbo.Address.City)),
-                    db.alias(nameof(Customer.BillingAddress), nameof(dbo.Address.State)),
-                    db.alias(nameof(Customer.BillingAddress), nameof(dbo.Address.Zip)),
-                    db.alias(nameof(Customer.ShippingAddress), nameof(dbo.Address.Line1)),
-                    db.alias(nameof(Customer.ShippingAddress), nameof(dbo.Address.Line2)),
-                    db.alias(nameof(Customer.ShippingAddress), nameof(dbo.Address.City)),
-                    db.alias(nameof(Customer.ShippingAddress), nameof(dbo.Address.State)),
-                    db.alias(nameof(Customer.ShippingAddress), nameof(dbo.Address.Zip))
+                    dbex.alias(nameof(Customer.MailingAddress), nameof(dbo.Address.Line1)),
+                    dbex.alias(nameof(Customer.MailingAddress), nameof(dbo.Address.Line2)),
+                    dbex.alias(nameof(Customer.MailingAddress), nameof(dbo.Address.City)),
+                    dbex.alias(nameof(Customer.MailingAddress), nameof(dbo.Address.State)),
+                    dbex.alias(nameof(Customer.MailingAddress), nameof(dbo.Address.Zip)),
+                    dbex.alias(nameof(Customer.BillingAddress), nameof(dbo.Address.Line1)),
+                    dbex.alias(nameof(Customer.BillingAddress), nameof(dbo.Address.Line2)),
+                    dbex.alias(nameof(Customer.BillingAddress), nameof(dbo.Address.City)),
+                    dbex.alias(nameof(Customer.BillingAddress), nameof(dbo.Address.State)),
+                    dbex.alias(nameof(Customer.BillingAddress), nameof(dbo.Address.Zip)),
+                    dbex.alias(nameof(Customer.ShippingAddress), nameof(dbo.Address.Line1)),
+                    dbex.alias(nameof(Customer.ShippingAddress), nameof(dbo.Address.Line2)),
+                    dbex.alias(nameof(Customer.ShippingAddress), nameof(dbo.Address.City)),
+                    dbex.alias(nameof(Customer.ShippingAddress), nameof(dbo.Address.State)),
+                    dbex.alias(nameof(Customer.ShippingAddress), nameof(dbo.Address.Zip))
                 )
                 .From(dbo.Person)
                 .LeftJoin(
@@ -346,7 +346,7 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
                     .From(dbo.Address)
                     .InnerJoin(dbo.PersonAddress).On(dbo.PersonAddress.AddressId == dbo.Address.Id)
                     .Where(dbo.PersonAddress.PersonId == personId & dbo.Address.AddressType == AddressType.Mailing)
-                ).As(nameof(Customer.MailingAddress)).On(dbo.Person.Id == db.alias(nameof(Customer.MailingAddress), nameof(dbo.PersonAddress.PersonId)))
+                ).As(nameof(Customer.MailingAddress)).On(dbo.Person.Id == dbex.alias(nameof(Customer.MailingAddress), nameof(dbo.PersonAddress.PersonId)))
                 .LeftJoin(
                     db.SelectOne(
                         dbo.PersonAddress.PersonId,
@@ -359,7 +359,7 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
                     .From(dbo.Address)
                     .InnerJoin(dbo.PersonAddress).On(dbo.PersonAddress.AddressId == dbo.Address.Id)
                     .Where(dbo.PersonAddress.PersonId == personId & dbo.Address.AddressType == AddressType.Billing)
-                ).As(nameof(Customer.BillingAddress)).On(dbo.Person.Id == db.alias(nameof(Customer.BillingAddress), nameof(dbo.PersonAddress.PersonId)))
+                ).As(nameof(Customer.BillingAddress)).On(dbo.Person.Id == dbex.alias(nameof(Customer.BillingAddress), nameof(dbo.PersonAddress.PersonId)))
                 .LeftJoin(
                     db.SelectOne(
                         dbo.PersonAddress.PersonId,
@@ -372,7 +372,7 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
                     .From(dbo.Address)
                     .InnerJoin(dbo.PersonAddress).On(dbo.PersonAddress.AddressId == dbo.Address.Id)
                     .Where(dbo.PersonAddress.PersonId == personId & dbo.Address.AddressType == AddressType.Shipping)
-                ).As(nameof(Customer.ShippingAddress)).On(dbo.Person.Id == db.alias(nameof(Customer.ShippingAddress), nameof(dbo.PersonAddress.PersonId)))
+                ).As(nameof(Customer.ShippingAddress)).On(dbo.Person.Id == dbex.alias(nameof(Customer.ShippingAddress), nameof(dbo.PersonAddress.PersonId)))
                 .Where(dbo.Person.Id == personId)
                 .ExecuteAsync(
                     sqlRow =>

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Average.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Average.cs
@@ -342,12 +342,12 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             ConfigureForMsSqlVersion(version);
 
             var exp = db.SelectOne(
-                    db.fx.Avg(db.alias("lines", "PurchasePrice")).Distinct().As("alias")
+                    db.fx.Avg(dbex.alias("lines", "PurchasePrice")).Distinct().As("alias")
                 ).From(dbo.Purchase)
                 .InnerJoin(
                     db.SelectMany<PurchaseLine>()
                     .From(dbo.PurchaseLine)
-                ).As("lines").On(dbo.Purchase.Id == db.alias("lines", "PurchaseId"));
+                ).As("lines").On(dbo.Purchase.Id == dbex.alias("lines", "PurchaseId"));
 
             //when               
             object avg = exp.Execute();

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Cast.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Cast.cs
@@ -221,13 +221,13 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             ConfigureForMsSqlVersion(version);
 
             var exp = db.SelectOne(
-                    db.fx.Cast(db.alias("lines", "PurchasePrice")).AsVarChar(50).As("alias")
+                    db.fx.Cast(dbex.alias("lines", "PurchasePrice")).AsVarChar(50).As("alias")
                 ).From(dbo.Purchase)
                 .InnerJoin(
                     db.SelectMany<PurchaseLine>().Top(100)
                     .From(dbo.PurchaseLine)
                     .OrderBy(dbo.PurchaseLine.PurchasePrice.Desc)
-                ).As("lines").On(dbo.Purchase.Id == db.alias("lines", "PurchaseId"));
+                ).As("lines").On(dbo.Purchase.Id == dbex.alias("lines", "PurchaseId"));
 
             //when               
             object result = exp.Execute();

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Ceiling.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Ceiling.cs
@@ -119,12 +119,12 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             ConfigureForMsSqlVersion(version);
 
             var exp = db.SelectOne(
-                    db.fx.Ceiling(db.alias("lines", "PurchasePrice")).As("alias")
+                    db.fx.Ceiling(dbex.alias("lines", "PurchasePrice")).As("alias")
                 ).From(dbo.Purchase)
                 .InnerJoin(
                     db.SelectMany<PurchaseLine>()
                     .From(dbo.PurchaseLine)
-                ).As("lines").On(dbo.Purchase.Id == db.alias("lines", "PurchaseId"));
+                ).As("lines").On(dbo.Purchase.Id == dbex.alias("lines", "PurchaseId"));
 
             //when               
             object value = exp.Execute();

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Count.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Count.cs
@@ -155,12 +155,12 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             ConfigureForMsSqlVersion(version);
 
             var exp = db.SelectOne(
-                    db.fx.Count(db.alias("lines","PurchaseId")).Distinct().As("alias")
+                    db.fx.Count(dbex.alias("lines","PurchaseId")).Distinct().As("alias")
                 ).From(dbo.Purchase)
                 .InnerJoin(
                     db.SelectMany<PurchaseLine>()
                     .From(dbo.PurchaseLine)
-                ).As("lines").On(dbo.Purchase.Id == db.alias("lines", "PurchaseId"));
+                ).As("lines").On(dbo.Purchase.Id == dbex.alias("lines", "PurchaseId"));
 
             //when               
             int result = exp.Execute();

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/DateDiff.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/DateDiff.cs
@@ -163,13 +163,13 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             ConfigureForMsSqlVersion(version);
 
             var exp = db.SelectOne(
-                    db.fx.DateDiff(DateParts.Day, db.alias("lines", "DateCreated"), dbo.Purchase.ShipDate).As("alias")
+                    db.fx.DateDiff(DateParts.Day, dbex.alias("lines", "DateCreated"), dbo.Purchase.ShipDate).As("alias")
                 ).From(dbo.Purchase)
                 .InnerJoin(
                     db.SelectMany<PurchaseLine>().Top(100)
                     .From(dbo.PurchaseLine)
                     .OrderBy(dbo.PurchaseLine.PurchasePrice.Desc)
-                ).As("lines").On(dbo.Purchase.Id == db.alias("lines", "PurchaseId"));
+                ).As("lines").On(dbo.Purchase.Id == dbex.alias("lines", "PurchaseId"));
 
             //when               
             int? result = exp.Execute();

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/DatePart.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/DatePart.cs
@@ -183,13 +183,13 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             ConfigureForMsSqlVersion(version);
 
             var exp = db.SelectOne(
-                    db.fx.DatePart(DateParts.Day, db.alias("lines", "DateCreated")).As("alias")
+                    db.fx.DatePart(DateParts.Day, dbex.alias("lines", "DateCreated")).As("alias")
                 ).From(dbo.Purchase)
                 .InnerJoin(
                     db.SelectMany<PurchaseLine>().Top(100)
                     .From(dbo.PurchaseLine)
                     .OrderBy(dbo.PurchaseLine.PurchasePrice.Desc)
-                ).As("lines").On(dbo.Purchase.Id == db.alias("lines", "PurchaseId"));
+                ).As("lines").On(dbo.Purchase.Id == dbex.alias("lines", "PurchaseId"));
 
             //when               
             int? result = exp.Execute();

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Floor.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Floor.cs
@@ -119,12 +119,12 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             ConfigureForMsSqlVersion(version);
 
             var exp = db.SelectOne(
-                    db.fx.Floor(db.alias("lines", "PurchasePrice")).As("alias")
+                    db.fx.Floor(dbex.alias("lines", "PurchasePrice")).As("alias")
                 ).From(dbo.Purchase)
                 .InnerJoin(
                     db.SelectMany<PurchaseLine>()
                     .From(dbo.PurchaseLine)
-                ).As("lines").On(dbo.Purchase.Id == db.alias("lines", "PurchaseId"));
+                ).As("lines").On(dbo.Purchase.Id == dbex.alias("lines", "PurchaseId"));
 
             //when               
             object value = exp.Execute();

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/IsNull.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/IsNull.cs
@@ -310,13 +310,13 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             ConfigureForMsSqlVersion(version);
 
             var exp = db.SelectOne(
-                    db.fx.IsNull(db.alias("lines", "PurchasePrice"), 0).As("alias")
+                    db.fx.IsNull(dbex.alias("lines", "PurchasePrice"), 0).As("alias")
                 ).From(dbo.Purchase)
                 .LeftJoin(
                     db.SelectOne<PurchaseLine>()
                     .From(dbo.PurchaseLine)
                     .OrderBy(dbo.PurchaseLine.PurchasePrice.Desc)
-                ).As("lines").On(dbo.Purchase.Id == db.alias("lines", "PurchaseId"))
+                ).As("lines").On(dbo.Purchase.Id == dbex.alias("lines", "PurchaseId"))
                 .Where(dbo.Purchase.Id == 1);
 
             //when               

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Maximum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Maximum.cs
@@ -137,12 +137,12 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             ConfigureForMsSqlVersion(version);
 
             var exp = db.SelectOne(
-                    db.fx.Max(db.alias("lines", "PurchasePrice")).As("alias")
+                    db.fx.Max(dbex.alias("lines", "PurchasePrice")).As("alias")
                 ).From(dbo.Purchase)
                 .InnerJoin(
                     db.SelectMany<PurchaseLine>()
                     .From(dbo.PurchaseLine)
-                ).As("lines").On(dbo.Purchase.Id == db.alias("lines", "PurchaseId"));
+                ).As("lines").On(dbo.Purchase.Id == dbex.alias("lines", "PurchaseId"));
 
             //when               
             object result = exp.Execute();

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Minimum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Minimum.cs
@@ -137,12 +137,12 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             ConfigureForMsSqlVersion(version);
 
             var exp = db.SelectOne(
-                    db.fx.Min(db.alias("lines", "PurchasePrice")).As("alias")
+                    db.fx.Min(dbex.alias("lines", "PurchasePrice")).As("alias")
                 ).From(dbo.Purchase)
                 .InnerJoin(
                     db.SelectMany<PurchaseLine>()
                     .From(dbo.PurchaseLine)
-                ).As("lines").On(dbo.Purchase.Id == db.alias("lines", "PurchaseId"));
+                ).As("lines").On(dbo.Purchase.Id == dbex.alias("lines", "PurchaseId"));
 
             //when               
             object result = exp.Execute();

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/PopulationStandardDeviation.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/PopulationStandardDeviation.cs
@@ -137,12 +137,12 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             ConfigureForMsSqlVersion(version);
 
             var exp = db.SelectOne(
-                    db.fx.StDevP(db.alias("lines", "PurchaseId")).Distinct().As("alias")
+                    db.fx.StDevP(dbex.alias("lines", "PurchaseId")).Distinct().As("alias")
                 ).From(dbo.Purchase)
                 .InnerJoin(
                     db.SelectMany<PurchaseLine>()
                     .From(dbo.PurchaseLine)
-                ).As("lines").On(dbo.Purchase.Id == db.alias("lines", "PurchaseId"));
+                ).As("lines").On(dbo.Purchase.Id == dbex.alias("lines", "PurchaseId"));
 
             //when               
             object result = exp.Execute();

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/PopulationVariance.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/PopulationVariance.cs
@@ -137,12 +137,12 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             ConfigureForMsSqlVersion(version);
 
             var exp = db.SelectOne(
-                    db.fx.VarP(db.alias("lines", "PurchaseId")).Distinct().As("alias")
+                    db.fx.VarP(dbex.alias("lines", "PurchaseId")).Distinct().As("alias")
                 ).From(dbo.Purchase)
                 .InnerJoin(
                     db.SelectMany<PurchaseLine>()
                     .From(dbo.PurchaseLine)
-                ).As("lines").On(dbo.Purchase.Id == db.alias("lines", "PurchaseId"));
+                ).As("lines").On(dbo.Purchase.Id == dbex.alias("lines", "PurchaseId"));
 
             //when               
             object result = exp.Execute();

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/StandardDeviation.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/StandardDeviation.cs
@@ -137,12 +137,12 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             ConfigureForMsSqlVersion(version);
 
             var exp = db.SelectOne(
-                    db.fx.StDev(db.alias("lines", "PurchaseId")).Distinct().As("alias")
+                    db.fx.StDev(dbex.alias("lines", "PurchaseId")).Distinct().As("alias")
                 ).From(dbo.Purchase)
                 .InnerJoin(
                     db.SelectMany<PurchaseLine>()
                     .From(dbo.PurchaseLine)
-                ).As("lines").On(dbo.Purchase.Id == db.alias("lines", "PurchaseId"));
+                ).As("lines").On(dbo.Purchase.Id == dbex.alias("lines", "PurchaseId"));
 
             //when               
             object result = exp.Execute();

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Sum.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Sum.cs
@@ -138,12 +138,12 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             ConfigureForMsSqlVersion(version);
 
             var exp = db.SelectOne(
-                    db.fx.Sum(db.alias("lines", "PurchasePrice")).As("alias")
+                    db.fx.Sum(dbex.alias("lines", "PurchasePrice")).As("alias")
                 ).From(dbo.Purchase)
                 .InnerJoin(
                     db.SelectMany<PurchaseLine>()
                     .From(dbo.PurchaseLine)
-                ).As("lines").On(dbo.Purchase.Id == db.alias("lines", "PurchaseId"));
+                ).As("lines").On(dbo.Purchase.Id == dbex.alias("lines", "PurchaseId"));
 
             //when               
             object result = exp.Execute();

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Variance.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Functions/Variance.cs
@@ -137,12 +137,12 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             ConfigureForMsSqlVersion(version);
 
             var exp = db.SelectOne(
-                    db.fx.Var(db.alias("lines", "PurchaseId")).As("alias")
+                    db.fx.Var(dbex.alias("lines", "PurchaseId")).As("alias")
                 ).From(dbo.Purchase)
                 .InnerJoin(
                     db.SelectMany<PurchaseLine>()
                     .From(dbo.PurchaseLine)
-                ).As("lines").On(dbo.Purchase.Id == db.alias("lines", "PurchaseId"));
+                ).As("lines").On(dbo.Purchase.Id == dbex.alias("lines", "PurchaseId"));
 
             //when               
             object result = exp.Execute();

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Insert/Insert.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Insert/Insert.cs
@@ -40,7 +40,7 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
 
             //then
             var t1 = dbo.Address.As("a");
-            var last_insert = db.alias("last_insert", "identity");
+            var last_insert = dbex.alias("last_insert", "identity");
             var address = db.SelectOne<Address>()
                 .From(t1)
                 .InnerJoin(
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
                         db.fx.Max(dbo.Product.Id).As("identity")
                     )
                     .From(dbo.Product)
-                ).As("last_insert").On(t1.Id == db.alias("last_insert","identity"))
+                ).As("last_insert").On(t1.Id == dbex.alias("last_insert","identity"))
                 .Execute();
 
             product.Should().NotBeNull();

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Random.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Random.cs
@@ -109,7 +109,7 @@ namespace HatTrick.DbEx.MsSql.Test.Database
 
             SelectEntity<Person> next = new MsSqlSelectEntityQueryExpressionBuilder<Person>(config, new SelectQueryExpression());
             person = next.From(dbo.Person)
-                .InnerJoin(db.SelectOne<Person>().From(dbo.Person)).As("foo").On(dbo.Person.Id == db.alias("foo", "Id"))
+                .InnerJoin(db.SelectOne<Person>().From(dbo.Person)).As("foo").On(dbo.Person.Id == dbex.alias("foo", "Id"))
                 .Where(dbo.Person.Id == 1)
                 .OrderBy(dbo.Person.FirstName)
                 .Execute();

--- a/test/HatTrick.DbEx.MsSql.Test/Generated/DbExDataService.generated.cs
+++ b/test/HatTrick.DbEx.MsSql.Test/Generated/DbExDataService.generated.cs
@@ -989,11 +989,6 @@ namespace DbEx.DataService
         {
         }
         #endregion
-
-        #region alias
-        public static AliasExpression alias(string tableName, string fieldName)
-            => new AliasExpression(tableName, fieldName);
-        #endregion
     }
     #endregion
 
@@ -1199,6 +1194,9 @@ namespace DbEx.dboDataService
         /// <item>
         /// <term>allow null</term><description>no</description>
         /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
+        /// </item>
         /// </list>
         /// </para>
         /// </summary>
@@ -1217,6 +1215,9 @@ namespace DbEx.dboDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -1707,6 +1708,9 @@ namespace DbEx.dboDataService
         /// <item>
         /// <term>allow null</term><description>no</description>
         /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
+        /// </item>
         /// </list>
         /// </para>
         /// </summary>
@@ -1725,6 +1729,9 @@ namespace DbEx.dboDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -2142,6 +2149,9 @@ namespace DbEx.dboDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -2623,6 +2633,9 @@ namespace DbEx.dboDataService
         /// <item>
         /// <term>allow null</term><description>no</description>
         /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
+        /// </item>
         /// </list>
         /// </para>
         /// </summary>
@@ -2641,6 +2654,9 @@ namespace DbEx.dboDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -3484,7 +3500,7 @@ namespace DbEx.dboDataService
         /// <term>allow null</term><description>no</description>
         /// </item>
         /// <item>
-        /// <term>default</term><description>(getutcdate())</description>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -3504,6 +3520,9 @@ namespace DbEx.dboDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -4091,6 +4110,9 @@ namespace DbEx.dboDataService
         /// <item>
         /// <term>allow null</term><description>no</description>
         /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
+        /// </item>
         /// </list>
         /// </para>
         /// </summary>
@@ -4109,6 +4131,9 @@ namespace DbEx.dboDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>
@@ -4834,6 +4859,9 @@ namespace DbEx.secDataService
         /// <item>
         /// <term>allow null</term><description>no</description>
         /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
+        /// </item>
         /// </list>
         /// </para>
         /// </summary>
@@ -4852,6 +4880,9 @@ namespace DbEx.secDataService
         /// </item>
         /// <item>
         /// <term>allow null</term><description>no</description>
+        /// </item>
+        /// <item>
+        /// <term>default</term><description>(getdate())</description>
         /// </item>
         /// </list>
         /// </para>

--- a/tools/HatTrick.DbEx.Tools/HatTrick.DbEx.Tools.csproj
+++ b/tools/HatTrick.DbEx.Tools/HatTrick.DbEx.Tools.csproj
@@ -11,7 +11,6 @@
     <None Remove="Resources\Templates\DbExDataPackage._cs.htt" />
     <None Remove="Resources\Templates\DbExDataService._cs.htt" />
     <None Remove="Resources\Templates\DbExMetadata._cs.htt" />
-    <None Remove="Resources\Templates\Partials\Alias.htt" />
     <None Remove="Resources\Templates\Partials\DataPackage.htt" />
     <None Remove="Resources\Templates\Partials\Db.htt" />
     <None Remove="Resources\Templates\Partials\DbMetadata.htt" />
@@ -33,7 +32,6 @@
     <EmbeddedResource Include="Resources\Templates\DbExDataPackage._cs.htt" />
     <EmbeddedResource Include="Resources\Templates\DbExDataService._cs.htt" />
     <EmbeddedResource Include="Resources\Templates\DbExMetadata._cs.htt" />
-    <EmbeddedResource Include="Resources\Templates\Partials\Alias.htt" />
     <EmbeddedResource Include="Resources\Templates\Partials\DataPackage.htt" />
     <EmbeddedResource Include="Resources\Templates\Partials\Db.htt" />
     <EmbeddedResource Include="Resources\Templates\Partials\DbMetadata.htt" />

--- a/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/Alias.htt
+++ b/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/Alias.htt
@@ -1,4 +1,0 @@
-﻿        #region alias
-        public static AliasExpression alias(string tableName, string fieldName)
-            => new AliasExpression(tableName, fieldName);
-        #endregion

--- a/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/RuntimeDb.htt
+++ b/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/RuntimeDb.htt
@@ -1200,7 +1200,5 @@
         #endregion
 
 {+>("Fx") => GetTemplatePartial+}
-
-{+>("Alias") => GetTemplatePartial+}
     }}
     #endregion


### PR DESCRIPTION
…lias('table', 'field') instead of db.alias('table', 'field').