### PR TITLE
Reworked startup and Entity interfaces hierarchy

### DIFF
--- a/samples/mssql/NetCoreConsoleApp/Data/_Generated/DbExDataService.generated.cs
+++ b/samples/mssql/NetCoreConsoleApp/Data/_Generated/DbExDataService.generated.cs
@@ -13,21 +13,39 @@ using System.Dynamic;
 #pragma warning disable CA1034 // Nested types should not be visible
 namespace SimpleConsole.DataService
 {
+	using SimpleConsole.dboDataService;
+	using SimpleConsole.secDataService;
+
     #region runtime db
-    public abstract class SimpleConsoleDbRuntimeSqlDatabase : IRuntimeSqlDatabase
+    public abstract class SimpleConsoleDbRuntimeSqlDatabase : IRuntimeSqlDatabase, IExpressionListProvider<SchemaExpression>
     {
         #region internals
         private const string NO_CONFIG_MESSAGE = "Cannot construct or execute queries as the database runtime environment has not been configured.";
+        protected static readonly MsSqlQueryExpressionBuilderFactory expressionBuilderFactory = new MsSqlQueryExpressionBuilderFactory();
+        protected static readonly IList<SchemaExpression> schemas = new List<SchemaExpression>();
         protected static RuntimeSqlDatabaseConfiguration config;
-        protected static MsSqlQueryExpressionBuilderFactory expressionBuilderFactory = new MsSqlQueryExpressionBuilderFactory();
         #endregion
 
         #region interface
-        RuntimeSqlDatabaseConfiguration IRuntimeSqlDatabase.Configuration => config;
+        IList<SchemaExpression> IExpressionListProvider<SchemaExpression>.Expressions => schemas;
+        #endregion
+
+        #region constructors
+        static SimpleConsoleDbRuntimeSqlDatabase()
+        {
+            var dboSchema = new dboSchemaExpression("dbo");
+            schemas.Add(dboSchema);
+            dbo.UseSchema(dboSchema);
+
+            var secSchema = new secSchemaExpression("sec");
+            schemas.Add(secSchema);
+            sec.UseSchema(secSchema);
+
+        }
         #endregion
 
         #region methods
-        void IRuntimeSqlDatabase.Initialize(RuntimeSqlDatabaseConfiguration configuration)
+        void IRuntimeSqlDatabase.UseConfiguration(RuntimeSqlDatabaseConfiguration configuration)
             => config = configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.");
 
         #region select one
@@ -4880,10 +4898,6 @@ namespace SimpleConsole.dboDataService
 #pragma warning restore IDE1006 // Naming Styles
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
-        #region internals
-        private static readonly dboSchemaExpression _schema = new dboSchemaExpression("dbo");
-        #endregion
-
         #region interface
         /// <summary>A <see cref="SimpleConsole.dboDataService.AddressEntity"/> representing the "dbo.Address" table in the database.
         /// <para>Properties:
@@ -4907,7 +4921,7 @@ namespace SimpleConsole.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly AddressEntity Address;
+        public static AddressEntity Address { get; private set; }
 
         /// <summary>A <see cref="SimpleConsole.dboDataService.PersonEntity"/> representing the "dbo.Person" table in the database.
         /// <para>Properties:
@@ -4931,7 +4945,7 @@ namespace SimpleConsole.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly PersonEntity Person;
+        public static PersonEntity Person { get; private set; }
 
         /// <summary>A <see cref="SimpleConsole.dboDataService.PersonAddressEntity"/> representing the "dbo.Person_Address" table in the database.
         /// <para>Properties:
@@ -4955,7 +4969,7 @@ namespace SimpleConsole.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly PersonAddressEntity PersonAddress;
+        public static PersonAddressEntity PersonAddress { get; private set; }
 
         /// <summary>A <see cref="SimpleConsole.dboDataService.ProductEntity"/> representing the "dbo.Product" table in the database.
         /// <para>Properties:
@@ -4979,7 +4993,7 @@ namespace SimpleConsole.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly ProductEntity Product;
+        public static ProductEntity Product { get; private set; }
 
         /// <summary>A <see cref="SimpleConsole.dboDataService.PurchaseEntity"/> representing the "dbo.Purchase" table in the database.
         /// <para>Properties:
@@ -5003,7 +5017,7 @@ namespace SimpleConsole.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly PurchaseEntity Purchase;
+        public static PurchaseEntity Purchase { get; private set; }
 
         /// <summary>A <see cref="SimpleConsole.dboDataService.PurchaseLineEntity"/> representing the "dbo.PurchaseLine" table in the database.
         /// <para>Properties:
@@ -5027,7 +5041,7 @@ namespace SimpleConsole.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly PurchaseLineEntity PurchaseLine;
+        public static PurchaseLineEntity PurchaseLine { get; private set; }
 
         /// <summary>A <see cref="SimpleConsole.dboDataService.PersonTotalPurchasesViewEntity"/> representing the "dbo.PersonTotalPurchasesView" view in the database.
         /// <para>Properties:
@@ -5038,20 +5052,22 @@ namespace SimpleConsole.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly PersonTotalPurchasesViewEntity PersonTotalPurchasesView;
+        public static PersonTotalPurchasesViewEntity PersonTotalPurchasesView { get; private set; }
 
         #endregion
 
-        #region constructors
-        static dbo()
+        #region methods
+        public static void UseSchema(dboSchemaExpression schema)
         { 
-            Address = _schema.Address;
-            Person = _schema.Person;
-            PersonAddress = _schema.PersonAddress;
-            Product = _schema.Product;
-            Purchase = _schema.Purchase;
-            PurchaseLine = _schema.PurchaseLine;
-            PersonTotalPurchasesView = _schema.PersonTotalPurchasesView;
+            if (schema == null)
+                 throw new ArgumentNullException($"{nameof(schema)} is required.");
+            Address = schema.Address ?? throw new ArgumentNullException($"{schema.Address } is required.");
+            Person = schema.Person ?? throw new ArgumentNullException($"{schema.Person } is required.");
+            PersonAddress = schema.PersonAddress ?? throw new ArgumentNullException($"{schema.PersonAddress } is required.");
+            Product = schema.Product ?? throw new ArgumentNullException($"{schema.Product } is required.");
+            Purchase = schema.Purchase ?? throw new ArgumentNullException($"{schema.Purchase } is required.");
+            PurchaseLine = schema.PurchaseLine ?? throw new ArgumentNullException($"{schema.PurchaseLine } is required.");
+            PersonTotalPurchasesView = schema.PersonTotalPurchasesView ?? throw new ArgumentNullException($"{schema.PersonTotalPurchasesView } is required.");
         }
         #endregion
     }
@@ -5352,10 +5368,6 @@ namespace SimpleConsole.secDataService
 #pragma warning restore IDE1006 // Naming Styles
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
-        #region internals
-        private static readonly secSchemaExpression _schema = new secSchemaExpression("sec");
-        #endregion
-
         #region interface
         /// <summary>A <see cref="SimpleConsole.secDataService.PersonEntity"/> representing the "sec.Person" table in the database.
         /// <para>Properties:
@@ -5379,14 +5391,16 @@ namespace SimpleConsole.secDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly PersonEntity Person;
+        public static PersonEntity Person { get; private set; }
 
         #endregion
 
-        #region constructors
-        static sec()
+        #region methods
+        public static void UseSchema(secSchemaExpression schema)
         { 
-            Person = _schema.Person;
+            if (schema == null)
+                 throw new ArgumentNullException($"{nameof(schema)} is required.");
+            Person = schema.Person ?? throw new ArgumentNullException($"{schema.Person } is required.");
         }
         #endregion
     }

