### PR TITLE
Changed how updates work when providing two objects for comparison.

### DIFF
--- a/samples/mssql/NetCoreConsoleApp/Data/_Generated/DbExDataService.generated.cs
+++ b/samples/mssql/NetCoreConsoleApp/Data/_Generated/DbExDataService.generated.cs
@@ -36,7 +36,7 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectEntity{TEntity}"/>, a fluent builder for constructing a sql SELECT query expression for a <typeparamref name="TEntity"/> entity.</returns>
+        /// <returns><see cref="SelectEntity{TEntity}"/>, a fluent builder for constructing a sql SELECT query expression for a <typeparamref name="TEntity"/> entity.</returns>
         /// <typeparam name="TEntity">The entity type to select.</typeparam>
         public static SelectEntity<TEntity> SelectOne<TEntity>()
             where TEntity : class, IDbEntity
@@ -48,10 +48,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.EnumElement{TEnum}" />
+        /// <param name="element">An expression of type <see cref="Sql.EnumElement{TEnum}" />
         ///, for example "dbo.Person.GenderType"
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression for a <typeparamref name="TEntity"/> entity.</returns>
+        /// <returns><see cref="Sql.SelectValue{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression for a <typeparamref name="TEntity"/> entity.</returns>
         /// <typeparam name="TEnum">The type of the Enum to select.</typeparam>
         public static SelectValue<TEnum> SelectOne<TEnum>(EnumElement<TEnum> element)
             where TEnum : struct, Enum, IComparable
@@ -63,10 +63,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableEnumElement{TEnum}" />
+        /// <param name="element">An expression of type <see cref="NullableEnumElement{TEnum}" />
         ///, for example "dbo.Address.AddressType"
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         /// <typeparam name="TEnum">The type of the Enum to select.</typeparam>
         public static SelectValue<TEnum?> SelectOne<TEnum>(NullableEnumElement<TEnum> element)
             where TEnum : struct, Enum, IComparable
@@ -78,10 +78,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.AnyObjectElement" />
+        /// <param name="element">An expression of type <see cref="AnyObjectElement" />
         ///, for example "dbo.Person.GenderType"
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<object> SelectOne(AnyObjectElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -91,9 +91,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.BooleanElement" />
+        /// <param name="element">An expression of type <see cref="BooleanElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<bool> SelectOne(BooleanElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -103,9 +103,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableBooleanElement" />
+        /// <param name="element">An expression of type <see cref="NullableBooleanElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<bool?> SelectOne(NullableBooleanElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -115,9 +115,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.ByteElement" />
+        /// <param name="element">An expression of type <see cref="ByteElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<byte> SelectOne(ByteElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -127,9 +127,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableByteElement" />
+        /// <param name="element">An expression of type <see cref="NullableByteElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<byte?> SelectOne(NullableByteElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -139,10 +139,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.ByteArrayElement" />
+        /// <param name="element">An expression of type <see cref="ByteArrayElement" />
         ///, for example "dbo.Product.Image" or "db.fx.IsNull(dbo.Product.Image, new byte[0])"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<byte[]> SelectOne(ByteArrayElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -152,9 +152,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableByteArrayElement" />
+        /// <param name="element">An expression of type <see cref="NullableByteArrayElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<byte[]> SelectOne(NullableByteArrayElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -164,10 +164,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DateTimeElement" />
+        /// <param name="element">An expression of type <see cref="DateTimeElement" />
         ///, for example "dbo.Address.DateCreated", "db.fx.DateAdd(DateParts.Year, 1, dbo.Address.DateCreated) or "db.fx.IsNull(dbo.Address.DateCreated, DateTime.Now)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<DateTime> SelectOne(DateTimeElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -177,10 +177,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDateTimeElement" />
+        /// <param name="element">An expression of type <see cref="NullableDateTimeElement" />
         ///, for example "dbo.Person.BirthDate" or "db.fx.DateAdd(DateParts.Year, 1, dbo.Person.BirthDate)
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<DateTime?> SelectOne(NullableDateTimeElement field)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, field);
 
@@ -190,10 +190,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DateTimeOffsetElement" />
+        /// <param name="element">An expression of type <see cref="DateTimeOffsetElement" />
         ///, for example "sec.Person.DateCreated", "db.fx.DateAdd(DateParts.Year, 1, sec.Person.DateCreated)" or "db.fx.IsNull(sec.Person.DateCreated, DateTimeOffset.Now)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<DateTimeOffset> SelectOne(DateTimeOffsetElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -203,9 +203,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDateTimeOffsetElement" />
+        /// <param name="element">An expression of type <see cref="NullableDateTimeOffsetElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<DateTimeOffset?> SelectOne(NullableDateTimeOffsetElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -215,10 +215,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DecimalElement" />
+        /// <param name="element">An expression of type <see cref="DecimalElement" />
         ///, for example "dbo.Product.ShippingWeight" or "db.fx.IsNull(dbo.Product.ShippingWeight, decimal.MinValue)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<decimal> SelectOne(DecimalElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -228,10 +228,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDecimalElement" />
+        /// <param name="element">An expression of type <see cref="NullableDecimalElement" />
         ///, for example "dbo.Product.Height" or "db.fx.Min(dbo.Product.Height)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<decimal?> SelectOne(NullableDecimalElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -241,10 +241,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DoubleElement" />
+        /// <param name="element">An expression of type <see cref="DoubleElement" />
         ///, for example "dbo.Product.ListPrice" or "db.fx.IsNull(dbo.Product.ListPrice, double.MinValue)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<double> SelectOne(DoubleElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -254,10 +254,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDoubleElement" />
+        /// <param name="element">An expression of type <see cref="NullableDoubleElement" />
         ///, for example "dbo.PersonTotalPurchasesView.TotalAmount" or "db.fx.Min(dbo.PersonTotalPurchasesView.TotalAmount)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<double?> SelectOne(NullableDoubleElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -267,9 +267,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.GuidElement" />
+        /// <param name="element">An expression of type <see cref="GuidElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<Guid> SelectOne(GuidElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -279,10 +279,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableGuidElement" />
+        /// <param name="element">An expression of type <see cref="NullableGuidElement" />
         ///, for example "dbo.Purchase.TrackingIdentifier"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<Guid?> SelectOne(NullableGuidElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -292,9 +292,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int16Element" />
+        /// <param name="element">An expression of type <see cref="Int16Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<short> SelectOne(Int16Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -304,9 +304,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt16Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt16Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<short?> SelectOne(NullableInt16Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -316,10 +316,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int32Element" />
+        /// <param name="element">An expression of type <see cref="Int32Element" />
         ///, for example "dbo.Address.Id" or "db.fx.Avg(dbo.Address.Id)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<int> SelectOne(Int32Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -329,10 +329,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt32Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt32Element" />
         ///, for example "dbo.Person.CreditLimit" or "db.fx.Avg(dbo.Person.CreditLimit)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<int?> SelectOne(NullableInt32Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -342,9 +342,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int64Element" />
+        /// <param name="element">An expression of type <see cref="Int64Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<long> SelectOne(Int64Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -354,9 +354,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt64Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt64Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<long?> SelectOne(NullableInt64Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -366,9 +366,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.SingleElement" />
+        /// <param name="element">An expression of type <see cref="SingleElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<float> SelectOne(SingleElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -378,9 +378,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableSingleElement" />
+        /// <param name="element">An expression of type <see cref="NullableSingleElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<float?> SelectOne(NullableSingleElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -390,10 +390,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.StringElement" />
+        /// <param name="element">An expression of type <see cref="StringElement" />
         ///, for example "dbo.Address.Line1" or "db.fx.Concat("Value: ", dbo.Address.Line1)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<string> SelectOne(StringElement element) 
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -403,9 +403,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableStringElement" />
+        /// <param name="element">An expression of type <see cref="NullableStringElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<string> SelectOne(NullableStringElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -415,9 +415,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.TimeSpanElement" />
+        /// <param name="element">An expression of type <see cref="TimeSpanElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<TimeSpan> SelectOne(TimeSpanElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -427,15 +427,15 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableTimeSpanElement" />
+        /// <param name="element">An expression of type <see cref="NullableTimeSpanElement" />
         ///, for example "dbo.Product.ValidStartTimeOfDayForPurchase"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<TimeSpan?> SelectOne(NullableTimeSpanElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
         /// <summary>
-        /// Start constructing a sql SELECT query expression for a single <see cref="System.Dynamic.ExpandoObject" /> object.  The dynamic properties of the returned objects are defined by the <see cref="HatTrick.DbEx.Sql.AnyElement" /> method parameters.
+        /// Start constructing a sql SELECT query expression for a single <see cref="System.Dynamic.ExpandoObject" /> object.  The dynamic properties of the returned objects are defined by the <see cref="AnyElement" /> method parameters.
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
@@ -443,19 +443,19 @@ namespace SimpleConsole.DataService
         /// <param name="element1">Any expression</param>
         /// <param name="element2">Any expression</param>
         /// <param name="elements">Any expression</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<ExpandoObject> SelectOne(AnyElement element1, AnyElement element2, params AnyElement[] elements)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element1, element2, elements);
 
         /// <summary>
-        /// Start constructing a sql SELECT query expression for a single <see cref="System.Dynamic.ExpandoObject" /> object.  The dynamic properties of the returned objects are defined by the <see cref="HatTrick.DbEx.Sql.AnyElement" /> method parameters.
+        /// Start constructing a sql SELECT query expression for a single <see cref="System.Dynamic.ExpandoObject" /> object.  The dynamic properties of the returned objects are defined by the <see cref="AnyElement" /> method parameters.
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
         /// <param name="element1">Any expression</param>
         /// <param name="elements">A list of any expression</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<ExpandoObject> SelectOne(IEnumerable<AnyElement> elements)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, elements);
         #endregion
@@ -470,7 +470,7 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectEntities{TEntity}"/>, a fluent builder for constructing a sql SELECT query expression for a list of <typeparamref name="TEntity"/> entities.</returns>
+        /// <returns><see cref="SelectEntities{TEntity}"/>, a fluent builder for constructing a sql SELECT query expression for a list of <typeparamref name="TEntity"/> entities.</returns>
         /// <typeparam name="TEntity">The entity type to select.</typeparam>
         public static SelectEntities<TEntity> SelectMany<TEntity>()
            where TEntity : class, IDbEntity
@@ -482,10 +482,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.EnumElement{TEnum}" />
+        /// <param name="element">An expression of type <see cref="EnumElement{TEnum}" />
         ///, for example "dbo.Person.GenderType"
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression for a list of <typeparamref name="TEntity"/> entities.</returns>
+        /// <returns><see cref="SelectValues{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression for a list of <typeparamref name="TEntity"/> entities.</returns>
         public static SelectValues<TEnum> SelectMany<TEnum>(EnumElement<TEnum> element)
             where TEnum : struct, Enum, IComparable
             => expressionBuilderFactory.CreateSelectValuesBuilder<TEnum>(config, element);
@@ -496,10 +496,10 @@ namespace SimpleConsole.DataService
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableEnumElement{TEnum}" />
+        /// <param name="element">An expression of type <see cref="NullableEnumElement{TEnum}" />
         ///, for example "dbo.Address.AddressType"
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<TEnum?> SelectMany<TEnum>(NullableEnumElement<TEnum> element)
             where TEnum : struct, Enum, IComparable
             => expressionBuilderFactory.CreateSelectValuesBuilder<TEnum>(config, element);
@@ -510,10 +510,10 @@ namespace SimpleConsole.DataService
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.AnyObjectElement" />
+        /// <param name="element">An expression of type <see cref="AnyObjectElement" />
         ///, for example "db.fx.Coalesce(dbo.Person.CreditLimit, dbo.Address.Line1)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<object> SelectMany(AnyObjectElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -523,9 +523,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.BooleanElement" />
+        /// <param name="element">An expression of type <see cref="BooleanElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<bool> SelectMany(BooleanElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -535,9 +535,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableBooleanElement" />
+        /// <param name="element">An expression of type <see cref="NullableBooleanElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<bool?> SelectMany(NullableBooleanElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -547,9 +547,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.ByteElement" />
+        /// <param name="element">An expression of type <see cref="ByteElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<byte> SelectMany(ByteElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -559,9 +559,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableByteElement" />
+        /// <param name="element">An expression of type <see cref="NullableByteElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<byte?> SelectMany(NullableByteElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -571,10 +571,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.ByteArrayElement" />
+        /// <param name="element">An expression of type <see cref="ByteArrayElement" />
         ///, for example "dbo.Product.Image" or "db.fx.IsNull(dbo.Product.Image, new byte[0])"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<byte[]> SelectMany(ByteArrayElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -584,9 +584,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableByteArrayElement" />
+        /// <param name="element">An expression of type <see cref="NullableByteArrayElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<byte[]> SelectMany(NullableByteArrayElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -596,10 +596,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DateTimeElement" />
+        /// <param name="element">An expression of type <see cref="DateTimeElement" />
         ///, for example "dbo.Address.DateCreated", "db.fx.DateAdd(DateParts.Year, 1, dbo.Address.DateCreated) or "db.fx.IsNull(dbo.Address.DateCreated, DateTime.Now)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<DateTime> SelectMany(DateTimeElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -609,10 +609,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDateTimeElement" />