--- a/samples/mssql/ServerSideBlazorApp/Data/_Generated/DbExDataService.generated.cs
+++ b/samples/mssql/ServerSideBlazorApp/Data/_Generated/DbExDataService.generated.cs
@@ -13,21 +13,39 @@ using System.Dynamic;
 #pragma warning disable CA1034 // Nested types should not be visible
 namespace ServerSideBlazorApp.DataService
 {
+	using ServerSideBlazorApp.dboDataService;
+	using ServerSideBlazorApp.secDataService;
+
     #region runtime db
-    public abstract class CRMDatabaseRuntimeSqlDatabase : IRuntimeSqlDatabase
+    public abstract class CRMDatabaseRuntimeSqlDatabase : IRuntimeSqlDatabase, IExpressionListProvider<SchemaExpression>
     {
         #region internals
         private const string NO_CONFIG_MESSAGE = "Cannot construct or execute queries as the database runtime environment has not been configured.";
+        protected static readonly MsSqlQueryExpressionBuilderFactory expressionBuilderFactory = new MsSqlQueryExpressionBuilderFactory();
+        protected static readonly IList<SchemaExpression> schemas = new List<SchemaExpression>();
         protected static RuntimeSqlDatabaseConfiguration config;
-        protected static MsSqlQueryExpressionBuilderFactory expressionBuilderFactory = new MsSqlQueryExpressionBuilderFactory();
         #endregion
 
         #region interface
-        RuntimeSqlDatabaseConfiguration IRuntimeSqlDatabase.Configuration => config;
+        IList<SchemaExpression> IExpressionListProvider<SchemaExpression>.Expressions => schemas;
+        #endregion
+
+        #region constructors
+        static CRMDatabaseRuntimeSqlDatabase()
+        {
+            var dboSchema = new dboSchemaExpression("dbo");
+            schemas.Add(dboSchema);
+            dbo.UseSchema(dboSchema);
+
+            var secSchema = new secSchemaExpression("sec");
+            schemas.Add(secSchema);
+            sec.UseSchema(secSchema);
+
+        }
         #endregion
 
         #region methods
-        void IRuntimeSqlDatabase.Initialize(RuntimeSqlDatabaseConfiguration configuration)
+        void IRuntimeSqlDatabase.UseConfiguration(RuntimeSqlDatabaseConfiguration configuration)
             => config = configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.");
 
         #region select one
@@ -4880,10 +4898,6 @@ namespace ServerSideBlazorApp.dboDataService
 #pragma warning restore IDE1006 // Naming Styles
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
-        #region internals
-        private static readonly dboSchemaExpression _schema = new dboSchemaExpression("dbo");
-        #endregion
-
         #region interface
         /// <summary>A <see cref="ServerSideBlazorApp.dboDataService.AddressEntity"/> representing the "dbo.Address" table in the database.
         /// <para>Properties:
@@ -4907,7 +4921,7 @@ namespace ServerSideBlazorApp.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly AddressEntity Address;
+        public static AddressEntity Address { get; private set; }
 
         /// <summary>A <see cref="ServerSideBlazorApp.dboDataService.CustomerEntity"/> representing the "dbo.Person" table in the database.
         /// <para>Properties:
@@ -4931,7 +4945,7 @@ namespace ServerSideBlazorApp.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly CustomerEntity Customer;
+        public static CustomerEntity Customer { get; private set; }
 
         /// <summary>A <see cref="ServerSideBlazorApp.dboDataService.CustomerAddressEntity"/> representing the "dbo.Person_Address" table in the database.
         /// <para>Properties:
@@ -4955,7 +4969,7 @@ namespace ServerSideBlazorApp.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly CustomerAddressEntity CustomerAddress;
+        public static CustomerAddressEntity CustomerAddress { get; private set; }
 
         /// <summary>A <see cref="ServerSideBlazorApp.dboDataService.ProductEntity"/> representing the "dbo.Product" table in the database.
         /// <para>Properties:
@@ -4979,7 +4993,7 @@ namespace ServerSideBlazorApp.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly ProductEntity Product;
+        public static ProductEntity Product { get; private set; }
 
         /// <summary>A <see cref="ServerSideBlazorApp.dboDataService.PurchaseEntity"/> representing the "dbo.Purchase" table in the database.
         /// <para>Properties:
@@ -5003,7 +5017,7 @@ namespace ServerSideBlazorApp.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly PurchaseEntity Purchase;
+        public static PurchaseEntity Purchase { get; private set; }
 
         /// <summary>A <see cref="ServerSideBlazorApp.dboDataService.PurchaseLineEntity"/> representing the "dbo.PurchaseLine" table in the database.
         /// <para>Properties:
@@ -5027,7 +5041,7 @@ namespace ServerSideBlazorApp.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly PurchaseLineEntity PurchaseLine;
+        public static PurchaseLineEntity PurchaseLine { get; private set; }
 
         /// <summary>A <see cref="ServerSideBlazorApp.dboDataService.PersonTotalPurchasesViewEntity"/> representing the "dbo.PersonTotalPurchasesView" view in the database.
         /// <para>Properties:
@@ -5038,20 +5052,22 @@ namespace ServerSideBlazorApp.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly PersonTotalPurchasesViewEntity PersonTotalPurchasesView;
+        public static PersonTotalPurchasesViewEntity PersonTotalPurchasesView { get; private set; }
 
         #endregion
 
-        #region constructors
-        static dbo()
+        #region methods
+        public static void UseSchema(dboSchemaExpression schema)
         { 
-            Address = _schema.Address;
-            Customer = _schema.Customer;
-            CustomerAddress = _schema.CustomerAddress;
-            Product = _schema.Product;
-            Purchase = _schema.Purchase;
-            PurchaseLine = _schema.PurchaseLine;
-            PersonTotalPurchasesView = _schema.PersonTotalPurchasesView;
+            if (schema == null)
+                 throw new ArgumentNullException($"{nameof(schema)} is required.");
+            Address = schema.Address ?? throw new ArgumentNullException($"{schema.Address } is required.");
+            Customer = schema.Customer ?? throw new ArgumentNullException($"{schema.Customer } is required.");
+            CustomerAddress = schema.CustomerAddress ?? throw new ArgumentNullException($"{schema.CustomerAddress } is required.");
+            Product = schema.Product ?? throw new ArgumentNullException($"{schema.Product } is required.");
+            Purchase = schema.Purchase ?? throw new ArgumentNullException($"{schema.Purchase } is required.");
+            PurchaseLine = schema.PurchaseLine ?? throw new ArgumentNullException($"{schema.PurchaseLine } is required.");
+            PersonTotalPurchasesView = schema.PersonTotalPurchasesView ?? throw new ArgumentNullException($"{schema.PersonTotalPurchasesView } is required.");
         }
         #endregion
     }
@@ -5352,10 +5368,6 @@ namespace ServerSideBlazorApp.secDataService
 #pragma warning restore IDE1006 // Naming Styles
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
-        #region internals
-        private static readonly secSchemaExpression _schema = new secSchemaExpression("sec");
-        #endregion
-
         #region interface
         /// <summary>A <see cref="ServerSideBlazorApp.secDataService.PersonEntity"/> representing the "sec.Person" table in the database.
         /// <para>Properties:
@@ -5379,14 +5391,16 @@ namespace ServerSideBlazorApp.secDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly PersonEntity Person;
+        public static PersonEntity Person { get; private set; }
 
         #endregion
 
-        #region constructors
-        static sec()
+        #region methods
+        public static void UseSchema(secSchemaExpression schema)
         { 
-            Person = _schema.Person;
+            if (schema == null)
+                 throw new ArgumentNullException($"{nameof(schema)} is required.");
+            Person = schema.Person ?? throw new ArgumentNullException($"{schema.Person } is required.");
         }
         #endregion
     }

--- a/src/HatTrick.DbEx.MsSql/_Extensions/Configuration/DatabaseConfigurationBuilderExtensions_Configure.cs
+++ b/src/HatTrick.DbEx.MsSql/_Extensions/Configuration/DatabaseConfigurationBuilderExtensions_Configure.cs
@@ -58,7 +58,7 @@ namespace HatTrick.DbEx.MsSql.Configuration
 
             runtimeConfiguration?.Invoke(configBuilder);
 
-            runtime.Database.Initialize(config);
+            runtime.Database.UseConfiguration(config);
         }
         #endregion
 
@@ -86,7 +86,7 @@ namespace HatTrick.DbEx.MsSql.Configuration
 
             runtimeConfiguration?.Invoke(configBuilder);
 
-            runtime.Database.Initialize(config);
+            runtime.Database.UseConfiguration(config);
         }
         #endregion
 
@@ -114,7 +114,7 @@ namespace HatTrick.DbEx.MsSql.Configuration
 
             runtimeConfiguration?.Invoke(configBuilder);
 
-            runtime.Database.Initialize(config);
+            runtime.Database.UseConfiguration(config);
         }
         #endregion
 
@@ -142,7 +142,7 @@ namespace HatTrick.DbEx.MsSql.Configuration
 
             runtimeConfiguration?.Invoke(configBuilder);
 