+        /// <param name="element">An expression of type <see cref="NullableDateTimeElement" />
         ///, for example "dbo.Person.BirthDate" or "db.fx.DateAdd(DateParts.Year, 1, dbo.Person.BirthDate)
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<DateTime?> SelectMany(NullableDateTimeElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -622,10 +622,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DateTimeOffsetElement" />
+        /// <param name="element">An expression of type <see cref="DateTimeOffsetElement" />
         ///, for example "sec.Person.DateCreated", "db.fx.DateAdd(DateParts.Year, 1, sec.Person.DateCreated)" or "db.fx.IsNull(sec.Person.DateCreated, DateTimeOffset.Now)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<DateTimeOffset> SelectMany(DateTimeOffsetElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -635,9 +635,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDateTimeOffsetElement" />
+        /// <param name="element">An expression of type <see cref="NullableDateTimeOffsetElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<DateTimeOffset?> SelectMany(NullableDateTimeOffsetElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -647,10 +647,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DecimalElement" />
+        /// <param name="element">An expression of type <see cref="DecimalElement" />
         ///, for example "dbo.Product.ShippingWeight" or "db.fx.IsNull(dbo.Product.ShippingWeight, decimal.MinValue)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<decimal> SelectMany(DecimalElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -660,10 +660,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDecimalElement" />
+        /// <param name="element">An expression of type <see cref="NullableDecimalElement" />
         ///, for example "dbo.Product.Height"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<decimal?> SelectMany(NullableDecimalElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -673,10 +673,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DoubleElement" />
+        /// <param name="element">An expression of type <see cref="DoubleElement" />
         ///, for example "dbo.Product.ListPrice" or "db.fx.IsNull(dbo.Product.ListPrice, double.MinValue)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<double> SelectMany(DoubleElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -686,10 +686,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDoubleElement" />
+        /// <param name="element">An expression of type <see cref="NullableDoubleElement" />
         ///, for example "dbo.PersonTotalPurchasesView.TotalAmount"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<double?> SelectMany(NullableDoubleElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -699,9 +699,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.GuidElement" />
+        /// <param name="element">An expression of type <see cref="GuidElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<Guid> SelectMany(GuidElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -711,10 +711,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableGuidElement" />
+        /// <param name="element">An expression of type <see cref="NullableGuidElement" />
         ///, for example "dbo.Purchase.TrackingIdentifier"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<Guid?> SelectMany(NullableGuidElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -724,9 +724,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int16Element" />
+        /// <param name="element">An expression of type <see cref="Int16Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<short> SelectMany(Int16Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -736,9 +736,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt16Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt16Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<short?> SelectMany(NullableInt16Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -748,10 +748,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int32Element" />
+        /// <param name="element">An expression of type <see cref="Int32Element" />
         ///, for example "dbo.Address.Id"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<int> SelectMany(Int32Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -761,10 +761,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt32Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt32Element" />
         ///, for example "dbo.:column.Entity.Name}.Id"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<int?> SelectMany(NullableInt32Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -774,9 +774,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int64Element" />
+        /// <param name="element">An expression of type <see cref="Int64Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<long> SelectMany(Int64Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -786,9 +786,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt64Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt64Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<long?> SelectMany(NullableInt64Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -798,9 +798,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.SingleElement" />
+        /// <param name="element">An expression of type <see cref="SingleElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<float> SelectMany(SingleElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -810,9 +810,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableSingleElement" />
+        /// <param name="element">An expression of type <see cref="NullableSingleElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<float?> SelectMany(NullableSingleElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -822,10 +822,10 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.StringElement" />
+        /// <param name="element">An expression of type <see cref="StringElement" />
         ///, for example "dbo.Address.Line1" or "db.fx.Concat("Value: ", dbo.Address.Line1)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<string> SelectMany(StringElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -835,9 +835,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableStringElement" />
+        /// <param name="element">An expression of type <see cref="NullableStringElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<string> SelectMany(NullableStringElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -847,9 +847,9 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.TimeSpanElement" />
+        /// <param name="element">An expression of type <see cref="TimeSpanElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<TimeSpan> SelectMany(TimeSpanElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -859,15 +859,15 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableTimeSpanElement" />
+        /// <param name="element">An expression of type <see cref="NullableTimeSpanElement" />
         ///, for example "dbo.Product.ValidStartTimeOfDayForPurchase"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<TimeSpan?> SelectMany(NullableTimeSpanElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
         /// <summary>
-        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="HatTrick.DbEx.Sql.AnyElement" /> method parameters.
+        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="AnyElement" /> method parameters.
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
@@ -875,18 +875,18 @@ namespace SimpleConsole.DataService
         /// <param name="element1">Any expression</param>
         /// <param name="element2">Any expression</param>
         /// <param name="elements">Any expression</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<ExpandoObject> SelectMany(AnyElement element1, AnyElement element2, params AnyElement[] elements)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element1, element2, elements);
 
         /// <summary>
-        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="HatTrick.DbEx.Sql.AnyElement" /> method parameters.
+        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="AnyElement" /> method parameters.
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
         /// <param name="elements">A list of any expression</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<ExpandoObject> SelectMany(IEnumerable<AnyElement> elements)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, elements);
         #endregion
@@ -898,11 +898,11 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/update-transact-sql">Microsoft docs on UPDATE</see>
         /// </para>
         /// </summary>
-        /// <param name="assignments">A list of <see cref="HatTrick.DbEx.Sql.EntityFieldAssignment" />(s) that assign a database field/column a new value.  
+        /// <param name="assignments">A list of <see cref="EntityFieldAssignment" />(s) that assign a database field/column a new value.  
         /// For example "dbo.Address.Line1.Set("new value")"
         /// or "dbo.Person.CreditLimit.Set(dbo.Person.CreditLimit + 10)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.UpdateEntities"/>, a fluent builder for constructing a sql UPDATE statement.</returns>
+        /// <returns><see cref="UpdateEntities"/>, a fluent builder for constructing a sql UPDATE statement.</returns>
         public static UpdateEntities Update(params EntityFieldAssignment[] assignments)
             => expressionBuilderFactory.CreateUpdateExpressionBuilder(config, assignments);
 
@@ -912,29 +912,13 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/update-transact-sql">Microsoft docs on UPDATE</see>
         /// </para>
         /// </summary>
-        /// <param name="assignments">A list of <see cref="HatTrick.DbEx.Sql.EntityFieldAssignment" />(s) that assign a database field/column a new value.  
+        /// <param name="assignments">A list of <see cref="EntityFieldAssignment" />(s) that assign a database field/column a new value.  
         /// For example "dbo.Address.Line1.Set("new value")"
         /// or "dbo.Person.CreditLimit.Set(dbo.Person.CreditLimit + 10)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.UpdateEntities"/>, a fluent builder for constructing a sql UPDATE statement.</returns>
-        public static UpdateEntities Update(IList<EntityFieldAssignment> assignments)
-            => expressionBuilderFactory.CreateUpdateExpressionBuilder(config, assignments);
-
-        /// <summary>
-        /// Start constructing a sql UPDATE query expression to update record(s) based on the comparison of property values between two entity instances.
-        /// <para>
-        /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/update-transact-sql">Microsoft docs on UPDATE</see>
-        /// </para>
-        /// </summary>
-        /// <param name="oldStateOfEntity">If a property value differs from the corresponding property value in "<paramref name="newStateOfEntity"/>", an assignment expression will be generated with the value set to the property value from "<paramref name="newStateOfEntity"/>".  
-        /// </param>
-        /// <param name="newStateOfEntity">Records will be updated to the property values from this entity when they differ from the property values in "<paramref name="oldStateOfEntity"/>". 
-        /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.UpdateEntities{TEntity}"/>, a fluent builder for constructing a sql UPDATE statement, with a list of "<see cref="HatTrick.DbEx.Sql.EntityFieldAssignment"/>" constructed from the comparison of the two entity params.</returns>
-        /// <typeparam name="TEntity">The entity type to update.</typeparam>
-        public static UpdateEntities<TEntity> Update<TEntity>(TEntity oldStateOfEntity, TEntity newStateOfEntity)
-            where TEntity : class, IDbEntity
-            => expressionBuilderFactory.CreateUpdateExpressionBuilder<TEntity>(config, oldStateOfEntity, newStateOfEntity);     
+        /// <returns><see cref="UpdateEntities"/>, a fluent builder for constructing a sql UPDATE statement.</returns>
+        public static UpdateEntities Update(IEnumerable<EntityFieldAssignment> assignments)
+            => expressionBuilderFactory.CreateUpdateExpressionBuilder(config, assignments);   
         #endregion
 
         #region delete
@@ -944,7 +928,7 @@ namespace SimpleConsole.DataService
         /// <see href="https://docs.microsoft.com/en-us/sql/t-sql/statements/delete-transact-sql">Microsoft docs on DELETE</see>
         /// </para>
         /// </summary>
-        /// <returns><see cref="HatTrick.DbEx.Sql.DeleteEntities"/>, a fluent builder for constructing a sql DELETE statement.</returns>
+        /// <returns><see cref="DeleteEntities"/>, a fluent builder for constructing a sql DELETE statement.</returns>
         public static DeleteEntities Delete()
             => expressionBuilderFactory.CreateDeleteExpressionBulder(config);
         #endregion
@@ -958,7 +942,7 @@ namespace SimpleConsole.DataService
         /// </summary>
         /// <param name="entity">The entity supplying the property values.
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.InsertEntity{TEntity}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
+        /// <returns><see cref="InsertEntity{TEntity}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
         /// <typeparam name="TEntity">The entity type of the entity to insert.</typeparam>
         public static InsertEntity<TEntity> Insert<TEntity>(TEntity entity)
             where TEntity : class, IDbEntity
@@ -972,7 +956,7 @@ namespace SimpleConsole.DataService
         /// </summary>
         /// <param name="entities">A list of entities.
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.InsertEntities{TEntity}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
+        /// <returns><see cref="InsertEntities{TEntity}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
         /// <typeparam name="TEntity">The entity type of the entities to insert.</typeparam>
         public static InsertEntities<TEntity> InsertMany<TEntity>(params TEntity[] entities)
             where TEntity : class, IDbEntity
@@ -986,7 +970,7 @@ namespace SimpleConsole.DataService
         /// </summary>
         /// <param name="entities">A list of entities.
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.InsertEntities{TEntity}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
+        /// <returns><see cref="InsertEntities{TEntity}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
         /// <typeparam name="TEntity">The entity type of the entities to insert.</typeparam>
         public static InsertEntities<TEntity> InsertMany<TEntity>(IList<TEntity> entities)
             where TEntity : class, IDbEntity
@@ -997,10 +981,10 @@ namespace SimpleConsole.DataService
         /// <summary>
         /// Creates a connection to the database.
         /// <para>
-        /// The connection has not been opened, use <see cref="System.Data.IDbConnection.Open"/> or <see cref="HatTrick.DbEx.Sql.Connection.ISqlConnection.EnsureOpen"/> to ensure an open connection to the database prior to operations like <see cref="System.Data.IDbConnection.BeginTransaction"/>.
+        /// The connection has not been opened, use <see cref="System.Data.IDbConnection.Open"/> or <see cref="Connection.ISqlConnection.EnsureOpen"/> to ensure an open connection to the database prior to operations like <see cref="System.Data.IDbConnection.BeginTransaction"/>.
         /// </para>
         /// </summary>
-        /// <returns><see cref="HatTrick.DbEx.Sql.Connection.ISqlConnection"/>, a connection to the database.</returns>
+        /// <returns><see cref="ISqlConnection"/>, a connection to the database.</returns>
         public static ISqlConnection GetConnection()
             => new SqlConnector(config.ConnectionFactory);
         #endregion

--- a/samples/mssql/ServerSideBlazorApp/Data/_Generated/DbExDataService.generated.cs
+++ b/samples/mssql/ServerSideBlazorApp/Data/_Generated/DbExDataService.generated.cs
@@ -36,7 +36,7 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectEntity{TEntity}"/>, a fluent builder for constructing a sql SELECT query expression for a <typeparamref name="TEntity"/> entity.</returns>
+        /// <returns><see cref="SelectEntity{TEntity}"/>, a fluent builder for constructing a sql SELECT query expression for a <typeparamref name="TEntity"/> entity.</returns>
         /// <typeparam name="TEntity">The entity type to select.</typeparam>
         public static SelectEntity<TEntity> SelectOne<TEntity>()
             where TEntity : class, IDbEntity
@@ -48,10 +48,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.EnumElement{TEnum}" />
+        /// <param name="element">An expression of type <see cref="Sql.EnumElement{TEnum}" />
         ///, for example "dbo.Person.GenderType"
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression for a <typeparamref name="TEntity"/> entity.</returns>
+        /// <returns><see cref="Sql.SelectValue{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression for a <typeparamref name="TEntity"/> entity.</returns>
         /// <typeparam name="TEnum">The type of the Enum to select.</typeparam>
         public static SelectValue<TEnum> SelectOne<TEnum>(EnumElement<TEnum> element)
             where TEnum : struct, Enum, IComparable
@@ -63,10 +63,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableEnumElement{TEnum}" />
+        /// <param name="element">An expression of type <see cref="NullableEnumElement{TEnum}" />
         ///, for example "dbo.Address.AddressType"
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         /// <typeparam name="TEnum">The type of the Enum to select.</typeparam>
         public static SelectValue<TEnum?> SelectOne<TEnum>(NullableEnumElement<TEnum> element)
             where TEnum : struct, Enum, IComparable
@@ -78,10 +78,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.AnyObjectElement" />
+        /// <param name="element">An expression of type <see cref="AnyObjectElement" />
         ///, for example "dbo.Person.GenderType"
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<object> SelectOne(AnyObjectElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -91,9 +91,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.BooleanElement" />
+        /// <param name="element">An expression of type <see cref="BooleanElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<bool> SelectOne(BooleanElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -103,9 +103,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableBooleanElement" />
+        /// <param name="element">An expression of type <see cref="NullableBooleanElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<bool?> SelectOne(NullableBooleanElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -115,9 +115,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.ByteElement" />
+        /// <param name="element">An expression of type <see cref="ByteElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<byte> SelectOne(ByteElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -127,9 +127,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableByteElement" />
+        /// <param name="element">An expression of type <see cref="NullableByteElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<byte?> SelectOne(NullableByteElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -139,10 +139,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.ByteArrayElement" />
+        /// <param name="element">An expression of type <see cref="ByteArrayElement" />
         ///, for example "dbo.Product.Image" or "db.fx.IsNull(dbo.Product.Image, new byte[0])"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<byte[]> SelectOne(ByteArrayElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -152,9 +152,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableByteArrayElement" />
+        /// <param name="element">An expression of type <see cref="NullableByteArrayElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<byte[]> SelectOne(NullableByteArrayElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -164,10 +164,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DateTimeElement" />
+        /// <param name="element">An expression of type <see cref="DateTimeElement" />
         ///, for example "dbo.Address.DateCreated", "db.fx.DateAdd(DateParts.Year, 1, dbo.Address.DateCreated) or "db.fx.IsNull(dbo.Address.DateCreated, DateTime.Now)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<DateTime> SelectOne(DateTimeElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -177,10 +177,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDateTimeElement" />
+        /// <param name="element">An expression of type <see cref="NullableDateTimeElement" />
         ///, for example "dbo.Person.BirthDate" or "db.fx.DateAdd(DateParts.Year, 1, dbo.Person.BirthDate)
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<DateTime?> SelectOne(NullableDateTimeElement field)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, field);
 
@@ -190,10 +190,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DateTimeOffsetElement" />
+        /// <param name="element">An expression of type <see cref="DateTimeOffsetElement" />
         ///, for example "sec.Person.DateCreated", "db.fx.DateAdd(DateParts.Year, 1, sec.Person.DateCreated)" or "db.fx.IsNull(sec.Person.DateCreated, DateTimeOffset.Now)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<DateTimeOffset> SelectOne(DateTimeOffsetElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -203,9 +203,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDateTimeOffsetElement" />
+        /// <param name="element">An expression of type <see cref="NullableDateTimeOffsetElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<DateTimeOffset?> SelectOne(NullableDateTimeOffsetElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -215,10 +215,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DecimalElement" />
+        /// <param name="element">An expression of type <see cref="DecimalElement" />
         ///, for example "dbo.Product.ShippingWeight" or "db.fx.IsNull(dbo.Product.ShippingWeight, decimal.MinValue)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<decimal> SelectOne(DecimalElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -228,10 +228,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDecimalElement" />
+        /// <param name="element">An expression of type <see cref="NullableDecimalElement" />
         ///, for example "dbo.Product.Height" or "db.fx.Min(dbo.Product.Height)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<decimal?> SelectOne(NullableDecimalElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -241,10 +241,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DoubleElement" />
+        /// <param name="element">An expression of type <see cref="DoubleElement" />
         ///, for example "dbo.Product.ListPrice" or "db.fx.IsNull(dbo.Product.ListPrice, double.MinValue)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<double> SelectOne(DoubleElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -254,10 +254,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDoubleElement" />
+        /// <param name="element">An expression of type <see cref="NullableDoubleElement" />
         ///, for example "dbo.PersonTotalPurchasesView.TotalAmount" or "db.fx.Min(dbo.PersonTotalPurchasesView.TotalAmount)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<double?> SelectOne(NullableDoubleElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -267,9 +267,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.GuidElement" />
+        /// <param name="element">An expression of type <see cref="GuidElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<Guid> SelectOne(GuidElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -279,10 +279,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableGuidElement" />
+        /// <param name="element">An expression of type <see cref="NullableGuidElement" />
         ///, for example "dbo.Purchase.TrackingIdentifier"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<Guid?> SelectOne(NullableGuidElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -292,9 +292,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int16Element" />
+        /// <param name="element">An expression of type <see cref="Int16Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<short> SelectOne(Int16Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -304,9 +304,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt16Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt16Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<short?> SelectOne(NullableInt16Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -316,10 +316,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int32Element" />
+        /// <param name="element">An expression of type <see cref="Int32Element" />
         ///, for example "dbo.Address.Id" or "db.fx.Avg(dbo.Address.Id)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<int> SelectOne(Int32Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -329,10 +329,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt32Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt32Element" />
         ///, for example "dbo.Person.CreditLimit" or "db.fx.Avg(dbo.Person.CreditLimit)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<int?> SelectOne(NullableInt32Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -342,9 +342,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int64Element" />
+        /// <param name="element">An expression of type <see cref="Int64Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<long> SelectOne(Int64Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -354,9 +354,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt64Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt64Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<long?> SelectOne(NullableInt64Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -366,9 +366,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.SingleElement" />
+        /// <param name="element">An expression of type <see cref="SingleElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<float> SelectOne(SingleElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -378,9 +378,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableSingleElement" />
+        /// <param name="element">An expression of type <see cref="NullableSingleElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<float?> SelectOne(NullableSingleElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -390,10 +390,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.StringElement" />
+        /// <param name="element">An expression of type <see cref="StringElement" />
         ///, for example "dbo.Address.Line1" or "db.fx.Concat("Value: ", dbo.Address.Line1)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<string> SelectOne(StringElement element) 
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -403,9 +403,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableStringElement" />
+        /// <param name="element">An expression of type <see cref="NullableStringElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<string> SelectOne(NullableStringElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -415,9 +415,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.TimeSpanElement" />
+        /// <param name="element">An expression of type <see cref="TimeSpanElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<TimeSpan> SelectOne(TimeSpanElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -427,15 +427,15 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableTimeSpanElement" />
+        /// <param name="element">An expression of type <see cref="NullableTimeSpanElement" />
         ///, for example "dbo.Product.ValidStartTimeOfDayForPurchase"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<TimeSpan?> SelectOne(NullableTimeSpanElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
         /// <summary>
-        /// Start constructing a sql SELECT query expression for a single <see cref="System.Dynamic.ExpandoObject" /> object.  The dynamic properties of the returned objects are defined by the <see cref="HatTrick.DbEx.Sql.AnyElement" /> method parameters.
+        /// Start constructing a sql SELECT query expression for a single <see cref="System.Dynamic.ExpandoObject" /> object.  The dynamic properties of the returned objects are defined by the <see cref="AnyElement" /> method parameters.
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
@@ -443,19 +443,19 @@ namespace ServerSideBlazorApp.DataService
         /// <param name="element1">Any expression</param>
         /// <param name="element2">Any expression</param>
         /// <param name="elements">Any expression</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<ExpandoObject> SelectOne(AnyElement element1, AnyElement element2, params AnyElement[] elements)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element1, element2, elements);
 
         /// <summary>
-        /// Start constructing a sql SELECT query expression for a single <see cref="System.Dynamic.ExpandoObject" /> object.  The dynamic properties of the returned objects are defined by the <see cref="HatTrick.DbEx.Sql.AnyElement" /> method parameters.
+        /// Start constructing a sql SELECT query expression for a single <see cref="System.Dynamic.ExpandoObject" /> object.  The dynamic properties of the returned objects are defined by the <see cref="AnyElement" /> method parameters.
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
         /// <param name="element1">Any expression</param>
         /// <param name="elements">A list of any expression</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<ExpandoObject> SelectOne(IEnumerable<AnyElement> elements)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, elements);
         #endregion
@@ -470,7 +470,7 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectEntities{TEntity}"/>, a fluent builder for constructing a sql SELECT query expression for a list of <typeparamref name="TEntity"/> entities.</returns>
+        /// <returns><see cref="SelectEntities{TEntity}"/>, a fluent builder for constructing a sql SELECT query expression for a list of <typeparamref name="TEntity"/> entities.</returns>
         /// <typeparam name="TEntity">The entity type to select.</typeparam>
         public static SelectEntities<TEntity> SelectMany<TEntity>()
            where TEntity : class, IDbEntity
@@ -482,10 +482,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.EnumElement{TEnum}" />
+        /// <param name="element">An expression of type <see cref="EnumElement{TEnum}" />
         ///, for example "dbo.Person.GenderType"
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression for a list of <typeparamref name="TEntity"/> entities.</returns>
+        /// <returns><see cref="SelectValues{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression for a list of <typeparamref name="TEntity"/> entities.</returns>
         public static SelectValues<TEnum> SelectMany<TEnum>(EnumElement<TEnum> element)
             where TEnum : struct, Enum, IComparable
             => expressionBuilderFactory.CreateSelectValuesBuilder<TEnum>(config, element);
@@ -496,10 +496,10 @@ namespace ServerSideBlazorApp.DataService
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableEnumElement{TEnum}" />
+        /// <param name="element">An expression of type <see cref="NullableEnumElement{TEnum}" />
         ///, for example "dbo.Address.AddressType"
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<TEnum?> SelectMany<TEnum>(NullableEnumElement<TEnum> element)
             where TEnum : struct, Enum, IComparable
             => expressionBuilderFactory.CreateSelectValuesBuilder<TEnum>(config, element);
@@ -510,10 +510,10 @@ namespace ServerSideBlazorApp.DataService
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.AnyObjectElement" />
+        /// <param name="element">An expression of type <see cref="AnyObjectElement" />
         ///, for example "db.fx.Coalesce(dbo.Person.CreditLimit, dbo.Address.Line1)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<object> SelectMany(AnyObjectElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -523,9 +523,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.BooleanElement" />
+        /// <param name="element">An expression of type <see cref="BooleanElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<bool> SelectMany(BooleanElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -535,9 +535,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableBooleanElement" />
+        /// <param name="element">An expression of type <see cref="NullableBooleanElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<bool?> SelectMany(NullableBooleanElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -547,9 +547,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.ByteElement" />
+        /// <param name="element">An expression of type <see cref="ByteElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<byte> SelectMany(ByteElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -559,9 +559,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableByteElement" />
+        /// <param name="element">An expression of type <see cref="NullableByteElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<byte?> SelectMany(NullableByteElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -571,10 +571,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.ByteArrayElement" />
+        /// <param name="element">An expression of type <see cref="ByteArrayElement" />
         ///, for example "dbo.Product.Image" or "db.fx.IsNull(dbo.Product.Image, new byte[0])"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<byte[]> SelectMany(ByteArrayElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -584,9 +584,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableByteArrayElement" />
+        /// <param name="element">An expression of type <see cref="NullableByteArrayElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<byte[]> SelectMany(NullableByteArrayElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -596,10 +596,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DateTimeElement" />
+        /// <param name="element">An expression of type <see cref="DateTimeElement" />
         ///, for example "dbo.Address.DateCreated", "db.fx.DateAdd(DateParts.Year, 1, dbo.Address.DateCreated) or "db.fx.IsNull(dbo.Address.DateCreated, DateTime.Now)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<DateTime> SelectMany(DateTimeElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -609,10 +609,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDateTimeElement" />
+        /// <param name="element">An expression of type <see cref="NullableDateTimeElement" />
         ///, for example "dbo.Person.BirthDate" or "db.fx.DateAdd(DateParts.Year, 1, dbo.Person.BirthDate)
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<DateTime?> SelectMany(NullableDateTimeElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -622,10 +622,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DateTimeOffsetElement" />
+        /// <param name="element">An expression of type <see cref="DateTimeOffsetElement" />
         ///, for example "sec.Person.DateCreated", "db.fx.DateAdd(DateParts.Year, 1, sec.Person.DateCreated)" or "db.fx.IsNull(sec.Person.DateCreated, DateTimeOffset.Now)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<DateTimeOffset> SelectMany(DateTimeOffsetElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -635,9 +635,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDateTimeOffsetElement" />
+        /// <param name="element">An expression of type <see cref="NullableDateTimeOffsetElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<DateTimeOffset?> SelectMany(NullableDateTimeOffsetElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -647,10 +647,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DecimalElement" />
+        /// <param name="element">An expression of type <see cref="DecimalElement" />
         ///, for example "dbo.Product.ShippingWeight" or "db.fx.IsNull(dbo.Product.ShippingWeight, decimal.MinValue)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<decimal> SelectMany(DecimalElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -660,10 +660,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDecimalElement" />
+        /// <param name="element">An expression of type <see cref="NullableDecimalElement" />
         ///, for example "dbo.Product.Height"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<decimal?> SelectMany(NullableDecimalElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -673,10 +673,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DoubleElement" />
+        /// <param name="element">An expression of type <see cref="DoubleElement" />
         ///, for example "dbo.Product.ListPrice" or "db.fx.IsNull(dbo.Product.ListPrice, double.MinValue)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<double> SelectMany(DoubleElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -686,10 +686,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDoubleElement" />
+        /// <param name="element">An expression of type <see cref="NullableDoubleElement" />
         ///, for example "dbo.PersonTotalPurchasesView.TotalAmount"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<double?> SelectMany(NullableDoubleElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -699,9 +699,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.GuidElement" />
+        /// <param name="element">An expression of type <see cref="GuidElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<Guid> SelectMany(GuidElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -711,10 +711,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableGuidElement" />
+        /// <param name="element">An expression of type <see cref="NullableGuidElement" />
         ///, for example "dbo.Purchase.TrackingIdentifier"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<Guid?> SelectMany(NullableGuidElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -724,9 +724,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int16Element" />
+        /// <param name="element">An expression of type <see cref="Int16Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<short> SelectMany(Int16Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -736,9 +736,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt16Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt16Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<short?> SelectMany(NullableInt16Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -748,10 +748,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int32Element" />
+        /// <param name="element">An expression of type <see cref="Int32Element" />
         ///, for example "dbo.Address.Id"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<int> SelectMany(Int32Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -761,10 +761,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt32Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt32Element" />
         ///, for example "dbo.:column.Entity.Name}.Id"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<int?> SelectMany(NullableInt32Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -774,9 +774,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int64Element" />
+        /// <param name="element">An expression of type <see cref="Int64Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<long> SelectMany(Int64Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -786,9 +786,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt64Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt64Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<long?> SelectMany(NullableInt64Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -798,9 +798,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.SingleElement" />
+        /// <param name="element">An expression of type <see cref="SingleElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<float> SelectMany(SingleElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -810,9 +810,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableSingleElement" />
+        /// <param name="element">An expression of type <see cref="NullableSingleElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<float?> SelectMany(NullableSingleElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -822,10 +822,10 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.StringElement" />
+        /// <param name="element">An expression of type <see cref="StringElement" />
         ///, for example "dbo.Address.Line1" or "db.fx.Concat("Value: ", dbo.Address.Line1)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<string> SelectMany(StringElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -835,9 +835,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableStringElement" />
+        /// <param name="element">An expression of type <see cref="NullableStringElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<string> SelectMany(NullableStringElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -847,9 +847,9 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.TimeSpanElement" />
+        /// <param name="element">An expression of type <see cref="TimeSpanElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<TimeSpan> SelectMany(TimeSpanElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -859,15 +859,15 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableTimeSpanElement" />
+        /// <param name="element">An expression of type <see cref="NullableTimeSpanElement" />
         ///, for example "dbo.Product.ValidStartTimeOfDayForPurchase"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<TimeSpan?> SelectMany(NullableTimeSpanElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
         /// <summary>
-        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="HatTrick.DbEx.Sql.AnyElement" /> method parameters.
+        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="AnyElement" /> method parameters.
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
@@ -875,18 +875,18 @@ namespace ServerSideBlazorApp.DataService
         /// <param name="element1">Any expression</param>
         /// <param name="element2">Any expression</param>
         /// <param name="elements">Any expression</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<ExpandoObject> SelectMany(AnyElement element1, AnyElement element2, params AnyElement[] elements)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element1, element2, elements);
 
         /// <summary>
-        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="HatTrick.DbEx.Sql.AnyElement" /> method parameters.
+        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="AnyElement" /> method parameters.
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
         /// <param name="elements">A list of any expression</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<ExpandoObject> SelectMany(IEnumerable<AnyElement> elements)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, elements);
         #endregion
@@ -898,11 +898,11 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/update-transact-sql">Microsoft docs on UPDATE</see>
         /// </para>
         /// </summary>
-        /// <param name="assignments">A list of <see cref="HatTrick.DbEx.Sql.EntityFieldAssignment" />(s) that assign a database field/column a new value.  
+        /// <param name="assignments">A list of <see cref="EntityFieldAssignment" />(s) that assign a database field/column a new value.  
         /// For example "dbo.Address.Line1.Set("new value")"
         /// or "dbo.Person.CreditLimit.Set(dbo.Person.CreditLimit + 10)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.UpdateEntities"/>, a fluent builder for constructing a sql UPDATE statement.</returns>
+        /// <returns><see cref="UpdateEntities"/>, a fluent builder for constructing a sql UPDATE statement.</returns>
         public static UpdateEntities Update(params EntityFieldAssignment[] assignments)
             => expressionBuilderFactory.CreateUpdateExpressionBuilder(config, assignments);
 
@@ -912,29 +912,13 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/update-transact-sql">Microsoft docs on UPDATE</see>
         /// </para>
         /// </summary>
-        /// <param name="assignments">A list of <see cref="HatTrick.DbEx.Sql.EntityFieldAssignment" />(s) that assign a database field/column a new value.  
+        /// <param name="assignments">A list of <see cref="EntityFieldAssignment" />(s) that assign a database field/column a new value.  
         /// For example "dbo.Address.Line1.Set("new value")"
         /// or "dbo.Person.CreditLimit.Set(dbo.Person.CreditLimit + 10)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.UpdateEntities"/>, a fluent builder for constructing a sql UPDATE statement.</returns>
-        public static UpdateEntities Update(IList<EntityFieldAssignment> assignments)
-            => expressionBuilderFactory.CreateUpdateExpressionBuilder(config, assignments);
-
-        /// <summary>
-        /// Start constructing a sql UPDATE query expression to update record(s) based on the comparison of property values between two entity instances.
-        /// <para>
-        /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/update-transact-sql">Microsoft docs on UPDATE</see>
-        /// </para>
-        /// </summary>
-        /// <param name="oldStateOfEntity">If a property value differs from the corresponding property value in "<paramref name="newStateOfEntity"/>", an assignment expression will be generated with the value set to the property value from "<paramref name="newStateOfEntity"/>".  
-        /// </param>
-        /// <param name="newStateOfEntity">Records will be updated to the property values from this entity when they differ from the property values in "<paramref name="oldStateOfEntity"/>". 
-        /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.UpdateEntities{TEntity}"/>, a fluent builder for constructing a sql UPDATE statement, with a list of "<see cref="HatTrick.DbEx.Sql.EntityFieldAssignment"/>" constructed from the comparison of the two entity params.</returns>
-        /// <typeparam name="TEntity">The entity type to update.</typeparam>
-        public static UpdateEntities<TEntity> Update<TEntity>(TEntity oldStateOfEntity, TEntity newStateOfEntity)
-            where TEntity : class, IDbEntity
-            => expressionBuilderFactory.CreateUpdateExpressionBuilder<TEntity>(config, oldStateOfEntity, newStateOfEntity);     
+        /// <returns><see cref="UpdateEntities"/>, a fluent builder for constructing a sql UPDATE statement.</returns>
+        public static UpdateEntities Update(IEnumerable<EntityFieldAssignment> assignments)
+            => expressionBuilderFactory.CreateUpdateExpressionBuilder(config, assignments);   
         #endregion
 
         #region delete
@@ -944,7 +928,7 @@ namespace ServerSideBlazorApp.DataService
         /// <see href="https://docs.microsoft.com/en-us/sql/t-sql/statements/delete-transact-sql">Microsoft docs on DELETE</see>
         /// </para>
         /// </summary>
-        /// <returns><see cref="HatTrick.DbEx.Sql.DeleteEntities"/>, a fluent builder for constructing a sql DELETE statement.</returns>
+        /// <returns><see cref="DeleteEntities"/>, a fluent builder for constructing a sql DELETE statement.</returns>
         public static DeleteEntities Delete()
             => expressionBuilderFactory.CreateDeleteExpressionBulder(config);
         #endregion
@@ -958,7 +942,7 @@ namespace ServerSideBlazorApp.DataService
         /// </summary>
         /// <param name="entity">The entity supplying the property values.
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.InsertEntity{TEntity}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
+        /// <returns><see cref="InsertEntity{TEntity}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
         /// <typeparam name="TEntity">The entity type of the entity to insert.</typeparam>
         public static InsertEntity<TEntity> Insert<TEntity>(TEntity entity)
             where TEntity : class, IDbEntity
@@ -972,7 +956,7 @@ namespace ServerSideBlazorApp.DataService
         /// </summary>
         /// <param name="entities">A list of entities.
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.InsertEntities{TEntity}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
+        /// <returns><see cref="InsertEntities{TEntity}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
         /// <typeparam name="TEntity">The entity type of the entities to insert.</typeparam>
         public static InsertEntities<TEntity> InsertMany<TEntity>(params TEntity[] entities)
             where TEntity : class, IDbEntity
@@ -986,7 +970,7 @@ namespace ServerSideBlazorApp.DataService
         /// </summary>
         /// <param name="entities">A list of entities.
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.InsertEntities{TEntity}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
+        /// <returns><see cref="InsertEntities{TEntity}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
         /// <typeparam name="TEntity">The entity type of the entities to insert.</typeparam>
         public static InsertEntities<TEntity> InsertMany<TEntity>(IList<TEntity> entities)
             where TEntity : class, IDbEntity
@@ -997,10 +981,10 @@ namespace ServerSideBlazorApp.DataService
         /// <summary>
         /// Creates a connection to the database.
         /// <para>
-        /// The connection has not been opened, use <see cref="System.Data.IDbConnection.Open"/> or <see cref="HatTrick.DbEx.Sql.Connection.ISqlConnection.EnsureOpen"/> to ensure an open connection to the database prior to operations like <see cref="System.Data.IDbConnection.BeginTransaction"/>.
+        /// The connection has not been opened, use <see cref="System.Data.IDbConnection.Open"/> or <see cref="Connection.ISqlConnection.EnsureOpen"/> to ensure an open connection to the database prior to operations like <see cref="System.Data.IDbConnection.BeginTransaction"/>.
         /// </para>
         /// </summary>
-        /// <returns><see cref="HatTrick.DbEx.Sql.Connection.ISqlConnection"/>, a connection to the database.</returns>
+        /// <returns><see cref="ISqlConnection"/>, a connection to the database.</returns>
         public static ISqlConnection GetConnection()
             => new SqlConnector(config.ConnectionFactory);
         #endregion

--- a/samples/mssql/ServerSideBlazorApp/Service/CustomerService.cs
+++ b/samples/mssql/ServerSideBlazorApp/Service/CustomerService.cs
@@ -291,13 +291,21 @@ namespace ServerSideBlazorApp.Service
                 .ExecuteAsync();
 
         private async Task UpdateAddressAsync(Address persisted, Address @new)
-            => await db.Update(
-                persisted,
-                @new
-            )
-            .From(dbo.Address)
-            .Where(dbo.Address.Id == persisted.Id)
-            .ExecuteAsync();
+        {
+            //build a list of assignment expressions for the update statement based on the difference between the two Address instances.
+            var assignments = dbex.BuildAssignmentsFor(dbo.Address).From(persisted).To(@new);
+
+            //if there are differences, execute an update.
+            if (assignments.Any())
+            {
+                await db.Update(
+                    assignments
+                )
+                .From(dbo.Address)
+                .Where(dbo.Address.Id == persisted.Id)
+                .ExecuteAsync();
+            }
+        }
 
         private async Task InsertAddressAsync(int customerId, Address address)
         {

--- a/src/HatTrick.DbEx.MsSql/Builder/MsSqlQueryExpressionBuilderFactory.cs
+++ b/src/HatTrick.DbEx.MsSql/Builder/MsSqlQueryExpressionBuilderFactory.cs
@@ -298,18 +298,11 @@ namespace HatTrick.DbEx.MsSql.Builder
         }
         #endregion
 
-        public UpdateEntities CreateUpdateExpressionBuilder(RuntimeSqlDatabaseConfiguration configuration, IList<EntityFieldAssignment> fields)
+        public UpdateEntities CreateUpdateExpressionBuilder(RuntimeSqlDatabaseConfiguration configuration, IEnumerable<EntityFieldAssignment> fields)
         {
             var expression = (configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.")).QueryExpressionFactory?.CreateQueryExpression<UpdateQueryExpression>() ?? throw new DbExpressionConfigurationException($"Expected query expression factory to return a query expression.");
             expression.Assign = new AssignmentExpressionSet(expression.Assign.Expressions.Concat(fields?.Select(x => x as AssignmentExpression ?? throw new DbExpressionException($"Expected all {nameof(fields)} to be assignable to {typeof(AssignmentExpression)}."))));
             return new MsSqlUpdateQueryExpressionBuilder(configuration, expression);
-        }
-
-        public UpdateEntities<TEntity> CreateUpdateExpressionBuilder<TEntity>(RuntimeSqlDatabaseConfiguration configuration, TEntity target, TEntity source)
-            where TEntity : class, IDbEntity
-        {
-            var expression = (configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.")).QueryExpressionFactory?.CreateQueryExpression<UpdateQueryExpression>() ?? throw new DbExpressionConfigurationException($"Expected query expression factory to return a query expression.");
-            return new UpdateEntitiesUpdateQueryExpressionBuilder<TEntity>(configuration, expression, target, source);
         }
 
         public DeleteEntities CreateDeleteExpressionBulder(RuntimeSqlDatabaseConfiguration configuration)

--- a/src/HatTrick.DbEx.MsSql/Builder/UpdateEntitiesUpdateQueryExpressionBuilder{T}.cs
+++ b/src/HatTrick.DbEx.MsSql/Builder/UpdateEntitiesUpdateQueryExpressionBuilder{T}.cs
@@ -13,12 +13,6 @@ namespace HatTrick.DbEx.MsSql.Builder
         {
 
         }
-
-        public UpdateEntitiesUpdateQueryExpressionBuilder(RuntimeSqlDatabaseConfiguration configuration, UpdateQueryExpression expression, TEntity target, TEntity source)
-            : base(configuration, expression, target, source)
-        {
-
-        }
         #endregion
 
         #region methods

--- a/src/HatTrick.DbEx.Sql/Builder/EntityComparisonAssignmentBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/EntityComparisonAssignmentBuilder{T}.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace HatTrick.DbEx.Sql.Builder
+{
+    public class EntityComparisonAssignmentBuilder<TEntity> : EntityFieldAssignmentsContinuation<TEntity>
+            where TEntity : class, IDbEntity
+    {
+        #region internals
+        private readonly Entity<TEntity> entity;
+        private TEntity oldStateOfEntity;
+        #endregion
+
+        #region constructors
+        public EntityComparisonAssignmentBuilder(Entity<TEntity> entity)
+        {
+            this.entity = entity ?? throw new ArgumentNullException($"{nameof(entity)} is required.");
+        }
+        #endregion
+
+        #region methods
+        ///<inheritdoc/>
+        EntityFieldAssignmentsContinuation<TEntity> EntityFieldAssignmentsContinuation<TEntity>.From(TEntity oldStateOfEntity)
+        {
+            this.oldStateOfEntity = oldStateOfEntity ?? throw new ArgumentNullException($"{nameof(oldStateOfEntity)} is required.");
+            return this;
+        }
+
+        ///<inheritdoc/>
+        IEnumerable<EntityFieldAssignment> EntityFieldAssignmentsContinuation<TEntity>.To(TEntity newStateOfEntity)
+            => entity.BuildAssignmentExpression(newStateOfEntity ?? throw new ArgumentNullException($"{nameof(newStateOfEntity)} is required."), oldStateOfEntity).Expressions.Cast<EntityFieldAssignment>();
+        #endregion
+    }
+}

--- a/src/HatTrick.DbEx.Sql/Builder/UpdateEntitiesUpdateQueryExpressionBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/UpdateEntitiesUpdateQueryExpressionBuilder{T}.cs
@@ -10,22 +10,10 @@ namespace HatTrick.DbEx.Sql.Builder
         UpdateEntitiesContinuation<TEntity>
         where TEntity : class, IDbEntity
     {
-        #region internals
-        protected TEntity Target { get; set; }
-        protected TEntity Source { get; set; }
-        #endregion
-
         #region constructors
         protected UpdateEntitiesUpdateQueryExpressionBuilder(RuntimeSqlDatabaseConfiguration config, UpdateQueryExpression expression, EntityExpression<TEntity> entity) : base(config, expression, entity)
         {
 
-        }
-
-        protected UpdateEntitiesUpdateQueryExpressionBuilder(RuntimeSqlDatabaseConfiguration configuration, UpdateQueryExpression expression, TEntity target, TEntity source)
-            : base(configuration, expression)
-        {
-            Target = target ?? throw new ArgumentNullException($"{target} is required.");
-            Source = source ?? throw new ArgumentNullException($"{source} is required.");
         }
         #endregion
 
@@ -70,11 +58,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         UpdateEntitiesContinuation<TEntity> UpdateEntities<TEntity>.From(Entity<TEntity> entity)
-        {
-            var builder = CreateTypedBuilder(Configuration, Expression, entity as EntityExpression<TEntity> ?? throw new DbExpressionException($"Expected {nameof(entity)} to be of type {nameof(EntityExpression<TEntity>)}."));
-            Expression.Assign = entity.BuildAssignmentExpression(Target, Source);
-            return builder;
-        }
+            => CreateTypedBuilder(Configuration, Expression, entity as EntityExpression<TEntity> ?? throw new DbExpressionException($"Expected {nameof(entity)} to be of type {nameof(EntityExpression<TEntity>)}."));
         #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/_api/EntityFieldAssignmentsContinuation{T}.cs
+++ b/src/HatTrick.DbEx.Sql/_api/EntityFieldAssignmentsContinuation{T}.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace HatTrick.DbEx.Sql
+{
+ #pragma warning disable IDE1006 // Naming Styles
+    public interface EntityFieldAssignmentsContinuation<TEntity>
+           where TEntity : class, IDbEntity
+ #pragma warning restore IDE1006 // Naming Styles   
+    {
+        /// <summary>
+        /// Continue constructing a list of <see cref="EntityFieldAssignment"/>s.
+        /// </summary>
+        /// <param name="oldStateOfEntity">The source entity to use for property comparison to develop the list of <see cref="EntityFieldAssignment"/>s.  This is the entity that will be "overwritten".  
+        /// </param>
+        /// <returns><see cref="EntityFieldAssignmentsContinuation{TEntity}"/>, a fluent builder for constructing a sql UPDATE statement, with a list of "<see cref="HEntityFieldAssignment"/>" constructed from the comparison of the two entity params.</returns>
+        EntityFieldAssignmentsContinuation<TEntity> From(TEntity oldStateOfEntity);
+        /// <summary>
+        /// Complete constructing a list of <see cref="EntityFieldAssignment"/>s.
+        /// </summary>
+        /// <param name="newStateOfEntity">If a property value differs from the property value in the entity provided in <see cref="EntityFieldAssignmentsContinuation{TEntity}.From(TEntity)"/>, an <see cref="EntityFieldAssignment"/> will be generated with the value set to the property value from <paramref name="newStateOfEntity"/>.
+        /// </param>
+        /// <returns><see cref="IEnumerable{EntityFieldAssignmentBuilder}"/>, the list of <see cref="EntityFieldAssignment"/>s constructed from the comparison of two entities.</returns>
+        IEnumerable<EntityFieldAssignment> To(TEntity newStateOfEntity);
+    }
+}

--- a/src/HatTrick.DbEx.Sql/dbex.cs
+++ b/src/HatTrick.DbEx.Sql/dbex.cs
@@ -1,4 +1,5 @@
-﻿using HatTrick.DbEx.Sql.Expression;
+﻿using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql.Expression;
 using System;
 
 namespace HatTrick.DbEx.Sql
@@ -99,6 +100,17 @@ namespace HatTrick.DbEx.Sql
         /// </summary>
         public static NullableTimeSpanElement coerce(TimeSpanElement element)
             => new NullableTimeSpanExpressionMediator(element);
+
+        /// <summary>
+        /// Start constructing a list of <see cref="EntityFieldAssignment"/> containing update assignments for an <typeparamref name="TEntity"/> based on the differences between two <typeparamref name="TEntity"/> entities.  
+        /// The completion of this fluent builder is useful for building an UPDATE query expression for updating an <typeparamref name="TEntity"/> entity.
+        /// </summary>
+        /// <returns><see cref="EntityFieldAssignmentsContinuation{TEntity}"/>, a fluent continuation for the construction of a list of <see cref="EntityFieldAssignment"/>s.</returns>
+        public static EntityFieldAssignmentsContinuation<TEntity> BuildAssignmentsFor<TEntity>(Entity<TEntity> entity)
+            where TEntity : class, IDbEntity
+        {
+            return new EntityComparisonAssignmentBuilder<TEntity>(entity);
+        }
     }
 #pragma warning restore IDE1006 // Naming Styles
 }

--- a/test/HatTrick.DbEx.MsSql.Test/Generated/DbExDataService.generated.cs
+++ b/test/HatTrick.DbEx.MsSql.Test/Generated/DbExDataService.generated.cs
@@ -36,7 +36,7 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectEntity{TEntity}"/>, a fluent builder for constructing a sql SELECT query expression for a <typeparamref name="TEntity"/> entity.</returns>
+        /// <returns><see cref="SelectEntity{TEntity}"/>, a fluent builder for constructing a sql SELECT query expression for a <typeparamref name="TEntity"/> entity.</returns>
         /// <typeparam name="TEntity">The entity type to select.</typeparam>
         public static SelectEntity<TEntity> SelectOne<TEntity>()
             where TEntity : class, IDbEntity
@@ -48,10 +48,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.EnumElement{TEnum}" />
+        /// <param name="element">An expression of type <see cref="Sql.EnumElement{TEnum}" />
         ///, for example "dbo.Person.GenderType"
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression for a <typeparamref name="TEntity"/> entity.</returns>
+        /// <returns><see cref="Sql.SelectValue{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression for a <typeparamref name="TEntity"/> entity.</returns>
         /// <typeparam name="TEnum">The type of the Enum to select.</typeparam>
         public static SelectValue<TEnum> SelectOne<TEnum>(EnumElement<TEnum> element)
             where TEnum : struct, Enum, IComparable
@@ -63,10 +63,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableEnumElement{TEnum}" />
+        /// <param name="element">An expression of type <see cref="NullableEnumElement{TEnum}" />
         ///, for example "dbo.Address.AddressType"
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         /// <typeparam name="TEnum">The type of the Enum to select.</typeparam>
         public static SelectValue<TEnum?> SelectOne<TEnum>(NullableEnumElement<TEnum> element)
             where TEnum : struct, Enum, IComparable
@@ -78,10 +78,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.AnyObjectElement" />
+        /// <param name="element">An expression of type <see cref="AnyObjectElement" />
         ///, for example "dbo.Person.GenderType"
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<object> SelectOne(AnyObjectElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -91,9 +91,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.BooleanElement" />
+        /// <param name="element">An expression of type <see cref="BooleanElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<bool> SelectOne(BooleanElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -103,9 +103,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableBooleanElement" />
+        /// <param name="element">An expression of type <see cref="NullableBooleanElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<bool?> SelectOne(NullableBooleanElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -115,9 +115,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.ByteElement" />
+        /// <param name="element">An expression of type <see cref="ByteElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<byte> SelectOne(ByteElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -127,9 +127,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableByteElement" />
+        /// <param name="element">An expression of type <see cref="NullableByteElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<byte?> SelectOne(NullableByteElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -139,10 +139,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.ByteArrayElement" />
+        /// <param name="element">An expression of type <see cref="ByteArrayElement" />
         ///, for example "dbo.Product.Image" or "db.fx.IsNull(dbo.Product.Image, new byte[0])"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<byte[]> SelectOne(ByteArrayElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -152,9 +152,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableByteArrayElement" />
+        /// <param name="element">An expression of type <see cref="NullableByteArrayElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<byte[]> SelectOne(NullableByteArrayElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -164,10 +164,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DateTimeElement" />
+        /// <param name="element">An expression of type <see cref="DateTimeElement" />
         ///, for example "dbo.Address.DateCreated", "db.fx.DateAdd(DateParts.Year, 1, dbo.Address.DateCreated) or "db.fx.IsNull(dbo.Address.DateCreated, DateTime.Now)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<DateTime> SelectOne(DateTimeElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -177,10 +177,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDateTimeElement" />
+        /// <param name="element">An expression of type <see cref="NullableDateTimeElement" />
         ///, for example "dbo.Person.BirthDate" or "db.fx.DateAdd(DateParts.Year, 1, dbo.Person.BirthDate)
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<DateTime?> SelectOne(NullableDateTimeElement field)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, field);
 
@@ -190,10 +190,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DateTimeOffsetElement" />
+        /// <param name="element">An expression of type <see cref="DateTimeOffsetElement" />
         ///, for example "sec.Person.DateCreated", "db.fx.DateAdd(DateParts.Year, 1, sec.Person.DateCreated)" or "db.fx.IsNull(sec.Person.DateCreated, DateTimeOffset.Now)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<DateTimeOffset> SelectOne(DateTimeOffsetElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -203,9 +203,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDateTimeOffsetElement" />
+        /// <param name="element">An expression of type <see cref="NullableDateTimeOffsetElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<DateTimeOffset?> SelectOne(NullableDateTimeOffsetElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -215,10 +215,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DecimalElement" />
+        /// <param name="element">An expression of type <see cref="DecimalElement" />
         ///, for example "dbo.Product.ShippingWeight" or "db.fx.IsNull(dbo.Product.ShippingWeight, decimal.MinValue)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<decimal> SelectOne(DecimalElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -228,10 +228,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDecimalElement" />
+        /// <param name="element">An expression of type <see cref="NullableDecimalElement" />
         ///, for example "dbo.Product.Height" or "db.fx.Min(dbo.Product.Height)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<decimal?> SelectOne(NullableDecimalElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -241,10 +241,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DoubleElement" />
+        /// <param name="element">An expression of type <see cref="DoubleElement" />
         ///, for example "dbo.Product.ListPrice" or "db.fx.IsNull(dbo.Product.ListPrice, double.MinValue)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<double> SelectOne(DoubleElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -254,10 +254,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDoubleElement" />
+        /// <param name="element">An expression of type <see cref="NullableDoubleElement" />
         ///, for example "dbo.PersonTotalPurchasesView.TotalAmount" or "db.fx.Min(dbo.PersonTotalPurchasesView.TotalAmount)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<double?> SelectOne(NullableDoubleElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -267,9 +267,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.GuidElement" />
+        /// <param name="element">An expression of type <see cref="GuidElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<Guid> SelectOne(GuidElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -279,10 +279,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableGuidElement" />
+        /// <param name="element">An expression of type <see cref="NullableGuidElement" />
         ///, for example "dbo.Purchase.TrackingIdentifier"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<Guid?> SelectOne(NullableGuidElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -292,9 +292,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int16Element" />
+        /// <param name="element">An expression of type <see cref="Int16Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<short> SelectOne(Int16Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -304,9 +304,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt16Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt16Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<short?> SelectOne(NullableInt16Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -316,10 +316,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int32Element" />
+        /// <param name="element">An expression of type <see cref="Int32Element" />
         ///, for example "dbo.Address.Id" or "db.fx.Avg(dbo.Address.Id)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<int> SelectOne(Int32Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -329,10 +329,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt32Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt32Element" />
         ///, for example "dbo.Person.CreditLimit" or "db.fx.Avg(dbo.Person.CreditLimit)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<int?> SelectOne(NullableInt32Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -342,9 +342,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int64Element" />
+        /// <param name="element">An expression of type <see cref="Int64Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<long> SelectOne(Int64Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -354,9 +354,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt64Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt64Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<long?> SelectOne(NullableInt64Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -366,9 +366,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.SingleElement" />
+        /// <param name="element">An expression of type <see cref="SingleElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<float> SelectOne(SingleElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -378,9 +378,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableSingleElement" />
+        /// <param name="element">An expression of type <see cref="NullableSingleElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<float?> SelectOne(NullableSingleElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -390,10 +390,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.StringElement" />
+        /// <param name="element">An expression of type <see cref="StringElement" />
         ///, for example "dbo.Address.Line1" or "db.fx.Concat("Value: ", dbo.Address.Line1)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<string> SelectOne(StringElement element) 
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -403,9 +403,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableStringElement" />
+        /// <param name="element">An expression of type <see cref="NullableStringElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<string> SelectOne(NullableStringElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -415,9 +415,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.TimeSpanElement" />
+        /// <param name="element">An expression of type <see cref="TimeSpanElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<TimeSpan> SelectOne(TimeSpanElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -427,15 +427,15 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableTimeSpanElement" />
+        /// <param name="element">An expression of type <see cref="NullableTimeSpanElement" />
         ///, for example "dbo.Product.ValidStartTimeOfDayForPurchase"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<TimeSpan?> SelectOne(NullableTimeSpanElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
         /// <summary>
-        /// Start constructing a sql SELECT query expression for a single <see cref="System.Dynamic.ExpandoObject" /> object.  The dynamic properties of the returned objects are defined by the <see cref="HatTrick.DbEx.Sql.AnyElement" /> method parameters.
+        /// Start constructing a sql SELECT query expression for a single <see cref="System.Dynamic.ExpandoObject" /> object.  The dynamic properties of the returned objects are defined by the <see cref="AnyElement" /> method parameters.
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
@@ -443,19 +443,19 @@ namespace DbEx.DataService
         /// <param name="element1">Any expression</param>
         /// <param name="element2">Any expression</param>
         /// <param name="elements">Any expression</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<ExpandoObject> SelectOne(AnyElement element1, AnyElement element2, params AnyElement[] elements)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element1, element2, elements);
 
         /// <summary>
-        /// Start constructing a sql SELECT query expression for a single <see cref="System.Dynamic.ExpandoObject" /> object.  The dynamic properties of the returned objects are defined by the <see cref="HatTrick.DbEx.Sql.AnyElement" /> method parameters.
+        /// Start constructing a sql SELECT query expression for a single <see cref="System.Dynamic.ExpandoObject" /> object.  The dynamic properties of the returned objects are defined by the <see cref="AnyElement" /> method parameters.
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
         /// <param name="element1">Any expression</param>
         /// <param name="elements">A list of any expression</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<ExpandoObject> SelectOne(IEnumerable<AnyElement> elements)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, elements);
         #endregion
@@ -470,7 +470,7 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectEntities{TEntity}"/>, a fluent builder for constructing a sql SELECT query expression for a list of <typeparamref name="TEntity"/> entities.</returns>
+        /// <returns><see cref="SelectEntities{TEntity}"/>, a fluent builder for constructing a sql SELECT query expression for a list of <typeparamref name="TEntity"/> entities.</returns>
         /// <typeparam name="TEntity">The entity type to select.</typeparam>
         public static SelectEntities<TEntity> SelectMany<TEntity>()
            where TEntity : class, IDbEntity
@@ -482,10 +482,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.EnumElement{TEnum}" />
+        /// <param name="element">An expression of type <see cref="EnumElement{TEnum}" />
         ///, for example "dbo.Person.GenderType"
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression for a list of <typeparamref name="TEntity"/> entities.</returns>
+        /// <returns><see cref="SelectValues{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression for a list of <typeparamref name="TEntity"/> entities.</returns>
         public static SelectValues<TEnum> SelectMany<TEnum>(EnumElement<TEnum> element)
             where TEnum : struct, Enum, IComparable
             => expressionBuilderFactory.CreateSelectValuesBuilder<TEnum>(config, element);
@@ -496,10 +496,10 @@ namespace DbEx.DataService
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableEnumElement{TEnum}" />
+        /// <param name="element">An expression of type <see cref="NullableEnumElement{TEnum}" />
         ///, for example "dbo.Address.AddressType"
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TEnum}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<TEnum?> SelectMany<TEnum>(NullableEnumElement<TEnum> element)
             where TEnum : struct, Enum, IComparable
             => expressionBuilderFactory.CreateSelectValuesBuilder<TEnum>(config, element);
@@ -510,10 +510,10 @@ namespace DbEx.DataService
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.AnyObjectElement" />
+        /// <param name="element">An expression of type <see cref="AnyObjectElement" />
         ///, for example "db.fx.Coalesce(dbo.Person.CreditLimit, dbo.Address.Line1)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<object> SelectMany(AnyObjectElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -523,9 +523,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.BooleanElement" />
+        /// <param name="element">An expression of type <see cref="BooleanElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<bool> SelectMany(BooleanElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -535,9 +535,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableBooleanElement" />
+        /// <param name="element">An expression of type <see cref="NullableBooleanElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<bool?> SelectMany(NullableBooleanElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -547,9 +547,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.ByteElement" />
+        /// <param name="element">An expression of type <see cref="ByteElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<byte> SelectMany(ByteElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -559,9 +559,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableByteElement" />
+        /// <param name="element">An expression of type <see cref="NullableByteElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<byte?> SelectMany(NullableByteElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -571,10 +571,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.ByteArrayElement" />
+        /// <param name="element">An expression of type <see cref="ByteArrayElement" />
         ///, for example "dbo.Product.Image" or "db.fx.IsNull(dbo.Product.Image, new byte[0])"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<byte[]> SelectMany(ByteArrayElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -584,9 +584,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableByteArrayElement" />
+        /// <param name="element">An expression of type <see cref="NullableByteArrayElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<byte[]> SelectMany(NullableByteArrayElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -596,10 +596,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DateTimeElement" />
+        /// <param name="element">An expression of type <see cref="DateTimeElement" />
         ///, for example "dbo.Address.DateCreated", "db.fx.DateAdd(DateParts.Year, 1, dbo.Address.DateCreated) or "db.fx.IsNull(dbo.Address.DateCreated, DateTime.Now)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<DateTime> SelectMany(DateTimeElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -609,10 +609,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDateTimeElement" />
+        /// <param name="element">An expression of type <see cref="NullableDateTimeElement" />
         ///, for example "dbo.Person.BirthDate" or "db.fx.DateAdd(DateParts.Year, 1, dbo.Person.BirthDate)
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<DateTime?> SelectMany(NullableDateTimeElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -622,10 +622,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DateTimeOffsetElement" />
+        /// <param name="element">An expression of type <see cref="DateTimeOffsetElement" />
         ///, for example "sec.Person.DateCreated", "db.fx.DateAdd(DateParts.Year, 1, sec.Person.DateCreated)" or "db.fx.IsNull(sec.Person.DateCreated, DateTimeOffset.Now)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<DateTimeOffset> SelectMany(DateTimeOffsetElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -635,9 +635,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDateTimeOffsetElement" />
+        /// <param name="element">An expression of type <see cref="NullableDateTimeOffsetElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<DateTimeOffset?> SelectMany(NullableDateTimeOffsetElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -647,10 +647,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DecimalElement" />
+        /// <param name="element">An expression of type <see cref="DecimalElement" />
         ///, for example "dbo.Product.ShippingWeight" or "db.fx.IsNull(dbo.Product.ShippingWeight, decimal.MinValue)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<decimal> SelectMany(DecimalElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -660,10 +660,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDecimalElement" />
+        /// <param name="element">An expression of type <see cref="NullableDecimalElement" />
         ///, for example "dbo.Product.Height"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<decimal?> SelectMany(NullableDecimalElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -673,10 +673,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DoubleElement" />
+        /// <param name="element">An expression of type <see cref="DoubleElement" />
         ///, for example "dbo.Product.ListPrice" or "db.fx.IsNull(dbo.Product.ListPrice, double.MinValue)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<double> SelectMany(DoubleElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -686,10 +686,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDoubleElement" />
+        /// <param name="element">An expression of type <see cref="NullableDoubleElement" />
         ///, for example "dbo.PersonTotalPurchasesView.TotalAmount"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<double?> SelectMany(NullableDoubleElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -699,9 +699,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.GuidElement" />
+        /// <param name="element">An expression of type <see cref="GuidElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<Guid> SelectMany(GuidElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -711,10 +711,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableGuidElement" />
+        /// <param name="element">An expression of type <see cref="NullableGuidElement" />
         ///, for example "dbo.Purchase.TrackingIdentifier"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<Guid?> SelectMany(NullableGuidElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -724,9 +724,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int16Element" />
+        /// <param name="element">An expression of type <see cref="Int16Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<short> SelectMany(Int16Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -736,9 +736,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt16Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt16Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<short?> SelectMany(NullableInt16Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -748,10 +748,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int32Element" />
+        /// <param name="element">An expression of type <see cref="Int32Element" />
         ///, for example "dbo.Address.Id"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<int> SelectMany(Int32Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -761,10 +761,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt32Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt32Element" />
         ///, for example "dbo.:column.Entity.Name}.Id"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<int?> SelectMany(NullableInt32Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -774,9 +774,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int64Element" />
+        /// <param name="element">An expression of type <see cref="Int64Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<long> SelectMany(Int64Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -786,9 +786,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt64Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt64Element" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<long?> SelectMany(NullableInt64Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -798,9 +798,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.SingleElement" />
+        /// <param name="element">An expression of type <see cref="SingleElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<float> SelectMany(SingleElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -810,9 +810,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableSingleElement" />
+        /// <param name="element">An expression of type <see cref="NullableSingleElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<float?> SelectMany(NullableSingleElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -822,10 +822,10 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.StringElement" />
+        /// <param name="element">An expression of type <see cref="StringElement" />
         ///, for example "dbo.Address.Line1" or "db.fx.Concat("Value: ", dbo.Address.Line1)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<string> SelectMany(StringElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -835,9 +835,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableStringElement" />
+        /// <param name="element">An expression of type <see cref="NullableStringElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<string> SelectMany(NullableStringElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -847,9 +847,9 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.TimeSpanElement" />
+        /// <param name="element">An expression of type <see cref="TimeSpanElement" />
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<TimeSpan> SelectMany(TimeSpanElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -859,15 +859,15 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableTimeSpanElement" />
+        /// <param name="element">An expression of type <see cref="NullableTimeSpanElement" />
         ///, for example "dbo.Product.ValidStartTimeOfDayForPurchase"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<TimeSpan?> SelectMany(NullableTimeSpanElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
         /// <summary>
-        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="HatTrick.DbEx.Sql.AnyElement" /> method parameters.
+        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="AnyElement" /> method parameters.
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
@@ -875,18 +875,18 @@ namespace DbEx.DataService
         /// <param name="element1">Any expression</param>
         /// <param name="element2">Any expression</param>
         /// <param name="elements">Any expression</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<ExpandoObject> SelectMany(AnyElement element1, AnyElement element2, params AnyElement[] elements)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element1, element2, elements);
 
         /// <summary>
-        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="HatTrick.DbEx.Sql.AnyElement" /> method parameters.
+        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="AnyElement" /> method parameters.
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
         /// <param name="elements">A list of any expression</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<ExpandoObject> SelectMany(IEnumerable<AnyElement> elements)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, elements);
         #endregion
@@ -898,11 +898,11 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/update-transact-sql">Microsoft docs on UPDATE</see>
         /// </para>
         /// </summary>
-        /// <param name="assignments">A list of <see cref="HatTrick.DbEx.Sql.EntityFieldAssignment" />(s) that assign a database field/column a new value.  
+        /// <param name="assignments">A list of <see cref="EntityFieldAssignment" />(s) that assign a database field/column a new value.  
         /// For example "dbo.Address.Line1.Set("new value")"
         /// or "dbo.Person.CreditLimit.Set(dbo.Person.CreditLimit + 10)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.UpdateEntities"/>, a fluent builder for constructing a sql UPDATE statement.</returns>
+        /// <returns><see cref="UpdateEntities"/>, a fluent builder for constructing a sql UPDATE statement.</returns>
         public static UpdateEntities Update(params EntityFieldAssignment[] assignments)
             => expressionBuilderFactory.CreateUpdateExpressionBuilder(config, assignments);
 
@@ -912,29 +912,13 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/update-transact-sql">Microsoft docs on UPDATE</see>
         /// </para>
         /// </summary>
-        /// <param name="assignments">A list of <see cref="HatTrick.DbEx.Sql.EntityFieldAssignment" />(s) that assign a database field/column a new value.  
+        /// <param name="assignments">A list of <see cref="EntityFieldAssignment" />(s) that assign a database field/column a new value.  
         /// For example "dbo.Address.Line1.Set("new value")"
         /// or "dbo.Person.CreditLimit.Set(dbo.Person.CreditLimit + 10)"
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.UpdateEntities"/>, a fluent builder for constructing a sql UPDATE statement.</returns>
-        public static UpdateEntities Update(IList<EntityFieldAssignment> assignments)
-            => expressionBuilderFactory.CreateUpdateExpressionBuilder(config, assignments);
-
-        /// <summary>
-        /// Start constructing a sql UPDATE query expression to update record(s) based on the comparison of property values between two entity instances.
-        /// <para>
-        /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/update-transact-sql">Microsoft docs on UPDATE</see>
-        /// </para>
-        /// </summary>
-        /// <param name="oldStateOfEntity">If a property value differs from the corresponding property value in "<paramref name="newStateOfEntity"/>", an assignment expression will be generated with the value set to the property value from "<paramref name="newStateOfEntity"/>".  
-        /// </param>
-        /// <param name="newStateOfEntity">Records will be updated to the property values from this entity when they differ from the property values in "<paramref name="oldStateOfEntity"/>". 
-        /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.UpdateEntities{TEntity}"/>, a fluent builder for constructing a sql UPDATE statement, with a list of "<see cref="HatTrick.DbEx.Sql.EntityFieldAssignment"/>" constructed from the comparison of the two entity params.</returns>
-        /// <typeparam name="TEntity">The entity type to update.</typeparam>
-        public static UpdateEntities<TEntity> Update<TEntity>(TEntity oldStateOfEntity, TEntity newStateOfEntity)
-            where TEntity : class, IDbEntity
-            => expressionBuilderFactory.CreateUpdateExpressionBuilder<TEntity>(config, oldStateOfEntity, newStateOfEntity);     
+        /// <returns><see cref="UpdateEntities"/>, a fluent builder for constructing a sql UPDATE statement.</returns>
+        public static UpdateEntities Update(IEnumerable<EntityFieldAssignment> assignments)
+            => expressionBuilderFactory.CreateUpdateExpressionBuilder(config, assignments);   
         #endregion
 
         #region delete
@@ -944,7 +928,7 @@ namespace DbEx.DataService
         /// <see href="https://docs.microsoft.com/en-us/sql/t-sql/statements/delete-transact-sql">Microsoft docs on DELETE</see>
         /// </para>
         /// </summary>
-        /// <returns><see cref="HatTrick.DbEx.Sql.DeleteEntities"/>, a fluent builder for constructing a sql DELETE statement.</returns>
+        /// <returns><see cref="DeleteEntities"/>, a fluent builder for constructing a sql DELETE statement.</returns>
         public static DeleteEntities Delete()
             => expressionBuilderFactory.CreateDeleteExpressionBulder(config);
         #endregion
@@ -958,7 +942,7 @@ namespace DbEx.DataService
         /// </summary>
         /// <param name="entity">The entity supplying the property values.
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.InsertEntity{TEntity}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
+        /// <returns><see cref="InsertEntity{TEntity}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
         /// <typeparam name="TEntity">The entity type of the entity to insert.</typeparam>
         public static InsertEntity<TEntity> Insert<TEntity>(TEntity entity)
             where TEntity : class, IDbEntity
@@ -972,7 +956,7 @@ namespace DbEx.DataService
         /// </summary>
         /// <param name="entities">A list of entities.
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.InsertEntities{TEntity}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
+        /// <returns><see cref="InsertEntities{TEntity}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
         /// <typeparam name="TEntity">The entity type of the entities to insert.</typeparam>
         public static InsertEntities<TEntity> InsertMany<TEntity>(params TEntity[] entities)
             where TEntity : class, IDbEntity
@@ -986,7 +970,7 @@ namespace DbEx.DataService
         /// </summary>
         /// <param name="entities">A list of entities.
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.InsertEntities{TEntity}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
+        /// <returns><see cref="InsertEntities{TEntity}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
         /// <typeparam name="TEntity">The entity type of the entities to insert.</typeparam>
         public static InsertEntities<TEntity> InsertMany<TEntity>(IList<TEntity> entities)
             where TEntity : class, IDbEntity
@@ -997,10 +981,10 @@ namespace DbEx.DataService
         /// <summary>
         /// Creates a connection to the database.
         /// <para>
-        /// The connection has not been opened, use <see cref="System.Data.IDbConnection.Open"/> or <see cref="HatTrick.DbEx.Sql.Connection.ISqlConnection.EnsureOpen"/> to ensure an open connection to the database prior to operations like <see cref="System.Data.IDbConnection.BeginTransaction"/>.
+        /// The connection has not been opened, use <see cref="System.Data.IDbConnection.Open"/> or <see cref="Connection.ISqlConnection.EnsureOpen"/> to ensure an open connection to the database prior to operations like <see cref="System.Data.IDbConnection.BeginTransaction"/>.
         /// </para>
         /// </summary>
-        /// <returns><see cref="HatTrick.DbEx.Sql.Connection.ISqlConnection"/>, a connection to the database.</returns>
+        /// <returns><see cref="ISqlConnection"/>, a connection to the database.</returns>
         public static ISqlConnection GetConnection()
             => new SqlConnector(config.ConnectionFactory);
         #endregion

--- a/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/RuntimeDb.htt
+++ b/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/RuntimeDb.htt
@@ -21,7 +21,7 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectEntity{{TEntity}}"/>, a fluent builder for constructing a sql SELECT query expression for a <typeparamref name="TEntity"/> entity.</returns>
+        /// <returns><see cref="SelectEntity{{TEntity}}"/>, a fluent builder for constructing a sql SELECT query expression for a <typeparamref name="TEntity"/> entity.</returns>
         /// <typeparam name="TEntity">The entity type to select.</typeparam>
         public static SelectEntity<TEntity> SelectOne<TEntity>()
             where TEntity : class, IDbEntity
@@ -33,13 +33,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.EnumElement{{TEnum}}" />
+        /// <param name="element">An expression of type <see cref="Sql.EnumElement{{TEnum}}" />
         {#if $.Documentation.AnyEnumColumnExpression}
         {?var:column = $.Documentation.AnyEnumColumnExpression}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}"
         {/if}      
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TEnum}}"/>, a fluent builder for constructing a sql SELECT query expression for a <typeparamref name="TEntity"/> entity.</returns>
+        /// <returns><see cref="Sql.SelectValue{{TEnum}}"/>, a fluent builder for constructing a sql SELECT query expression for a <typeparamref name="TEntity"/> entity.</returns>
         /// <typeparam name="TEnum">The type of the Enum to select.</typeparam>
         public static SelectValue<TEnum> SelectOne<TEnum>(EnumElement<TEnum> element)
             where TEnum : struct, Enum, IComparable
@@ -51,13 +51,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableEnumElement{{TEnum}}" />
+        /// <param name="element">An expression of type <see cref="NullableEnumElement{{TEnum}}" />
         {#if $.Documentation.AnyNullableEnumColumnExpression}
         {?var:column = $.Documentation.AnyNullableEnumColumnExpression}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}"
         {/if}
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TEnum}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TEnum}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         /// <typeparam name="TEnum">The type of the Enum to select.</typeparam>
         public static SelectValue<TEnum?> SelectOne<TEnum>(NullableEnumElement<TEnum> element)
             where TEnum : struct, Enum, IComparable