-            runtime.Database.Initialize(config);
+            runtime.Database.UseConfiguration(config);
         }
         #endregion
 
@@ -170,7 +170,7 @@ namespace HatTrick.DbEx.MsSql.Configuration
 
             runtimeConfiguration?.Invoke(configBuilder);
 
-            runtime.Database.Initialize(config);
+            runtime.Database.UseConfiguration(config);
         }
         #endregion
 
@@ -198,7 +198,7 @@ namespace HatTrick.DbEx.MsSql.Configuration
 
             runtimeConfiguration?.Invoke(configBuilder);
 
-            runtime.Database.Initialize(config);
+            runtime.Database.UseConfiguration(config);
         }
         #endregion
 
@@ -226,7 +226,7 @@ namespace HatTrick.DbEx.MsSql.Configuration
 
             runtimeConfiguration?.Invoke(configBuilder);
 
-            runtime.Database.Initialize(config);
+            runtime.Database.UseConfiguration(config);
         }
         #endregion
 

--- a/src/HatTrick.DbEx.Sql/Builder/InsertQueryExpressionBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/InsertQueryExpressionBuilder{T}.cs
@@ -41,7 +41,7 @@ namespace HatTrick.DbEx.Sql.Builder
         protected virtual void Into(Entity<TEntity> entity)
         {
             var i = 0;
-            var insertEntity = entity as IExpressionEntity<TEntity> ?? throw new DbExpressionException($"Expected {nameof(entity)} to be of type {nameof(EntityExpression<TEntity>)}.");
+            var insertEntity = entity as IEntityExpression<TEntity> ?? throw new DbExpressionException($"Expected {nameof(entity)} to be of type {nameof(EntityExpression<TEntity>)}.");
             expression.BaseEntity = entity as EntityExpression<TEntity>;
             expression.Inserts = instances.ToDictionary(x => i++, x => new InsertExpressionSet(x, insertEntity.BuildInclusiveInsertExpression(x).Expressions));
             expression.Outputs = insertEntity.BuildInclusiveSelectExpression().Expressions.Select(x => x.AsFieldExpression()).ToList();

--- a/src/HatTrick.DbEx.Sql/Builder/SelectEntitiesSelectQueryExpressionBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/SelectEntitiesSelectQueryExpressionBuilder{T}.cs
@@ -20,6 +20,12 @@ namespace HatTrick.DbEx.Sql.Builder
         #endregion
 
         #region methods
+        protected override void From<T>(Entity<T> entity)
+        {
+            base.From(entity);
+            Expression.Select = new SelectExpressionSet(entity.BuildInclusiveSelectExpression());
+        }
+
         SelectEntities<TEntity> SelectEntities<TEntity>.Top(int value)
         {
             Top(value);
@@ -34,7 +40,7 @@ namespace HatTrick.DbEx.Sql.Builder
 
         SelectEntitiesContinuation<TEntity> SelectEntities<TEntity>.From(Entity<TEntity> entity)
         {
-            From(entity, true);
+            From(entity);
             return this;
         }
 

--- a/src/HatTrick.DbEx.Sql/Builder/SelectEntityQueryExpressionBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/SelectEntityQueryExpressionBuilder{T}.cs
@@ -18,9 +18,15 @@ namespace HatTrick.DbEx.Sql.Builder
         #endregion
 
         #region methods
+        protected override void From<T>(Entity<T> entity)
+        {
+            base.From(entity);
+            Expression.Select = new SelectExpressionSet(entity.BuildInclusiveSelectExpression());
+        }
+
         SelectEntityContinuation<TEntity> SelectEntity<TEntity>.From(Entity<TEntity> entity)
         {
-            From(entity, true);
+            From(entity);
             return this;
         }
 

--- a/src/HatTrick.DbEx.Sql/Builder/SelectQueryExpressionBuilder.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/SelectQueryExpressionBuilder.cs
@@ -20,15 +20,12 @@ namespace HatTrick.DbEx.Sql.Builder
         #endregion
 
         #region methods
-        protected void From<T>(Entity<T> entity, bool populateSelectListFromEntity)
+        protected virtual void From<T>(Entity<T> entity)
             where T : class, IDbEntity
         {
             if (!(entity is EntityExpression e))
-                throw new DbExpressionException($"Expected {nameof(entity)} to be of type {nameof(EntityExpression)}.");
-
+                throw new DbExpressionException($"Expected {nameof(entity)} to be of type {nameof(EntityExpression)}.");          
             Expression.BaseEntity = e;
-            if (populateSelectListFromEntity)
-                Expression.Select = new SelectExpressionSet(entity.BuildInclusiveSelectExpression());
         }
 
         protected void Top(int value)

--- a/src/HatTrick.DbEx.Sql/Builder/SelectValueSelectQueryExpressionBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/SelectValueSelectQueryExpressionBuilder{T}.cs
@@ -19,7 +19,7 @@ namespace HatTrick.DbEx.Sql.Builder
         #region methods
         SelectValueContinuation<TValue> SelectValue<TValue>.From<TEntity>(Entity<TEntity> entity)
         {
-            From(entity, false);
+            From(entity);
             return this;
         }
 

--- a/src/HatTrick.DbEx.Sql/Builder/SelectValuesSelectQueryExpressionBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/SelectValuesSelectQueryExpressionBuilder{T}.cs
@@ -34,7 +34,7 @@ namespace HatTrick.DbEx.Sql.Builder
 
         SelectValuesContinuation<TValue> SelectValues<TValue>.From<TEntity>(Entity<TEntity> entity)
         {
-            From(entity, false);
+            From(entity);
             return this;
         }
 

--- a/src/HatTrick.DbEx.Sql/Expression/EntityExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/EntityExpression.cs
@@ -4,7 +4,8 @@ using System.Linq;
 
 namespace HatTrick.DbEx.Sql.Expression
 {
-    public abstract class EntityExpression :
+    public abstract class EntityExpression : 
+        IEntityExpression,
         AnyEntity,
         ISqlMetadataIdentifier,
         IExpressionProvider<SchemaExpression>,
@@ -102,7 +103,5 @@ namespace HatTrick.DbEx.Sql.Expression
             }
         }
         #endregion
-
-        protected abstract SelectExpressionSet GetInclusiveSelectExpression();
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/EntityExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/EntityExpression{T}.cs
@@ -22,17 +22,18 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region interface
-        SelectExpressionSet IExpressionEntity.BuildInclusiveSelectExpression()
-            => GetInclusiveSelectExpression();
-        InsertExpressionSet<T> IExpressionEntity<T>.BuildInclusiveInsertExpression(T entity)
+        SelectExpressionSet IEntityExpression<T>.BuildInclusiveSelectExpression()
+            => GetInclusiveSelectExpression();        
+        InsertExpressionSet<T> IEntityExpression<T>.BuildInclusiveInsertExpression(T entity)
             => GetInclusiveInsertExpression(entity);
-        AssignmentExpressionSet IExpressionEntity<T>.BuildAssignmentExpression(T target, T source)
+        AssignmentExpressionSet IEntityExpression<T>.BuildAssignmentExpression(T target, T source)
             => GetAssignmentExpression(target, source);
-        void IExpressionEntity<T>.HydrateEntity(T entity, ISqlFieldReader reader)
+        void IEntityExpression<T>.HydrateEntity(T entity, ISqlFieldReader reader)
             => HydrateEntity(entity, reader);
         #endregion
 
         #region methods
+        protected abstract SelectExpressionSet GetInclusiveSelectExpression();
         protected abstract InsertExpressionSet<T> GetInclusiveInsertExpression(T entity);
         protected abstract AssignmentExpressionSet GetAssignmentExpression(T from, T to);
         protected abstract void HydrateEntity(T entity, ISqlFieldReader reader);

--- a/src/HatTrick.DbEx.Sql/Expression/IEntityExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/IEntityExpression.cs
@@ -1,0 +1,6 @@
+﻿namespace HatTrick.DbEx.Sql.Expression
+{
+    public interface IEntityExpression : IExpressionElement
+    {
+    }
+}

--- a/src/HatTrick.DbEx.Sql/Expression/IEntityExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/IEntityExpression{T}.cs
@@ -2,8 +2,9 @@
 
 namespace HatTrick.DbEx.Sql.Expression
 {
-    public interface IExpressionEntity<T> : IExpressionEntity
+    public interface IEntityExpression<T> : IEntityExpression
     {
+        SelectExpressionSet BuildInclusiveSelectExpression();
         InsertExpressionSet<T> BuildInclusiveInsertExpression(T entity);
         AssignmentExpressionSet BuildAssignmentExpression(T from, T to);
         void HydrateEntity(T entity, ISqlFieldReader reader);

--- a/src/HatTrick.DbEx.Sql/Expression/IExpressionEntity.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/IExpressionEntity.cs
@@ -1,7 +1,0 @@
-﻿namespace HatTrick.DbEx.Sql.Expression
-{
-    public interface IExpressionEntity : IExpressionElement
-    {
-        SelectExpressionSet BuildInclusiveSelectExpression();
-    }
-}

--- a/src/HatTrick.DbEx.Sql/Expression/QueryExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/QueryExpression.cs
@@ -2,6 +2,6 @@
 {
     public abstract class QueryExpression : IExpressionElement
     {
-        public EntityExpression BaseEntity { get; set; }
+        public IEntityExpression BaseEntity { get; set; }
     }    
 }

--- a/src/HatTrick.DbEx.Sql/IRuntimeSqlDatabase.cs
+++ b/src/HatTrick.DbEx.Sql/IRuntimeSqlDatabase.cs
@@ -4,7 +4,6 @@ namespace HatTrick.DbEx.Sql
 {
     public interface IRuntimeSqlDatabase
     {
-        RuntimeSqlDatabaseConfiguration Configuration { get; }
-        void Initialize(RuntimeSqlDatabaseConfiguration configuration);
+        void UseConfiguration(RuntimeSqlDatabaseConfiguration configuration);
     }
 }

--- a/src/HatTrick.DbEx.Sql/Mapper/MapperFactory.cs
+++ b/src/HatTrick.DbEx.Sql/Mapper/MapperFactory.cs
@@ -27,7 +27,7 @@ namespace HatTrick.DbEx.Sql.Mapper
             if (entityMappers.TryGetValue(typeof(TEntity), out Func<IMapper> map))
                 return map() as IEntityMapper<TEntity>;
 
-            var entityMap = new EntityMapper<TEntity>((entity as IExpressionEntity<TEntity>).HydrateEntity);
+            var entityMap = new EntityMapper<TEntity>((entity as IEntityExpression<TEntity>).HydrateEntity);
             entityMappers.TryAdd(typeof(TEntity), () => entityMap);
 
             return entityMap;

--- a/src/HatTrick.DbEx.Sql/_api/_Element/Entity{T}.cs
+++ b/src/HatTrick.DbEx.Sql/_api/_Element/Entity{T}.cs
@@ -3,7 +3,7 @@
 namespace HatTrick.DbEx.Sql
 {
 #pragma warning disable IDE1006 // Naming Styles
-    public interface Entity<TEntity> : AnyEntity, IExpressionEntity<TEntity>
+    public interface Entity<TEntity> : AnyEntity, IEntityExpression<TEntity>
 #pragma warning restore IDE1006 // Naming Styles
         where TEntity : class, IDbEntity
     {

--- a/test/HatTrick.DbEx.MsSql.Test.Code/Configuration/RuntimeSqlDatabaseConfigurationTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Code/Configuration/RuntimeSqlDatabaseConfigurationTests.cs
@@ -18,7 +18,7 @@ namespace HatTrick.DbEx.MsSql.Test.Code.Configuration
             var dbInstance = new db() as IRuntimeSqlDatabase;
 
             //when & then
-            var ex = Assert.Throws<ArgumentNullException>(() => dbInstance.Initialize(null));
+            var ex = Assert.Throws<ArgumentNullException>(() => dbInstance.UseConfiguration(null));
         }
 
         [Fact]

--- a/test/HatTrick.DbEx.MsSql.Test/Generated/DbExDataService.generated.cs
+++ b/test/HatTrick.DbEx.MsSql.Test/Generated/DbExDataService.generated.cs
@@ -13,21 +13,39 @@ using System.Dynamic;
 #pragma warning disable CA1034 // Nested types should not be visible
 namespace DbEx.DataService
 {
+	using DbEx.dboDataService;
+	using DbEx.secDataService;
+
     #region runtime db
-    public abstract class MsSqlDbRuntimeSqlDatabase : IRuntimeSqlDatabase
+    public abstract class MsSqlDbRuntimeSqlDatabase : IRuntimeSqlDatabase, IExpressionListProvider<SchemaExpression>
     {
         #region internals
         private const string NO_CONFIG_MESSAGE = "Cannot construct or execute queries as the database runtime environment has not been configured.";
+        protected static readonly MsSqlQueryExpressionBuilderFactory expressionBuilderFactory = new MsSqlQueryExpressionBuilderFactory();
+        protected static readonly IList<SchemaExpression> schemas = new List<SchemaExpression>();
         protected static RuntimeSqlDatabaseConfiguration config;
-        protected static MsSqlQueryExpressionBuilderFactory expressionBuilderFactory = new MsSqlQueryExpressionBuilderFactory();
         #endregion
 
         #region interface
-        RuntimeSqlDatabaseConfiguration IRuntimeSqlDatabase.Configuration => config;
+        IList<SchemaExpression> IExpressionListProvider<SchemaExpression>.Expressions => schemas;
+        #endregion
+
+        #region constructors
+        static MsSqlDbRuntimeSqlDatabase()
+        {
+            var dboSchema = new dboSchemaExpression("dbo");
+            schemas.Add(dboSchema);
+            dbo.UseSchema(dboSchema);
+
+            var secSchema = new secSchemaExpression("sec");
+            schemas.Add(secSchema);
+            sec.UseSchema(secSchema);
+
+        }
         #endregion
 
         #region methods
-        void IRuntimeSqlDatabase.Initialize(RuntimeSqlDatabaseConfiguration configuration)
+        void IRuntimeSqlDatabase.UseConfiguration(RuntimeSqlDatabaseConfiguration configuration)
             => config = configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.");
 
         #region select one
@@ -4880,10 +4898,6 @@ namespace DbEx.dboDataService
 #pragma warning restore IDE1006 // Naming Styles
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
-        #region internals
-        private static readonly dboSchemaExpression _schema = new dboSchemaExpression("dbo");
-        #endregion
-
         #region interface
         /// <summary>A <see cref="DbEx.dboDataService.AddressEntity"/> representing the "dbo.Address" table in the database.
         /// <para>Properties:
@@ -4907,7 +4921,7 @@ namespace DbEx.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly AddressEntity Address;
+        public static AddressEntity Address { get; private set; }
 
         /// <summary>A <see cref="DbEx.dboDataService.PersonEntity"/> representing the "dbo.Person" table in the database.
         /// <para>Properties:
@@ -4931,7 +4945,7 @@ namespace DbEx.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly PersonEntity Person;
+        public static PersonEntity Person { get; private set; }
 
         /// <summary>A <see cref="DbEx.dboDataService.PersonAddressEntity"/> representing the "dbo.Person_Address" table in the database.
         /// <para>Properties:
@@ -4955,7 +4969,7 @@ namespace DbEx.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly PersonAddressEntity PersonAddress;
+        public static PersonAddressEntity PersonAddress { get; private set; }
 
         /// <summary>A <see cref="DbEx.dboDataService.ProductEntity"/> representing the "dbo.Product" table in the database.
         /// <para>Properties:
@@ -4979,7 +4993,7 @@ namespace DbEx.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly ProductEntity Product;
+        public static ProductEntity Product { get; private set; }
 
         /// <summary>A <see cref="DbEx.dboDataService.PurchaseEntity"/> representing the "dbo.Purchase" table in the database.
         /// <para>Properties:
@@ -5003,7 +5017,7 @@ namespace DbEx.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly PurchaseEntity Purchase;
+        public static PurchaseEntity Purchase { get; private set; }
 
         /// <summary>A <see cref="DbEx.dboDataService.PurchaseLineEntity"/> representing the "dbo.PurchaseLine" table in the database.
         /// <para>Properties:
@@ -5027,7 +5041,7 @@ namespace DbEx.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly PurchaseLineEntity PurchaseLine;
+        public static PurchaseLineEntity PurchaseLine { get; private set; }
 
         /// <summary>A <see cref="DbEx.dboDataService.PersonTotalPurchasesViewEntity"/> representing the "dbo.PersonTotalPurchasesView" view in the database.
         /// <para>Properties:
@@ -5038,20 +5052,22 @@ namespace DbEx.dboDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly PersonTotalPurchasesViewEntity PersonTotalPurchasesView;
+        public static PersonTotalPurchasesViewEntity PersonTotalPurchasesView { get; private set; }
 
         #endregion
 
-        #region constructors
-        static dbo()
+        #region methods
+        public static void UseSchema(dboSchemaExpression schema)
         { 
-            Address = _schema.Address;
-            Person = _schema.Person;
-            PersonAddress = _schema.PersonAddress;
-            Product = _schema.Product;
-            Purchase = _schema.Purchase;
-            PurchaseLine = _schema.PurchaseLine;
-            PersonTotalPurchasesView = _schema.PersonTotalPurchasesView;
+            if (schema == null)
+                 throw new ArgumentNullException($"{nameof(schema)} is required.");
+            Address = schema.Address ?? throw new ArgumentNullException($"{schema.Address } is required.");
+            Person = schema.Person ?? throw new ArgumentNullException($"{schema.Person } is required.");
+            PersonAddress = schema.PersonAddress ?? throw new ArgumentNullException($"{schema.PersonAddress } is required.");
+            Product = schema.Product ?? throw new ArgumentNullException($"{schema.Product } is required.");
+            Purchase = schema.Purchase ?? throw new ArgumentNullException($"{schema.Purchase } is required.");
+            PurchaseLine = schema.PurchaseLine ?? throw new ArgumentNullException($"{schema.PurchaseLine } is required.");
+            PersonTotalPurchasesView = schema.PersonTotalPurchasesView ?? throw new ArgumentNullException($"{schema.PersonTotalPurchasesView } is required.");
         }
         #endregion
     }
@@ -5352,10 +5368,6 @@ namespace DbEx.secDataService
 #pragma warning restore IDE1006 // Naming Styles
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
-        #region internals
-        private static readonly secSchemaExpression _schema = new secSchemaExpression("sec");
-        #endregion
-
         #region interface
         /// <summary>A <see cref="DbEx.secDataService.PersonEntity"/> representing the "sec.Person" table in the database.
         /// <para>Properties:
@@ -5379,14 +5391,16 @@ namespace DbEx.secDataService
         /// </list>
         /// </para>
         /// </summary>
-        public static readonly PersonEntity Person;
+        public static PersonEntity Person { get; private set; }
 
         #endregion
 
-        #region constructors
-        static sec()
+        #region methods
+        public static void UseSchema(secSchemaExpression schema)
         { 
-            Person = _schema.Person;
+            if (schema == null)
+                 throw new ArgumentNullException($"{nameof(schema)} is required.");
+            Person = schema.Person ?? throw new ArgumentNullException($"{schema.Person } is required.");
         }
         #endregion
     }

--- a/tools/HatTrick.DbEx.Tools/Resources/Templates/DbExDataService._cs.htt
+++ b/tools/HatTrick.DbEx.Tools/Resources/Templates/DbExDataService._cs.htt
@@ -13,6 +13,10 @@ using System.Dynamic;
 #pragma warning disable CA1034 // Nested types should not be visible
 namespace {$.DatabaseExpression.NamespaceRoot}DataService
 {{
+	{#each $.Items}
+	using {$.SchemaExpression.NamespaceRoot}DataService;
+	{/each}
+
 {>("RuntimeDb") => GetTemplatePartial+}
 
 {>("RuntimeEnvironmentDb") => GetTemplatePartial+}

--- a/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/RuntimeDb.htt
+++ b/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/RuntimeDb.htt
@@ -1,18 +1,31 @@
 ﻿    #region runtime db
-    public abstract class {$.DatabaseExpression.Name}RuntimeSqlDatabase : IRuntimeSqlDatabase
+    public abstract class {$.DatabaseExpression.Name}RuntimeSqlDatabase : IRuntimeSqlDatabase, IExpressionListProvider<SchemaExpression>
     {{
         #region internals
         private const string NO_CONFIG_MESSAGE = "Cannot construct or execute queries as the database runtime environment has not been configured.";
+        protected static readonly MsSqlQueryExpressionBuilderFactory expressionBuilderFactory = new MsSqlQueryExpressionBuilderFactory();
+        protected static readonly IList<SchemaExpression> schemas = new List<SchemaExpression>();
         protected static RuntimeSqlDatabaseConfiguration config;
-        protected static MsSqlQueryExpressionBuilderFactory expressionBuilderFactory = new MsSqlQueryExpressionBuilderFactory();
         #endregion
 
         #region interface
-        RuntimeSqlDatabaseConfiguration IRuntimeSqlDatabase.Configuration => config;
+        IList<SchemaExpression> IExpressionListProvider<SchemaExpression>.Expressions => schemas;
+        #endregion
+
+        #region constructors
+        static {$.DatabaseExpression.Name}RuntimeSqlDatabase()
+        {{
+            {#each $.Items}
+            var {$.SchemaExpression.Name}Schema = new {$.SchemaExpression.Name}SchemaExpression("{$.SchemaExpression.Name}");
+            schemas.Add({$.SchemaExpression.Name}Schema);
+            {$.SchemaExpression.Name}.UseSchema({$.SchemaExpression.Name}Schema);
+
+            {/each}
+        }}
         #endregion
 
         #region methods
-        void IRuntimeSqlDatabase.Initialize(RuntimeSqlDatabaseConfiguration configuration)
+        void IRuntimeSqlDatabase.UseConfiguration(RuntimeSqlDatabaseConfiguration configuration)
             => config = configuration ?? throw new ArgumentNullException($"{{nameof(configuration)}} is required.");
 
         #region select one

--- a/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/Schema.htt
+++ b/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/Schema.htt
@@ -5,23 +5,21 @@
 #pragma warning restore IDE1006 // Naming Styles
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {{
-        #region internals
-        private static readonly {$.SchemaExpression.Name}SchemaExpression _schema = new {$.SchemaExpression.Name}SchemaExpression("{$.Schema.Name}");
-        #endregion
-
         #region interface
 		{#each $.Items}
         {>("EntityExpression.Documentation") => GetTemplatePartial+}
-        public static readonly {$.EntityExpression.Name}Entity {$.EntityExpression.Name};
+        public static {$.EntityExpression.Name}Entity {$.EntityExpression.Name} {{ get; private set; }}
 
 		{/each}
         #endregion
 
-        #region constructors
-        static {$.SchemaExpression.Name}()
+        #region methods
+        public static void UseSchema({$.SchemaExpression.Name}SchemaExpression schema)
         {{ 
+            if (schema == null)
+                 throw new ArgumentNullException($"{{nameof(schema)}} is required.");
 		    {#each $.Items}
-            {$.EntityExpression.Name} = _schema.{$.EntityExpression.Name};
+            {$.EntityExpression.Name} = schema.{$.EntityExpression.Name} ?? throw new ArgumentNullException($"{{schema.{$.EntityExpression.Name} }} is required.");
 		    {/each}
         }}
         #endregion


### PR DESCRIPTION
- Runtime database maintains list of schemas for future ability to pass to query expression builders.
- Renamed entity-specific interfaces to be align to convention.
- Restructured IEntityExpression and IEntityExpression{T} (after rename) to move all methods into the typed version.
- Corrected bad implementation on From methods of query expression builders that were passing a boolean flag to base.  Should have used overrides to achieve.