@@ -69,13 +69,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.AnyObjectElement" />
+        /// <param name="element">An expression of type <see cref="AnyObjectElement" />
         {#if $.Documentation.AnyEnumColumnExpression}
         {?var:column = $.Documentation.AnyEnumColumnExpression}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}"
         {/if}      
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<object> SelectOne(AnyObjectElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -85,13 +85,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.BooleanElement" />
+        /// <param name="element">An expression of type <see cref="BooleanElement" />
         {#if $.Documentation.AnyColumnOfTypeBoolean}
         {?var:column = $.Documentation.AnyColumnOfTypeBoolean}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, false)
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<bool> SelectOne(BooleanElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -101,13 +101,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableBooleanElement" />
+        /// <param name="element">An expression of type <see cref="NullableBooleanElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableBoolean}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableBoolean}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}""
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<bool?> SelectOne(NullableBooleanElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -117,13 +117,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.ByteElement" />
+        /// <param name="element">An expression of type <see cref="ByteElement" />
         {#if $.Documentation.AnyColumnOfTypeByte}
         {?var:column = $.Documentation.AnyColumnOfTypeByte}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, byte.MinValue)"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<byte> SelectOne(ByteElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -133,13 +133,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableByteElement" />
+        /// <param name="element">An expression of type <see cref="NullableByteElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableByte}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableByte}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<byte?> SelectOne(NullableByteElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -149,13 +149,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.ByteArrayElement" />
+        /// <param name="element">An expression of type <see cref="ByteArrayElement" />
         {#if $.Documentation.AnyColumnOfTypeByteArray}
         {?var:column = $.Documentation.AnyColumnOfTypeByteArray}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, new byte[0])"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<byte[]> SelectOne(ByteArrayElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -165,13 +165,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableByteArrayElement" />
+        /// <param name="element">An expression of type <see cref="NullableByteArrayElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableByteArray}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableByteArray}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<byte[]> SelectOne(NullableByteArrayElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -181,13 +181,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DateTimeElement" />
+        /// <param name="element">An expression of type <see cref="DateTimeElement" />
         {#if $.Documentation.AnyColumnOfTypeDateTime}
         {?var:column = $.Documentation.AnyColumnOfTypeDateTime}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}", "db.fx.DateAdd(DateParts.Year, 1, {:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}) or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, DateTime.Now)"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<DateTime> SelectOne(DateTimeElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -197,13 +197,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDateTimeElement" />
+        /// <param name="element">An expression of type <see cref="NullableDateTimeElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableDateTime}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableDateTime}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.DateAdd(DateParts.Year, 1, {:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name})
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<DateTime?> SelectOne(NullableDateTimeElement field)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, field);
 
@@ -213,13 +213,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DateTimeOffsetElement" />
+        /// <param name="element">An expression of type <see cref="DateTimeOffsetElement" />
         {#if $.Documentation.AnyColumnOfTypeDateTimeOffset}
         {?var:column = $.Documentation.AnyColumnOfTypeDateTimeOffset}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}", "db.fx.DateAdd(DateParts.Year, 1, {:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name})" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, DateTimeOffset.Now)"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<DateTimeOffset> SelectOne(DateTimeOffsetElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -229,13 +229,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDateTimeOffsetElement" />
+        /// <param name="element">An expression of type <see cref="NullableDateTimeOffsetElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableDateTimeOffset}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableDateTimeOffset}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.DateAdd(DateParts.Year, 1, {:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name})" 
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<DateTimeOffset?> SelectOne(NullableDateTimeOffsetElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -245,13 +245,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DecimalElement" />
+        /// <param name="element">An expression of type <see cref="DecimalElement" />
         {#if $.Documentation.AnyColumnOfTypeDecimal}
         {?var:column = $.Documentation.AnyColumnOfTypeDecimal}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, decimal.MinValue)"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<decimal> SelectOne(DecimalElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -261,13 +261,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDecimalElement" />
+        /// <param name="element">An expression of type <see cref="NullableDecimalElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableDecimal}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableDecimal}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.Min({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name})"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<decimal?> SelectOne(NullableDecimalElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -277,13 +277,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DoubleElement" />
+        /// <param name="element">An expression of type <see cref="DoubleElement" />
         {#if $.Documentation.AnyColumnOfTypeDouble}
         {?var:column = $.Documentation.AnyColumnOfTypeDouble}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, double.MinValue)"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<double> SelectOne(DoubleElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -293,13 +293,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDoubleElement" />
+        /// <param name="element">An expression of type <see cref="NullableDoubleElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableDouble}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableDouble}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.Min({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name})"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<double?> SelectOne(NullableDoubleElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -309,13 +309,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.GuidElement" />
+        /// <param name="element">An expression of type <see cref="GuidElement" />
         {#if $.Documentation.AnyColumnOfTypeGuid}
         {?var:column = $.Documentation.AnyColumnOfTypeGuid}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, Guid.Empty)"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<Guid> SelectOne(GuidElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -325,13 +325,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableGuidElement" />
+        /// <param name="element">An expression of type <see cref="NullableGuidElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableGuid}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableGuid}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<Guid?> SelectOne(NullableGuidElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -341,13 +341,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int16Element" />
+        /// <param name="element">An expression of type <see cref="Int16Element" />
         {#if $.Documentation.AnyColumnOfTypeInt16}
         {?var:column = $.Documentation.AnyColumnOfTypeInt16}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, short.MinValue)"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<short> SelectOne(Int16Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -357,13 +357,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt16Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt16Element" />
         {#if $.Documentation.AnyColumnOfTypeNullableInt16}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableInt16}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.Max({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name})"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<short?> SelectOne(NullableInt16Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -373,13 +373,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int32Element" />
+        /// <param name="element">An expression of type <see cref="Int32Element" />
         {#if $.Documentation.AnyColumnOfTypeInt32}  
         {?var:column = $.Documentation.AnyColumnOfTypeInt32}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.Avg({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name})"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<int> SelectOne(Int32Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -389,13 +389,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt32Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt32Element" />
         {#if $.Documentation.AnyColumnOfTypeNullableInt32}  
         {?var:column = $.Documentation.AnyColumnOfTypeNullableInt32}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.Avg({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name})"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<int?> SelectOne(NullableInt32Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -405,13 +405,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int64Element" />
+        /// <param name="element">An expression of type <see cref="Int64Element" />
         {#if $.Documentation.AnyColumnOfTypeInt64}
         {?var:column = $.Documentation.AnyColumnOfTypeInt64}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, long.MinValue)"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<long> SelectOne(Int64Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -421,13 +421,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt64Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt64Element" />
         {#if $.Documentation.AnyColumnOfTypeNullableInt64}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableInt64}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.Max({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name})"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<long?> SelectOne(NullableInt64Element element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -437,13 +437,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.SingleElement" />
+        /// <param name="element">An expression of type <see cref="SingleElement" />
         {#if $.Documentation.AnyColumnOfTypeSingle}
         {?var:column = $.Documentation.AnyColumnOfTypeSingle}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, float.MinValue)"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<float> SelectOne(SingleElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -453,13 +453,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableSingleElement" />
+        /// <param name="element">An expression of type <see cref="NullableSingleElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableSingle}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableSingle}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.Max({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name})"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<float?> SelectOne(NullableSingleElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -469,13 +469,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.StringElement" />
+        /// <param name="element">An expression of type <see cref="StringElement" />
         {#if $.Documentation.AnyColumnOfTypeString}
         {?var:column = $.Documentation.AnyColumnOfTypeString}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.Concat("Value: ", {:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name})"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<string> SelectOne(StringElement element) 
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -485,13 +485,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableStringElement" />
+        /// <param name="element">An expression of type <see cref="NullableStringElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableString}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableString}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, "(not provided)")"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<string> SelectOne(NullableStringElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -501,13 +501,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.TimeSpanElement" />
+        /// <param name="element">An expression of type <see cref="TimeSpanElement" />
         {#if $.Documentation.AnyColumnOfTypeTimeSpan}
         {?var:column = $.Documentation.AnyColumnOfTypeTimeSpan}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}", "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, TimeSpan.MinValue)" or "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name} + DateTime.Now"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<TimeSpan> SelectOne(TimeSpanElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
@@ -517,18 +517,18 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableTimeSpanElement" />
+        /// <param name="element">An expression of type <see cref="NullableTimeSpanElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableTimeSpan}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableTimeSpan}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<TimeSpan?> SelectOne(NullableTimeSpanElement element)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element);
 
         /// <summary>
-        /// Start constructing a sql SELECT query expression for a single <see cref="System.Dynamic.ExpandoObject" /> object.  The dynamic properties of the returned objects are defined by the <see cref="HatTrick.DbEx.Sql.AnyElement" /> method parameters.
+        /// Start constructing a sql SELECT query expression for a single <see cref="System.Dynamic.ExpandoObject" /> object.  The dynamic properties of the returned objects are defined by the <see cref="AnyElement" /> method parameters.
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
@@ -536,19 +536,19 @@
         /// <param name="element1">Any expression</param>
         /// <param name="element2">Any expression</param>
         /// <param name="elements">Any expression</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<ExpandoObject> SelectOne(AnyElement element1, AnyElement element2, params AnyElement[] elements)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element1, element2, elements);
 
         /// <summary>
-        /// Start constructing a sql SELECT query expression for a single <see cref="System.Dynamic.ExpandoObject" /> object.  The dynamic properties of the returned objects are defined by the <see cref="HatTrick.DbEx.Sql.AnyElement" /> method parameters.
+        /// Start constructing a sql SELECT query expression for a single <see cref="System.Dynamic.ExpandoObject" /> object.  The dynamic properties of the returned objects are defined by the <see cref="AnyElement" /> method parameters.
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
         /// <param name="element1">Any expression</param>
         /// <param name="elements">A list of any expression</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<ExpandoObject> SelectOne(IEnumerable<AnyElement> elements)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, elements);
         #endregion
@@ -563,7 +563,7 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectEntities{{TEntity}}"/>, a fluent builder for constructing a sql SELECT query expression for a list of <typeparamref name="TEntity"/> entities.</returns>
+        /// <returns><see cref="SelectEntities{{TEntity}}"/>, a fluent builder for constructing a sql SELECT query expression for a list of <typeparamref name="TEntity"/> entities.</returns>
         /// <typeparam name="TEntity">The entity type to select.</typeparam>
         public static SelectEntities<TEntity> SelectMany<TEntity>()
            where TEntity : class, IDbEntity
@@ -575,13 +575,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.EnumElement{{TEnum}}" />
+        /// <param name="element">An expression of type <see cref="EnumElement{{TEnum}}" />
         {#if $.Documentation.AnyEnumColumnExpression}
         {?var:column = $.Documentation.AnyEnumColumnExpression}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}"
         {/if}      
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TEnum}}"/>, a fluent builder for constructing a sql SELECT query expression for a list of <typeparamref name="TEntity"/> entities.</returns>
+        /// <returns><see cref="SelectValues{{TEnum}}"/>, a fluent builder for constructing a sql SELECT query expression for a list of <typeparamref name="TEntity"/> entities.</returns>
         public static SelectValues<TEnum> SelectMany<TEnum>(EnumElement<TEnum> element)
             where TEnum : struct, Enum, IComparable
             => expressionBuilderFactory.CreateSelectValuesBuilder<TEnum>(config, element);
@@ -592,13 +592,13 @@
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableEnumElement{{TEnum}}" />
+        /// <param name="element">An expression of type <see cref="NullableEnumElement{{TEnum}}" />
         {#if $.Documentation.AnyNullableEnumColumnExpression}
         {?var:column = $.Documentation.AnyNullableEnumColumnExpression}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}"
         {/if}      
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TEnum}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TEnum}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<TEnum?> SelectMany<TEnum>(NullableEnumElement<TEnum> element)
             where TEnum : struct, Enum, IComparable
             => expressionBuilderFactory.CreateSelectValuesBuilder<TEnum>(config, element);
@@ -609,7 +609,7 @@
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.AnyObjectElement" />
+        /// <param name="element">An expression of type <see cref="AnyObjectElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableInt32}
         {#if $.Documentation.AnyColumnOfTypeString}
         {?var:firstColumn = $.Documentation.AnyColumnOfTypeNullableInt32}
@@ -618,7 +618,7 @@
         {/if}
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<object> SelectMany(AnyObjectElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -628,13 +628,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.BooleanElement" />
+        /// <param name="element">An expression of type <see cref="BooleanElement" />
         {#if $.Documentation.AnyColumnOfTypeBoolean}
         {?var:column = $.Documentation.AnyColumnOfTypeBoolean}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, false)
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<bool> SelectMany(BooleanElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -644,13 +644,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableBooleanElement" />
+        /// <param name="element">An expression of type <see cref="NullableBooleanElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableBoolean}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableBoolean}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}""
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<bool?> SelectMany(NullableBooleanElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -660,13 +660,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.ByteElement" />
+        /// <param name="element">An expression of type <see cref="ByteElement" />
         {#if $.Documentation.AnyColumnOfTypeByte}
         {?var:column = $.Documentation.AnyColumnOfTypeByte}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, byte.MinValue)"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<byte> SelectMany(ByteElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -676,13 +676,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableByteElement" />
+        /// <param name="element">An expression of type <see cref="NullableByteElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableByte}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableByte}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<byte?> SelectMany(NullableByteElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -692,13 +692,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.ByteArrayElement" />
+        /// <param name="element">An expression of type <see cref="ByteArrayElement" />
         {#if $.Documentation.AnyColumnOfTypeByteArray}
         {?var:column = $.Documentation.AnyColumnOfTypeByteArray}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, new byte[0])"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<byte[]> SelectMany(ByteArrayElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -708,13 +708,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableByteArrayElement" />
+        /// <param name="element">An expression of type <see cref="NullableByteArrayElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableByteArray}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableByteArray}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<byte[]> SelectMany(NullableByteArrayElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -724,13 +724,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DateTimeElement" />
+        /// <param name="element">An expression of type <see cref="DateTimeElement" />
         {#if $.Documentation.AnyColumnOfTypeDateTime}
         {?var:column = $.Documentation.AnyColumnOfTypeDateTime}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}", "db.fx.DateAdd(DateParts.Year, 1, {:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}) or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, DateTime.Now)"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<DateTime> SelectMany(DateTimeElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -740,13 +740,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDateTimeElement" />
+        /// <param name="element">An expression of type <see cref="NullableDateTimeElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableDateTime}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableDateTime}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.DateAdd(DateParts.Year, 1, {:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name})
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<DateTime?> SelectMany(NullableDateTimeElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -756,13 +756,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DateTimeOffsetElement" />
+        /// <param name="element">An expression of type <see cref="DateTimeOffsetElement" />
         {#if $.Documentation.AnyColumnOfTypeDateTimeOffset}
         {?var:column = $.Documentation.AnyColumnOfTypeDateTimeOffset}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}", "db.fx.DateAdd(DateParts.Year, 1, {:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name})" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, DateTimeOffset.Now)"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<DateTimeOffset> SelectMany(DateTimeOffsetElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -772,13 +772,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDateTimeOffsetElement" />
+        /// <param name="element">An expression of type <see cref="NullableDateTimeOffsetElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableDateTimeOffset}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableDateTimeOffset}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.DateAdd(DateParts.Year, 1, {:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name})" 
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<DateTimeOffset?> SelectMany(NullableDateTimeOffsetElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -788,13 +788,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DecimalElement" />
+        /// <param name="element">An expression of type <see cref="DecimalElement" />
         {#if $.Documentation.AnyColumnOfTypeDecimal}
         {?var:column = $.Documentation.AnyColumnOfTypeDecimal}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, decimal.MinValue)"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<decimal> SelectMany(DecimalElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -804,13 +804,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDecimalElement" />
+        /// <param name="element">An expression of type <see cref="NullableDecimalElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableDecimal}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableDecimal}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<decimal?> SelectMany(NullableDecimalElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -820,13 +820,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.DoubleElement" />
+        /// <param name="element">An expression of type <see cref="DoubleElement" />
         {#if $.Documentation.AnyColumnOfTypeDouble}
         {?var:column = $.Documentation.AnyColumnOfTypeDouble}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, double.MinValue)"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<double> SelectMany(DoubleElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -836,13 +836,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableDoubleElement" />
+        /// <param name="element">An expression of type <see cref="NullableDoubleElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableDouble}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableDouble}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<double?> SelectMany(NullableDoubleElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -852,13 +852,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.GuidElement" />
+        /// <param name="element">An expression of type <see cref="GuidElement" />
         {#if $.Documentation.AnyColumnOfTypeGuid}
         {?var:column = $.Documentation.AnyColumnOfTypeGuid}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, Guid.Empty)"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<Guid> SelectMany(GuidElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -868,13 +868,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableGuidElement" />
+        /// <param name="element">An expression of type <see cref="NullableGuidElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableGuid}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableGuid}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<Guid?> SelectMany(NullableGuidElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -884,13 +884,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int16Element" />
+        /// <param name="element">An expression of type <see cref="Int16Element" />
         {#if $.Documentation.AnyColumnOfTypeInt16}
         {?var:column = $.Documentation.AnyColumnOfTypeInt16}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, short.MinValue)"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<short> SelectMany(Int16Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -900,13 +900,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt16Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt16Element" />
         {#if $.Documentation.AnyColumnOfTypeNullableInt16}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableInt16}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<short?> SelectMany(NullableInt16Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -916,13 +916,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int32Element" />
+        /// <param name="element">An expression of type <see cref="Int32Element" />
         {#if $.Documentation.AnyColumnOfTypeInt32}  
         {?var:column = $.Documentation.AnyColumnOfTypeInt32}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<int> SelectMany(Int32Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -932,13 +932,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt32Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt32Element" />
         {#if $.Documentation.AnyColumnOfTypeNullableInt32}  
         {?var:column = $.Documentation.AnyColumnOfTypeInt32}
         ///, for example "{:column.Entity.Schema.Name}.:column.Entity.Name}.{:column.Name}"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<int?> SelectMany(NullableInt32Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -948,13 +948,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.Int64Element" />
+        /// <param name="element">An expression of type <see cref="Int64Element" />
         {#if $.Documentation.AnyColumnOfTypeInt64}
         {?var:column = $.Documentation.AnyColumnOfTypeInt64}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, long.MinValue)"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<long> SelectMany(Int64Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -964,13 +964,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableInt64Element" />
+        /// <param name="element">An expression of type <see cref="NullableInt64Element" />
         {#if $.Documentation.AnyColumnOfTypeNullableInt64}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableInt64}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<long?> SelectMany(NullableInt64Element element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -980,13 +980,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.SingleElement" />
+        /// <param name="element">An expression of type <see cref="SingleElement" />
         {#if $.Documentation.AnyColumnOfTypeSingle}
         {?var:column = $.Documentation.AnyColumnOfTypeSingle}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, float.MinValue)"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<float> SelectMany(SingleElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -996,13 +996,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableSingleElement" />
+        /// <param name="element">An expression of type <see cref="NullableSingleElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableSingle}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableSingle}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<float?> SelectMany(NullableSingleElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -1012,13 +1012,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.StringElement" />
+        /// <param name="element">An expression of type <see cref="StringElement" />
         {#if $.Documentation.AnyColumnOfTypeString}
         {?var:column = $.Documentation.AnyColumnOfTypeString}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.Concat("Value: ", {:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name})"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<string> SelectMany(StringElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -1028,13 +1028,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableStringElement" />
+        /// <param name="element">An expression of type <see cref="NullableStringElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableString}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableString}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}" or "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, "(not provided)")"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<string> SelectMany(NullableStringElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -1044,13 +1044,13 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.TimeSpanElement" />
+        /// <param name="element">An expression of type <see cref="TimeSpanElement" />
         {#if $.Documentation.AnyColumnOfTypeTimeSpan}
         {?var:column = $.Documentation.AnyColumnOfTypeTimeSpan}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}", "db.fx.IsNull({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}, TimeSpan.MinValue)" or "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name} + DateTime.Now"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<TimeSpan> SelectMany(TimeSpanElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
@@ -1060,18 +1060,18 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
-        /// <param name="element">An expression of type <see cref="HatTrick.DbEx.Sql.NullableTimeSpanElement" />
+        /// <param name="element">An expression of type <see cref="NullableTimeSpanElement" />
         {#if $.Documentation.AnyColumnOfTypeNullableTimeSpan}
         {?var:column = $.Documentation.AnyColumnOfTypeNullableTimeSpan}
         ///, for example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<TimeSpan?> SelectMany(NullableTimeSpanElement element)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element);
 
         /// <summary>
-        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="HatTrick.DbEx.Sql.AnyElement" /> method parameters.
+        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="AnyElement" /> method parameters.
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
@@ -1079,18 +1079,18 @@
         /// <param name="element1">Any expression</param>
         /// <param name="element2">Any expression</param>
         /// <param name="elements">Any expression</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<ExpandoObject> SelectMany(AnyElement element1, AnyElement element2, params AnyElement[] elements)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element1, element2, elements);
 
         /// <summary>
-        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="HatTrick.DbEx.Sql.AnyElement" /> method parameters.
+        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="AnyElement" /> method parameters.
         /// <para>
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
         /// </para>
         /// </summary>
         /// <param name="elements">A list of any expression</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<ExpandoObject> SelectMany(IEnumerable<AnyElement> elements)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, elements);
         #endregion
@@ -1102,7 +1102,7 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/update-transact-sql">Microsoft docs on UPDATE</see>
         /// </para>
         /// </summary>
-        /// <param name="assignments">A list of <see cref="HatTrick.DbEx.Sql.EntityFieldAssignment" />(s) that assign a database field/column a new value.  
+        /// <param name="assignments">A list of <see cref="EntityFieldAssignment" />(s) that assign a database field/column a new value.  
         {#if $.Documentation.AnyColumnOfTypeString}
         {?var:column = $.Documentation.AnyColumnOfTypeString}
         /// For example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}.Set("new value")"
@@ -1112,7 +1112,7 @@
         /// or "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}.Set({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name} + 10)"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.UpdateEntities"/>, a fluent builder for constructing a sql UPDATE statement.</returns>
+        /// <returns><see cref="UpdateEntities"/>, a fluent builder for constructing a sql UPDATE statement.</returns>
         public static UpdateEntities Update(params EntityFieldAssignment[] assignments)
             => expressionBuilderFactory.CreateUpdateExpressionBuilder(config, assignments);
 
@@ -1122,7 +1122,7 @@
         /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/update-transact-sql">Microsoft docs on UPDATE</see>
         /// </para>
         /// </summary>
-        /// <param name="assignments">A list of <see cref="HatTrick.DbEx.Sql.EntityFieldAssignment" />(s) that assign a database field/column a new value.  
+        /// <param name="assignments">A list of <see cref="EntityFieldAssignment" />(s) that assign a database field/column a new value.  
         {#if $.Documentation.AnyColumnOfTypeString}
         {?var:column = $.Documentation.AnyColumnOfTypeString}
         /// For example "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}.Set("new value")"
@@ -1132,25 +1132,9 @@
         /// or "{:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name}.Set({:column.Entity.Schema.Name}.{:column.Entity.Name}.{:column.Name} + 10)"
         {/if}
         ///</param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.UpdateEntities"/>, a fluent builder for constructing a sql UPDATE statement.</returns>
-        public static UpdateEntities Update(IList<EntityFieldAssignment> assignments)
-            => expressionBuilderFactory.CreateUpdateExpressionBuilder(config, assignments);
-
-        /// <summary>
-        /// Start constructing a sql UPDATE query expression to update record(s) based on the comparison of property values between two entity instances.
-        /// <para>
-        /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/update-transact-sql">Microsoft docs on UPDATE</see>
-        /// </para>
-        /// </summary>
-        /// <param name="oldStateOfEntity">If a property value differs from the corresponding property value in "<paramref name="newStateOfEntity"/>", an assignment expression will be generated with the value set to the property value from "<paramref name="newStateOfEntity"/>".  
-        /// </param>
-        /// <param name="newStateOfEntity">Records will be updated to the property values from this entity when they differ from the property values in "<paramref name="oldStateOfEntity"/>". 
-        /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.UpdateEntities{{TEntity}}"/>, a fluent builder for constructing a sql UPDATE statement, with a list of "<see cref="HatTrick.DbEx.Sql.EntityFieldAssignment"/>" constructed from the comparison of the two entity params.</returns>
-        /// <typeparam name="TEntity">The entity type to update.</typeparam>
-        public static UpdateEntities<TEntity> Update<TEntity>(TEntity oldStateOfEntity, TEntity newStateOfEntity)
-            where TEntity : class, IDbEntity
-            => expressionBuilderFactory.CreateUpdateExpressionBuilder<TEntity>(config, oldStateOfEntity, newStateOfEntity);     
+        /// <returns><see cref="UpdateEntities"/>, a fluent builder for constructing a sql UPDATE statement.</returns>
+        public static UpdateEntities Update(IEnumerable<EntityFieldAssignment> assignments)
+            => expressionBuilderFactory.CreateUpdateExpressionBuilder(config, assignments);   
         #endregion
 
         #region delete
@@ -1160,7 +1144,7 @@
         /// <see href="https://docs.microsoft.com/en-us/sql/t-sql/statements/delete-transact-sql">Microsoft docs on DELETE</see>
         /// </para>
         /// </summary>
-        /// <returns><see cref="HatTrick.DbEx.Sql.DeleteEntities"/>, a fluent builder for constructing a sql DELETE statement.</returns>
+        /// <returns><see cref="DeleteEntities"/>, a fluent builder for constructing a sql DELETE statement.</returns>
         public static DeleteEntities Delete()
             => expressionBuilderFactory.CreateDeleteExpressionBulder(config);
         #endregion
@@ -1174,7 +1158,7 @@
         /// </summary>
         /// <param name="entity">The entity supplying the property values.
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.InsertEntity{{TEntity}}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
+        /// <returns><see cref="InsertEntity{{TEntity}}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
         /// <typeparam name="TEntity">The entity type of the entity to insert.</typeparam>
         public static InsertEntity<TEntity> Insert<TEntity>(TEntity entity)
             where TEntity : class, IDbEntity
@@ -1188,7 +1172,7 @@
         /// </summary>
         /// <param name="entities">A list of entities.
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.InsertEntities{{TEntity}}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
+        /// <returns><see cref="InsertEntities{{TEntity}}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
         /// <typeparam name="TEntity">The entity type of the entities to insert.</typeparam>
         public static InsertEntities<TEntity> InsertMany<TEntity>(params TEntity[] entities)
             where TEntity : class, IDbEntity
@@ -1202,7 +1186,7 @@
         /// </summary>
         /// <param name="entities">A list of entities.
         /// </param>
-        /// <returns><see cref="HatTrick.DbEx.Sql.InsertEntities{{TEntity}}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
+        /// <returns><see cref="InsertEntities{{TEntity}}"/>, a fluent builder for constructing a sql INSERT statement.</returns>
         /// <typeparam name="TEntity">The entity type of the entities to insert.</typeparam>
         public static InsertEntities<TEntity> InsertMany<TEntity>(IList<TEntity> entities)
             where TEntity : class, IDbEntity
@@ -1213,10 +1197,10 @@
         /// <summary>
         /// Creates a connection to the database.
         /// <para>
-        /// The connection has not been opened, use <see cref="System.Data.IDbConnection.Open"/> or <see cref="HatTrick.DbEx.Sql.Connection.ISqlConnection.EnsureOpen"/> to ensure an open connection to the database prior to operations like <see cref="System.Data.IDbConnection.BeginTransaction"/>.
+        /// The connection has not been opened, use <see cref="System.Data.IDbConnection.Open"/> or <see cref="Connection.ISqlConnection.EnsureOpen"/> to ensure an open connection to the database prior to operations like <see cref="System.Data.IDbConnection.BeginTransaction"/>.
         /// </para>
         /// </summary>
-        /// <returns><see cref="HatTrick.DbEx.Sql.Connection.ISqlConnection"/>, a connection to the database.</returns>
+        /// <returns><see cref="ISqlConnection"/>, a connection to the database.</returns>
         public static ISqlConnection GetConnection()
             => new SqlConnector(config.ConnectionFactory);
         #endregion


### PR DESCRIPTION
Instead of having the two as parameters to the Update fluent method,

now have a specific method on dbex that returns the list of assignement expressions.
This enables someone to see if there are any assignments (won't be if there is no difference in the entities) prior to executing an update query.
A SqlException is still thrown when an update query is executed that has no assignments.