### PR TITLE
Execute with deferred management of reader, helper methods in dbex, and cleanup of aliasing

### DIFF
--- a/samples/mssql/NetCoreConsoleApp/Data/_Generated/DbExDataService.generated.cs
+++ b/samples/mssql/NetCoreConsoleApp/Data/_Generated/DbExDataService.generated.cs
@@ -7,6 +7,7 @@ using HatTrick.DbEx.Sql.Expression;
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.Linq;
 
 #pragma warning disable IDE1006 // Naming Styles
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
@@ -466,7 +467,7 @@ namespace SimpleConsole.DataService
         /// <param name="element1">Any expression</param>
         /// <param name="element2">Any expression</param>
         /// <param name="elements">Any expression</param>
-        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{ExpandoObject}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<ExpandoObject> SelectOne(AnyElement element1, AnyElement element2, params AnyElement[] elements)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element1, element2, elements);
 
@@ -478,9 +479,21 @@ namespace SimpleConsole.DataService
         /// </summary>
         /// <param name="element1">Any expression</param>
         /// <param name="elements">A list of any expression</param>
-        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{ExpandoObject}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<ExpandoObject> SelectOne(IEnumerable<AnyElement> elements)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, elements);
+
+        /// <summary>
+        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="AnyElement" /> method parameters.
+        /// <para>
+        /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
+        /// </para>
+        /// </summary>
+        /// <param name="elements">A list of any expression that is valid for a SELECT query expression.</param>
+        /// <param name="additionalElements">Any additional fields to select as part of the SELECT query expression.</param>
+        /// <returns><see cref="SelectValues{ExpandoObject}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        public static SelectValue<ExpandoObject> SelectOne(IEnumerable<AnyElement> elements, params AnyElement[] additionalElements)
+            => expressionBuilderFactory.CreateSelectValueBuilder(config, (elements ?? throw new ArgumentNullException($"{nameof(elements)} is required.")).Concat(additionalElements));
         #endregion
 
         #region select many
@@ -899,7 +912,7 @@ namespace SimpleConsole.DataService
         /// <param name="element1">Any expression</param>
         /// <param name="element2">Any expression</param>
         /// <param name="elements">Any expression</param>
-        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{ExpandoObject}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<ExpandoObject> SelectMany(AnyElement element1, AnyElement element2, params AnyElement[] elements)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element1, element2, elements);
 
@@ -910,9 +923,21 @@ namespace SimpleConsole.DataService
         /// </para>
         /// </summary>
         /// <param name="elements">A list of any expression</param>
-        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{ExpandoObject}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<ExpandoObject> SelectMany(IEnumerable<AnyElement> elements)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, elements);
+
+            /// <summary>
+        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="AnyElement" /> method parameters.
+        /// <para>
+        /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
+        /// </para>
+        /// </summary>
+        /// <param name="elements">A list of any expression that is valid for a SELECT query expression.</param>
+        /// <param name="additionalElements">Any additional fields to select as part of the SELECT query expression.</param>
+        /// <returns><see cref="SelectValues{ExpandoObject}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        public static SelectValues<ExpandoObject> SelectMany(IEnumerable<AnyElement> elements, params AnyElement[] additionalElements)
+            => expressionBuilderFactory.CreateSelectValuesBuilder(config, (elements ?? throw new ArgumentNullException($"{nameof(elements)} is required.")).Concat(additionalElements));
         #endregion
 
         #region update
@@ -1060,13 +1085,13 @@ namespace SimpleConsole.dboDataService
         #region constructors
         public dboSchemaExpression(string identifier) : base(identifier, null)
         {
-            Entities.Add($"{identifier}.Address", Address = new AddressEntity($"{identifier}.Address", this));
-            Entities.Add($"{identifier}.Person", Person = new PersonEntity($"{identifier}.Person", this));
-            Entities.Add($"{identifier}.Person_Address", PersonAddress = new PersonAddressEntity($"{identifier}.Person_Address", this));
-            Entities.Add($"{identifier}.Product", Product = new ProductEntity($"{identifier}.Product", this));
-            Entities.Add($"{identifier}.Purchase", Purchase = new PurchaseEntity($"{identifier}.Purchase", this));
-            Entities.Add($"{identifier}.PurchaseLine", PurchaseLine = new PurchaseLineEntity($"{identifier}.PurchaseLine", this));
-            Entities.Add($"{identifier}.PersonTotalPurchasesView", PersonTotalPurchasesView = new PersonTotalPurchasesViewEntity($"{identifier}.PersonTotalPurchasesView", this));
+            Entities.Add($"{identifier}.Address", Address = new AddressEntity($"{identifier}.Address", "Address", this));
+            Entities.Add($"{identifier}.Person", Person = new PersonEntity($"{identifier}.Person", "Person", this));
+            Entities.Add($"{identifier}.Person_Address", PersonAddress = new PersonAddressEntity($"{identifier}.Person_Address", "Person_Address", this));
+            Entities.Add($"{identifier}.Product", Product = new ProductEntity($"{identifier}.Product", "Product", this));
+            Entities.Add($"{identifier}.Purchase", Purchase = new PurchaseEntity($"{identifier}.Purchase", "Purchase", this));
+            Entities.Add($"{identifier}.PurchaseLine", PurchaseLine = new PurchaseLineEntity($"{identifier}.PurchaseLine", "PurchaseLine", this));
+            Entities.Add($"{identifier}.PersonTotalPurchasesView", PersonTotalPurchasesView = new PersonTotalPurchasesViewEntity($"{identifier}.PersonTotalPurchasesView", "PersonTotalPurchasesView", this));
         }
         #endregion
     }
@@ -1263,31 +1288,31 @@ namespace SimpleConsole.dboDataService
         #endregion
 
         #region constructors
-        private AddressEntity() : base(null, null, null)
+        private AddressEntity() : base(null, null, null, null)
         {
         }
 
-		public AddressEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public AddressEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private AddressEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private AddressEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.AddressType", AddressType = new AddressTypeField($"{identifier}.AddressType", this));
-            Fields.Add($"{identifier}.Line1", Line1 = new Line1Field($"{identifier}.Line1", this));
-            Fields.Add($"{identifier}.Line2", Line2 = new Line2Field($"{identifier}.Line2", this));
-            Fields.Add($"{identifier}.City", City = new CityField($"{identifier}.City", this));
-            Fields.Add($"{identifier}.State", State = new StateField($"{identifier}.State", this));
-            Fields.Add($"{identifier}.Zip", Zip = new ZipField($"{identifier}.Zip", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.AddressType", AddressType = new AddressTypeField($"{identifier}.AddressType", "AddressType", this));
+            Fields.Add($"{identifier}.Line1", Line1 = new Line1Field($"{identifier}.Line1", "Line1", this));
+            Fields.Add($"{identifier}.Line2", Line2 = new Line2Field($"{identifier}.Line2", "Line2", this));
+            Fields.Add($"{identifier}.City", City = new CityField($"{identifier}.City", "City", this));
+            Fields.Add($"{identifier}.State", State = new StateField($"{identifier}.State", "State", this));
+            Fields.Add($"{identifier}.Zip", Zip = new ZipField($"{identifier}.Zip", "Zip", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", "DateUpdated", this));
         }
         #endregion
 
         #region methods
         public AddressEntity As(string name)
-            => new AddressEntity(this.identifier, this.schema, name);
+            => new AddressEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -1302,6 +1327,44 @@ namespace SimpleConsole.dboDataService
                 ,new DateTimeSelectExpression(DateCreated)
                 ,new DateTimeSelectExpression(DateUpdated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(AddressType));
+            set &= aliased != nameof(AddressType) ? new NullableEnumSelectExpression<SimpleConsole.Data.AddressType>(AddressType).As(aliased) as NullableEnumSelectExpression<SimpleConsole.Data.AddressType> : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(AddressType));
+
+            aliased = alias(nameof(Line1));
+            set &= aliased != nameof(Line1) ? new StringSelectExpression(Line1).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Line1));
+
+            aliased = alias(nameof(Line2));
+            set &= aliased != nameof(Line2) ? new NullableStringSelectExpression(Line2).As(aliased) as NullableStringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Line2));
+
+            aliased = alias(nameof(City));
+            set &= aliased != nameof(City) ? new StringSelectExpression(City).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(City));
+
+            aliased = alias(nameof(State));
+            set &= aliased != nameof(State) ? new StringSelectExpression(State).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(State));
+
+            aliased = alias(nameof(Zip));
+            set &= aliased != nameof(Zip) ? new StringSelectExpression(Zip).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Zip));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            aliased = alias(nameof(DateUpdated));
+            set &= aliased != nameof(DateUpdated) ? new DateTimeSelectExpression(DateUpdated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateUpdated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<Address> GetInclusiveInsertExpression(Address address)
@@ -1329,7 +1392,7 @@ namespace SimpleConsole.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(Address address, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, Address address)
         {
 			address.Id = reader.ReadField().GetValue<int>();
 			address.AddressType = reader.ReadField().GetValue<SimpleConsole.Data.AddressType?>();
@@ -1348,12 +1411,7 @@ namespace SimpleConsole.dboDataService
         public partial class IdField : Int32FieldExpression<Address>
         {
             #region constructors
-            public IdField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1375,12 +1433,7 @@ namespace SimpleConsole.dboDataService
         public partial class AddressTypeField : NullableEnumFieldExpression<Address, SimpleConsole.Data.AddressType>
         {
             #region constructors
-            public AddressTypeField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private AddressTypeField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public AddressTypeField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1407,12 +1460,7 @@ namespace SimpleConsole.dboDataService
         public partial class Line1Field : StringFieldExpression<Address>
         {
             #region constructors
-            public Line1Field(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private Line1Field(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public Line1Field(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1436,12 +1484,7 @@ namespace SimpleConsole.dboDataService
         public partial class Line2Field : NullableStringFieldExpression<Address>
         {
             #region constructors
-            public Line2Field(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private Line2Field(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public Line2Field(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1467,12 +1510,7 @@ namespace SimpleConsole.dboDataService
         public partial class CityField : StringFieldExpression<Address>
         {
             #region constructors
-            public CityField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private CityField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public CityField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1496,12 +1534,7 @@ namespace SimpleConsole.dboDataService
         public partial class StateField : StringFieldExpression<Address>
         {
             #region constructors
-            public StateField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private StateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public StateField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1525,12 +1558,7 @@ namespace SimpleConsole.dboDataService
         public partial class ZipField : StringFieldExpression<Address>
         {
             #region constructors
-            public ZipField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ZipField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ZipField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1554,12 +1582,7 @@ namespace SimpleConsole.dboDataService
         public partial class DateCreatedField : DateTimeFieldExpression<Address>
         {
             #region constructors
-            public DateCreatedField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1581,12 +1604,7 @@ namespace SimpleConsole.dboDataService
         public partial class DateUpdatedField : DateTimeFieldExpression<Address>
         {
             #region constructors
-            public DateUpdatedField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateUpdatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateUpdatedField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1840,33 +1858,33 @@ namespace SimpleConsole.dboDataService
         #endregion
 
         #region constructors
-        private PersonEntity() : base(null, null, null)
+        private PersonEntity() : base(null, null, null, null)
         {
         }
 
-		public PersonEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public PersonEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private PersonEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private PersonEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.FirstName", FirstName = new FirstNameField($"{identifier}.FirstName", this));
-            Fields.Add($"{identifier}.LastName", LastName = new LastNameField($"{identifier}.LastName", this));
-            Fields.Add($"{identifier}.BirthDate", BirthDate = new BirthDateField($"{identifier}.BirthDate", this));
-            Fields.Add($"{identifier}.GenderType", GenderType = new GenderTypeField($"{identifier}.GenderType", this));
-            Fields.Add($"{identifier}.CreditLimit", CreditLimit = new CreditLimitField($"{identifier}.CreditLimit", this));
-            Fields.Add($"{identifier}.YearOfLastCreditLimitReview", YearOfLastCreditLimitReview = new YearOfLastCreditLimitReviewField($"{identifier}.YearOfLastCreditLimitReview", this));
-            Fields.Add($"{identifier}.RegistrationDate", RegistrationDate = new RegistrationDateField($"{identifier}.RegistrationDate", this));
-            Fields.Add($"{identifier}.LastLoginDate", LastLoginDate = new LastLoginDateField($"{identifier}.LastLoginDate", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.FirstName", FirstName = new FirstNameField($"{identifier}.FirstName", "FirstName", this));
+            Fields.Add($"{identifier}.LastName", LastName = new LastNameField($"{identifier}.LastName", "LastName", this));
+            Fields.Add($"{identifier}.BirthDate", BirthDate = new BirthDateField($"{identifier}.BirthDate", "BirthDate", this));
+            Fields.Add($"{identifier}.GenderType", GenderType = new GenderTypeField($"{identifier}.GenderType", "GenderType", this));
+            Fields.Add($"{identifier}.CreditLimit", CreditLimit = new CreditLimitField($"{identifier}.CreditLimit", "CreditLimit", this));
+            Fields.Add($"{identifier}.YearOfLastCreditLimitReview", YearOfLastCreditLimitReview = new YearOfLastCreditLimitReviewField($"{identifier}.YearOfLastCreditLimitReview", "YearOfLastCreditLimitReview", this));
+            Fields.Add($"{identifier}.RegistrationDate", RegistrationDate = new RegistrationDateField($"{identifier}.RegistrationDate", "RegistrationDate", this));
+            Fields.Add($"{identifier}.LastLoginDate", LastLoginDate = new LastLoginDateField($"{identifier}.LastLoginDate", "LastLoginDate", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", "DateUpdated", this));
         }
         #endregion
 
         #region methods
         public PersonEntity As(string name)
-            => new PersonEntity(this.identifier, this.schema, name);
+            => new PersonEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -1883,6 +1901,50 @@ namespace SimpleConsole.dboDataService
                 ,new DateTimeSelectExpression(DateCreated)
                 ,new DateTimeSelectExpression(DateUpdated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(FirstName));
+            set &= aliased != nameof(FirstName) ? new StringSelectExpression(FirstName).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(FirstName));
+
+            aliased = alias(nameof(LastName));
+            set &= aliased != nameof(LastName) ? new StringSelectExpression(LastName).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(LastName));
+
+            aliased = alias(nameof(BirthDate));
+            set &= aliased != nameof(BirthDate) ? new NullableDateTimeSelectExpression(BirthDate).As(aliased) as NullableDateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(BirthDate));
+
+            aliased = alias(nameof(GenderType));
+            set &= aliased != nameof(GenderType) ? new EnumSelectExpression<SimpleConsole.Data.GenderType>(GenderType).As(aliased) as EnumSelectExpression<SimpleConsole.Data.GenderType> : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(GenderType));
+
+            aliased = alias(nameof(CreditLimit));
+            set &= aliased != nameof(CreditLimit) ? new NullableInt32SelectExpression(CreditLimit).As(aliased) as NullableInt32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(CreditLimit));
+
+            aliased = alias(nameof(YearOfLastCreditLimitReview));
+            set &= aliased != nameof(YearOfLastCreditLimitReview) ? new NullableInt32SelectExpression(YearOfLastCreditLimitReview).As(aliased) as NullableInt32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(YearOfLastCreditLimitReview));
+
+            aliased = alias(nameof(RegistrationDate));
+            set &= aliased != nameof(RegistrationDate) ? new DateTimeOffsetSelectExpression(RegistrationDate).As(aliased) as DateTimeOffsetSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(RegistrationDate));
+
+            aliased = alias(nameof(LastLoginDate));
+            set &= aliased != nameof(LastLoginDate) ? new NullableDateTimeOffsetSelectExpression(LastLoginDate).As(aliased) as NullableDateTimeOffsetSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(LastLoginDate));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            aliased = alias(nameof(DateUpdated));
+            set &= aliased != nameof(DateUpdated) ? new DateTimeSelectExpression(DateUpdated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateUpdated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<Person> GetInclusiveInsertExpression(Person person)
@@ -1914,7 +1976,7 @@ namespace SimpleConsole.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(Person person, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, Person person)
         {
 			person.Id = reader.ReadField().GetValue<int>();
 			person.FirstName = reader.ReadField().GetValue<string>();
@@ -1935,12 +1997,7 @@ namespace SimpleConsole.dboDataService
         public partial class IdField : Int32FieldExpression<Person>
         {
             #region constructors
-            public IdField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1962,12 +2019,7 @@ namespace SimpleConsole.dboDataService
         public partial class FirstNameField : StringFieldExpression<Person>
         {
             #region constructors
-            public FirstNameField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private FirstNameField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public FirstNameField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1991,12 +2043,7 @@ namespace SimpleConsole.dboDataService
         public partial class LastNameField : StringFieldExpression<Person>
         {
             #region constructors
-            public LastNameField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private LastNameField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public LastNameField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2020,12 +2067,7 @@ namespace SimpleConsole.dboDataService
         public partial class BirthDateField : NullableDateTimeFieldExpression<Person>
         {
             #region constructors
-            public BirthDateField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private BirthDateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public BirthDateField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2052,12 +2094,7 @@ namespace SimpleConsole.dboDataService
         public partial class GenderTypeField : EnumFieldExpression<Person, SimpleConsole.Data.GenderType>
         {
             #region constructors
-            public GenderTypeField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private GenderTypeField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public GenderTypeField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2081,12 +2118,7 @@ namespace SimpleConsole.dboDataService
         public partial class CreditLimitField : NullableInt32FieldExpression<Person>
         {
             #region constructors
-            public CreditLimitField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private CreditLimitField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public CreditLimitField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2113,12 +2145,7 @@ namespace SimpleConsole.dboDataService
         public partial class YearOfLastCreditLimitReviewField : NullableInt32FieldExpression<Person>
         {
             #region constructors
-            public YearOfLastCreditLimitReviewField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private YearOfLastCreditLimitReviewField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public YearOfLastCreditLimitReviewField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2145,12 +2172,7 @@ namespace SimpleConsole.dboDataService
         public partial class RegistrationDateField : DateTimeOffsetFieldExpression<Person>
         {
             #region constructors
-            public RegistrationDateField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private RegistrationDateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public RegistrationDateField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2174,12 +2196,7 @@ namespace SimpleConsole.dboDataService
         public partial class LastLoginDateField : NullableDateTimeOffsetFieldExpression<Person>
         {
             #region constructors
-            public LastLoginDateField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private LastLoginDateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public LastLoginDateField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2206,12 +2223,7 @@ namespace SimpleConsole.dboDataService
         public partial class DateCreatedField : DateTimeFieldExpression<Person>
         {
             #region constructors
-            public DateCreatedField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2233,12 +2245,7 @@ namespace SimpleConsole.dboDataService
         public partial class DateUpdatedField : DateTimeFieldExpression<Person>
         {
             #region constructors
-            public DateUpdatedField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateUpdatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateUpdatedField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2353,26 +2360,26 @@ namespace SimpleConsole.dboDataService
         #endregion
 
         #region constructors
-        private PersonAddressEntity() : base(null, null, null)
+        private PersonAddressEntity() : base(null, null, null, null)
         {
         }
 
-		public PersonAddressEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public PersonAddressEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private PersonAddressEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private PersonAddressEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.PersonId", PersonId = new PersonIdField($"{identifier}.PersonId", this));
-            Fields.Add($"{identifier}.AddressId", AddressId = new AddressIdField($"{identifier}.AddressId", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.PersonId", PersonId = new PersonIdField($"{identifier}.PersonId", "PersonId", this));
+            Fields.Add($"{identifier}.AddressId", AddressId = new AddressIdField($"{identifier}.AddressId", "AddressId", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
         }
         #endregion
 
         #region methods
         public PersonAddressEntity As(string name)
-            => new PersonAddressEntity(this.identifier, this.schema, name);
+            => new PersonAddressEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -2382,6 +2389,29 @@ namespace SimpleConsole.dboDataService
                 ,new Int32SelectExpression(AddressId)
                 ,new DateTimeSelectExpression(DateCreated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(PersonId));
+            set &= aliased != nameof(PersonId) ? new Int32SelectExpression(PersonId).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(PersonId));
+
+            aliased = alias(nameof(AddressId));
+            set &= aliased != nameof(AddressId) ? new Int32SelectExpression(AddressId).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(AddressId));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<PersonAddress> GetInclusiveInsertExpression(PersonAddress personAddress)
@@ -2401,7 +2431,7 @@ namespace SimpleConsole.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(PersonAddress personAddress, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, PersonAddress personAddress)
         {
 			personAddress.Id = reader.ReadField().GetValue<int>();
 			personAddress.PersonId = reader.ReadField().GetValue<int>();
@@ -2415,12 +2445,7 @@ namespace SimpleConsole.dboDataService
         public partial class IdField : Int32FieldExpression<PersonAddress>
         {
             #region constructors
-            public IdField(string identifier, PersonAddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, PersonAddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2442,12 +2467,7 @@ namespace SimpleConsole.dboDataService
         public partial class PersonIdField : Int32FieldExpression<PersonAddress>
         {
             #region constructors
-            public PersonIdField(string identifier, PersonAddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PersonIdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PersonIdField(string identifier, string name, PersonAddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2471,12 +2491,7 @@ namespace SimpleConsole.dboDataService
         public partial class AddressIdField : Int32FieldExpression<PersonAddress>
         {
             #region constructors
-            public AddressIdField(string identifier, PersonAddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private AddressIdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public AddressIdField(string identifier, string name, PersonAddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2500,12 +2515,7 @@ namespace SimpleConsole.dboDataService
         public partial class DateCreatedField : DateTimeFieldExpression<PersonAddress>
         {
             #region constructors
-            public DateCreatedField(string identifier, PersonAddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, PersonAddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2870,39 +2880,39 @@ namespace SimpleConsole.dboDataService
         #endregion
 
         #region constructors
-        private ProductEntity() : base(null, null, null)
+        private ProductEntity() : base(null, null, null, null)
         {
         }
 
-		public ProductEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public ProductEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private ProductEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private ProductEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.ProductCategoryType", ProductCategoryType = new ProductCategoryTypeField($"{identifier}.ProductCategoryType", this));
-            Fields.Add($"{identifier}.Name", Name = new NameField($"{identifier}.Name", this));
-            Fields.Add($"{identifier}.Description", Description = new DescriptionField($"{identifier}.Description", this));
-            Fields.Add($"{identifier}.ListPrice", ListPrice = new ListPriceField($"{identifier}.ListPrice", this));
-            Fields.Add($"{identifier}.Price", Price = new PriceField($"{identifier}.Price", this));
-            Fields.Add($"{identifier}.Quantity", Quantity = new QuantityField($"{identifier}.Quantity", this));
-            Fields.Add($"{identifier}.Image", Image = new ImageField($"{identifier}.Image", this));
-            Fields.Add($"{identifier}.Height", Height = new HeightField($"{identifier}.Height", this));
-            Fields.Add($"{identifier}.Width", Width = new WidthField($"{identifier}.Width", this));
-            Fields.Add($"{identifier}.Depth", Depth = new DepthField($"{identifier}.Depth", this));
-            Fields.Add($"{identifier}.Weight", Weight = new WeightField($"{identifier}.Weight", this));
-            Fields.Add($"{identifier}.ShippingWeight", ShippingWeight = new ShippingWeightField($"{identifier}.ShippingWeight", this));
-            Fields.Add($"{identifier}.ValidStartTimeOfDayForPurchase", ValidStartTimeOfDayForPurchase = new ValidStartTimeOfDayForPurchaseField($"{identifier}.ValidStartTimeOfDayForPurchase", this));
-            Fields.Add($"{identifier}.ValidEndTimeOfDayForPurchase", ValidEndTimeOfDayForPurchase = new ValidEndTimeOfDayForPurchaseField($"{identifier}.ValidEndTimeOfDayForPurchase", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.ProductCategoryType", ProductCategoryType = new ProductCategoryTypeField($"{identifier}.ProductCategoryType", "ProductCategoryType", this));
+            Fields.Add($"{identifier}.Name", Name = new NameField($"{identifier}.Name", "Name", this));
+            Fields.Add($"{identifier}.Description", Description = new DescriptionField($"{identifier}.Description", "Description", this));
+            Fields.Add($"{identifier}.ListPrice", ListPrice = new ListPriceField($"{identifier}.ListPrice", "ListPrice", this));
+            Fields.Add($"{identifier}.Price", Price = new PriceField($"{identifier}.Price", "Price", this));
+            Fields.Add($"{identifier}.Quantity", Quantity = new QuantityField($"{identifier}.Quantity", "Quantity", this));
+            Fields.Add($"{identifier}.Image", Image = new ImageField($"{identifier}.Image", "Image", this));
+            Fields.Add($"{identifier}.Height", Height = new HeightField($"{identifier}.Height", "Height", this));
+            Fields.Add($"{identifier}.Width", Width = new WidthField($"{identifier}.Width", "Width", this));
+            Fields.Add($"{identifier}.Depth", Depth = new DepthField($"{identifier}.Depth", "Depth", this));
+            Fields.Add($"{identifier}.Weight", Weight = new WeightField($"{identifier}.Weight", "Weight", this));
+            Fields.Add($"{identifier}.ShippingWeight", ShippingWeight = new ShippingWeightField($"{identifier}.ShippingWeight", "ShippingWeight", this));
+            Fields.Add($"{identifier}.ValidStartTimeOfDayForPurchase", ValidStartTimeOfDayForPurchase = new ValidStartTimeOfDayForPurchaseField($"{identifier}.ValidStartTimeOfDayForPurchase", "ValidStartTimeOfDayForPurchase", this));
+            Fields.Add($"{identifier}.ValidEndTimeOfDayForPurchase", ValidEndTimeOfDayForPurchase = new ValidEndTimeOfDayForPurchaseField($"{identifier}.ValidEndTimeOfDayForPurchase", "ValidEndTimeOfDayForPurchase", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", "DateUpdated", this));
         }
         #endregion
 
         #region methods
         public ProductEntity As(string name)
-            => new ProductEntity(this.identifier, this.schema, name);
+            => new ProductEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -2925,6 +2935,68 @@ namespace SimpleConsole.dboDataService
                 ,new DateTimeSelectExpression(DateCreated)
                 ,new DateTimeSelectExpression(DateUpdated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(ProductCategoryType));
+            set &= aliased != nameof(ProductCategoryType) ? new NullableEnumSelectExpression<SimpleConsole.Data.ProductCategoryType>(ProductCategoryType).As(aliased) as NullableEnumSelectExpression<SimpleConsole.Data.ProductCategoryType> : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ProductCategoryType));
+
+            aliased = alias(nameof(Name));
+            set &= aliased != nameof(Name) ? new StringSelectExpression(Name).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Name));
+
+            aliased = alias(nameof(Description));
+            set &= aliased != nameof(Description) ? new NullableStringSelectExpression(Description).As(aliased) as NullableStringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Description));
+
+            aliased = alias(nameof(ListPrice));
+            set &= aliased != nameof(ListPrice) ? new DoubleSelectExpression(ListPrice).As(aliased) as DoubleSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ListPrice));
+
+            aliased = alias(nameof(Price));
+            set &= aliased != nameof(Price) ? new DoubleSelectExpression(Price).As(aliased) as DoubleSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Price));
+
+            aliased = alias(nameof(Quantity));
+            set &= aliased != nameof(Quantity) ? new Int32SelectExpression(Quantity).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Quantity));
+
+            aliased = alias(nameof(Image));
+            set &= aliased != nameof(Image) ? new NullableByteArraySelectExpression(Image).As(aliased) as NullableByteArraySelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Image));
+
+            aliased = alias(nameof(Height));
+            set &= aliased != nameof(Height) ? new NullableDecimalSelectExpression(Height).As(aliased) as NullableDecimalSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Height));
+
+            aliased = alias(nameof(Width));
+            set &= aliased != nameof(Width) ? new NullableDecimalSelectExpression(Width).As(aliased) as NullableDecimalSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Width));
+
+            aliased = alias(nameof(Depth));
+            set &= aliased != nameof(Depth) ? new NullableDecimalSelectExpression(Depth).As(aliased) as NullableDecimalSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Depth));
+
+            aliased = alias(nameof(Weight));
+            set &= aliased != nameof(Weight) ? new NullableDecimalSelectExpression(Weight).As(aliased) as NullableDecimalSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Weight));
+
+            aliased = alias(nameof(ShippingWeight));
+            set &= aliased != nameof(ShippingWeight) ? new DecimalSelectExpression(ShippingWeight).As(aliased) as DecimalSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ShippingWeight));
+
+            aliased = alias(nameof(ValidStartTimeOfDayForPurchase));
+            set &= aliased != nameof(ValidStartTimeOfDayForPurchase) ? new NullableTimeSpanSelectExpression(ValidStartTimeOfDayForPurchase).As(aliased) as NullableTimeSpanSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ValidStartTimeOfDayForPurchase));
+
+            aliased = alias(nameof(ValidEndTimeOfDayForPurchase));
+            set &= aliased != nameof(ValidEndTimeOfDayForPurchase) ? new NullableTimeSpanSelectExpression(ValidEndTimeOfDayForPurchase).As(aliased) as NullableTimeSpanSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ValidEndTimeOfDayForPurchase));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            aliased = alias(nameof(DateUpdated));
+            set &= aliased != nameof(DateUpdated) ? new DateTimeSelectExpression(DateUpdated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateUpdated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<Product> GetInclusiveInsertExpression(Product product)
@@ -2968,7 +3040,7 @@ namespace SimpleConsole.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(Product product, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, Product product)
         {
 			product.Id = reader.ReadField().GetValue<int>();
 			product.ProductCategoryType = reader.ReadField().GetValue<SimpleConsole.Data.ProductCategoryType?>();
@@ -2995,12 +3067,7 @@ namespace SimpleConsole.dboDataService
         public partial class IdField : Int32FieldExpression<Product>
         {
             #region constructors
-            public IdField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3022,12 +3089,7 @@ namespace SimpleConsole.dboDataService
         public partial class ProductCategoryTypeField : NullableEnumFieldExpression<Product, SimpleConsole.Data.ProductCategoryType>
         {
             #region constructors
-            public ProductCategoryTypeField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ProductCategoryTypeField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ProductCategoryTypeField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3054,12 +3116,7 @@ namespace SimpleConsole.dboDataService
         public partial class NameField : StringFieldExpression<Product>
         {
             #region constructors
-            public NameField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private NameField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public NameField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3083,12 +3140,7 @@ namespace SimpleConsole.dboDataService
         public partial class DescriptionField : NullableStringFieldExpression<Product>
         {
             #region constructors
-            public DescriptionField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DescriptionField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DescriptionField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3114,12 +3166,7 @@ namespace SimpleConsole.dboDataService
         public partial class ListPriceField : DoubleFieldExpression<Product>
         {
             #region constructors
-            public ListPriceField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ListPriceField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ListPriceField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3143,12 +3190,7 @@ namespace SimpleConsole.dboDataService
         public partial class PriceField : DoubleFieldExpression<Product>
         {
             #region constructors
-            public PriceField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PriceField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PriceField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3172,12 +3214,7 @@ namespace SimpleConsole.dboDataService
         public partial class QuantityField : Int32FieldExpression<Product>
         {
             #region constructors
-            public QuantityField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private QuantityField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public QuantityField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3201,12 +3238,7 @@ namespace SimpleConsole.dboDataService
         public partial class ImageField : NullableByteArrayFieldExpression<Product>
         {
             #region constructors
-            public ImageField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ImageField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ImageField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3232,12 +3264,7 @@ namespace SimpleConsole.dboDataService
         public partial class HeightField : NullableDecimalFieldExpression<Product>
         {
             #region constructors
-            public HeightField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private HeightField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public HeightField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3264,12 +3291,7 @@ namespace SimpleConsole.dboDataService
         public partial class WidthField : NullableDecimalFieldExpression<Product>
         {
             #region constructors
-            public WidthField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private WidthField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public WidthField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3296,12 +3318,7 @@ namespace SimpleConsole.dboDataService
         public partial class DepthField : NullableDecimalFieldExpression<Product>
         {
             #region constructors
-            public DepthField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DepthField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DepthField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3328,12 +3345,7 @@ namespace SimpleConsole.dboDataService
         public partial class WeightField : NullableDecimalFieldExpression<Product>
         {
             #region constructors
-            public WeightField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private WeightField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public WeightField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3360,12 +3372,7 @@ namespace SimpleConsole.dboDataService
         public partial class ShippingWeightField : DecimalFieldExpression<Product>
         {
             #region constructors
-            public ShippingWeightField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ShippingWeightField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ShippingWeightField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3389,12 +3396,7 @@ namespace SimpleConsole.dboDataService
         public partial class ValidStartTimeOfDayForPurchaseField : NullableTimeSpanFieldExpression<Product>
         {
             #region constructors
-            public ValidStartTimeOfDayForPurchaseField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ValidStartTimeOfDayForPurchaseField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ValidStartTimeOfDayForPurchaseField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3421,12 +3423,7 @@ namespace SimpleConsole.dboDataService
         public partial class ValidEndTimeOfDayForPurchaseField : NullableTimeSpanFieldExpression<Product>
         {
             #region constructors
-            public ValidEndTimeOfDayForPurchaseField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ValidEndTimeOfDayForPurchaseField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ValidEndTimeOfDayForPurchaseField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3453,12 +3450,7 @@ namespace SimpleConsole.dboDataService
         public partial class DateCreatedField : DateTimeFieldExpression<Product>
         {
             #region constructors
-            public DateCreatedField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3480,12 +3472,7 @@ namespace SimpleConsole.dboDataService
         public partial class DateUpdatedField : DateTimeFieldExpression<Product>
         {
             #region constructors
-            public DateUpdatedField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateUpdatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateUpdatedField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3774,35 +3761,35 @@ namespace SimpleConsole.dboDataService
         #endregion
 
         #region constructors
-        private PurchaseEntity() : base(null, null, null)
+        private PurchaseEntity() : base(null, null, null, null)
         {
         }
 
-		public PurchaseEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public PurchaseEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private PurchaseEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private PurchaseEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.PersonId", PersonId = new PersonIdField($"{identifier}.PersonId", this));
-            Fields.Add($"{identifier}.OrderNumber", OrderNumber = new OrderNumberField($"{identifier}.OrderNumber", this));
-            Fields.Add($"{identifier}.TotalPurchaseQuantity", TotalPurchaseQuantity = new TotalPurchaseQuantityField($"{identifier}.TotalPurchaseQuantity", this));
-            Fields.Add($"{identifier}.TotalPurchaseAmount", TotalPurchaseAmount = new TotalPurchaseAmountField($"{identifier}.TotalPurchaseAmount", this));
-            Fields.Add($"{identifier}.PurchaseDate", PurchaseDate = new PurchaseDateField($"{identifier}.PurchaseDate", this));
-            Fields.Add($"{identifier}.ShipDate", ShipDate = new ShipDateField($"{identifier}.ShipDate", this));
-            Fields.Add($"{identifier}.ExpectedDeliveryDate", ExpectedDeliveryDate = new ExpectedDeliveryDateField($"{identifier}.ExpectedDeliveryDate", this));
-            Fields.Add($"{identifier}.TrackingIdentifier", TrackingIdentifier = new TrackingIdentifierField($"{identifier}.TrackingIdentifier", this));
-            Fields.Add($"{identifier}.PaymentMethodType", PaymentMethodType = new PaymentMethodTypeField($"{identifier}.PaymentMethodType", this));
-            Fields.Add($"{identifier}.PaymentSourceType", PaymentSourceType = new PaymentSourceTypeField($"{identifier}.PaymentSourceType", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.PersonId", PersonId = new PersonIdField($"{identifier}.PersonId", "PersonId", this));
+            Fields.Add($"{identifier}.OrderNumber", OrderNumber = new OrderNumberField($"{identifier}.OrderNumber", "OrderNumber", this));
+            Fields.Add($"{identifier}.TotalPurchaseQuantity", TotalPurchaseQuantity = new TotalPurchaseQuantityField($"{identifier}.TotalPurchaseQuantity", "TotalPurchaseQuantity", this));
+            Fields.Add($"{identifier}.TotalPurchaseAmount", TotalPurchaseAmount = new TotalPurchaseAmountField($"{identifier}.TotalPurchaseAmount", "TotalPurchaseAmount", this));
+            Fields.Add($"{identifier}.PurchaseDate", PurchaseDate = new PurchaseDateField($"{identifier}.PurchaseDate", "PurchaseDate", this));
+            Fields.Add($"{identifier}.ShipDate", ShipDate = new ShipDateField($"{identifier}.ShipDate", "ShipDate", this));
+            Fields.Add($"{identifier}.ExpectedDeliveryDate", ExpectedDeliveryDate = new ExpectedDeliveryDateField($"{identifier}.ExpectedDeliveryDate", "ExpectedDeliveryDate", this));
+            Fields.Add($"{identifier}.TrackingIdentifier", TrackingIdentifier = new TrackingIdentifierField($"{identifier}.TrackingIdentifier", "TrackingIdentifier", this));
+            Fields.Add($"{identifier}.PaymentMethodType", PaymentMethodType = new PaymentMethodTypeField($"{identifier}.PaymentMethodType", "PaymentMethodType", this));
+            Fields.Add($"{identifier}.PaymentSourceType", PaymentSourceType = new PaymentSourceTypeField($"{identifier}.PaymentSourceType", "PaymentSourceType", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", "DateUpdated", this));
         }
         #endregion
 
         #region methods
         public PurchaseEntity As(string name)
-            => new PurchaseEntity(this.identifier, this.schema, name);
+            => new PurchaseEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -3821,6 +3808,56 @@ namespace SimpleConsole.dboDataService
                 ,new DateTimeSelectExpression(DateCreated)
                 ,new DateTimeSelectExpression(DateUpdated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(PersonId));
+            set &= aliased != nameof(PersonId) ? new Int32SelectExpression(PersonId).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(PersonId));
+
+            aliased = alias(nameof(OrderNumber));
+            set &= aliased != nameof(OrderNumber) ? new StringSelectExpression(OrderNumber).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(OrderNumber));
+
+            aliased = alias(nameof(TotalPurchaseQuantity));
+            set &= aliased != nameof(TotalPurchaseQuantity) ? new Int32SelectExpression(TotalPurchaseQuantity).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(TotalPurchaseQuantity));
+
+            aliased = alias(nameof(TotalPurchaseAmount));
+            set &= aliased != nameof(TotalPurchaseAmount) ? new DoubleSelectExpression(TotalPurchaseAmount).As(aliased) as DoubleSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(TotalPurchaseAmount));
+
+            aliased = alias(nameof(PurchaseDate));
+            set &= aliased != nameof(PurchaseDate) ? new DateTimeSelectExpression(PurchaseDate).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(PurchaseDate));
+
+            aliased = alias(nameof(ShipDate));
+            set &= aliased != nameof(ShipDate) ? new NullableDateTimeSelectExpression(ShipDate).As(aliased) as NullableDateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ShipDate));
+
+            aliased = alias(nameof(ExpectedDeliveryDate));
+            set &= aliased != nameof(ExpectedDeliveryDate) ? new NullableDateTimeSelectExpression(ExpectedDeliveryDate).As(aliased) as NullableDateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ExpectedDeliveryDate));
+
+            aliased = alias(nameof(TrackingIdentifier));
+            set &= aliased != nameof(TrackingIdentifier) ? new NullableGuidSelectExpression(TrackingIdentifier).As(aliased) as NullableGuidSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(TrackingIdentifier));
+
+            aliased = alias(nameof(PaymentMethodType));
+            set &= aliased != nameof(PaymentMethodType) ? new EnumSelectExpression<SimpleConsole.Data.PaymentMethodType>(PaymentMethodType).As(aliased) as EnumSelectExpression<SimpleConsole.Data.PaymentMethodType> : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(PaymentMethodType));
+
+            aliased = alias(nameof(PaymentSourceType));
+            set &= aliased != nameof(PaymentSourceType) ? new NullableEnumSelectExpression<SimpleConsole.Data.PaymentSourceType>(PaymentSourceType).As(aliased) as NullableEnumSelectExpression<SimpleConsole.Data.PaymentSourceType> : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(PaymentSourceType));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            aliased = alias(nameof(DateUpdated));
+            set &= aliased != nameof(DateUpdated) ? new DateTimeSelectExpression(DateUpdated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateUpdated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<Purchase> GetInclusiveInsertExpression(Purchase purchase)
@@ -3856,7 +3893,7 @@ namespace SimpleConsole.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(Purchase purchase, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, Purchase purchase)
         {
 			purchase.Id = reader.ReadField().GetValue<int>();
 			purchase.PersonId = reader.ReadField().GetValue<int>();
@@ -3879,12 +3916,7 @@ namespace SimpleConsole.dboDataService
         public partial class IdField : Int32FieldExpression<Purchase>
         {
             #region constructors
-            public IdField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3906,12 +3938,7 @@ namespace SimpleConsole.dboDataService
         public partial class PersonIdField : Int32FieldExpression<Purchase>
         {
             #region constructors
-            public PersonIdField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PersonIdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PersonIdField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3935,12 +3962,7 @@ namespace SimpleConsole.dboDataService
         public partial class OrderNumberField : StringFieldExpression<Purchase>
         {
             #region constructors
-            public OrderNumberField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private OrderNumberField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public OrderNumberField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3964,12 +3986,7 @@ namespace SimpleConsole.dboDataService
         public partial class TotalPurchaseQuantityField : Int32FieldExpression<Purchase>
         {
             #region constructors
-            public TotalPurchaseQuantityField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private TotalPurchaseQuantityField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public TotalPurchaseQuantityField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3993,12 +4010,7 @@ namespace SimpleConsole.dboDataService
         public partial class TotalPurchaseAmountField : DoubleFieldExpression<Purchase>
         {
             #region constructors
-            public TotalPurchaseAmountField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private TotalPurchaseAmountField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public TotalPurchaseAmountField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4022,12 +4034,7 @@ namespace SimpleConsole.dboDataService
         public partial class PurchaseDateField : DateTimeFieldExpression<Purchase>
         {
             #region constructors
-            public PurchaseDateField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PurchaseDateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PurchaseDateField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4051,12 +4058,7 @@ namespace SimpleConsole.dboDataService
         public partial class ShipDateField : NullableDateTimeFieldExpression<Purchase>
         {
             #region constructors
-            public ShipDateField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ShipDateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ShipDateField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4083,12 +4085,7 @@ namespace SimpleConsole.dboDataService
         public partial class ExpectedDeliveryDateField : NullableDateTimeFieldExpression<Purchase>
         {
             #region constructors
-            public ExpectedDeliveryDateField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ExpectedDeliveryDateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ExpectedDeliveryDateField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4115,12 +4112,7 @@ namespace SimpleConsole.dboDataService
         public partial class TrackingIdentifierField : NullableGuidFieldExpression<Purchase>
         {
             #region constructors
-            public TrackingIdentifierField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private TrackingIdentifierField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public TrackingIdentifierField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4147,12 +4139,7 @@ namespace SimpleConsole.dboDataService
         public partial class PaymentMethodTypeField : EnumFieldExpression<Purchase, SimpleConsole.Data.PaymentMethodType>
         {
             #region constructors
-            public PaymentMethodTypeField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PaymentMethodTypeField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PaymentMethodTypeField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4176,12 +4163,7 @@ namespace SimpleConsole.dboDataService
         public partial class PaymentSourceTypeField : NullableEnumFieldExpression<Purchase, SimpleConsole.Data.PaymentSourceType>
         {
             #region constructors
-            public PaymentSourceTypeField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PaymentSourceTypeField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PaymentSourceTypeField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4208,12 +4190,7 @@ namespace SimpleConsole.dboDataService
         public partial class DateCreatedField : DateTimeFieldExpression<Purchase>
         {
             #region constructors
-            public DateCreatedField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4235,12 +4212,7 @@ namespace SimpleConsole.dboDataService
         public partial class DateUpdatedField : DateTimeFieldExpression<Purchase>
         {
             #region constructors
-            public DateUpdatedField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateUpdatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateUpdatedField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4415,29 +4387,29 @@ namespace SimpleConsole.dboDataService
         #endregion
 
         #region constructors
-        private PurchaseLineEntity() : base(null, null, null)
+        private PurchaseLineEntity() : base(null, null, null, null)
         {
         }
 
-		public PurchaseLineEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public PurchaseLineEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private PurchaseLineEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private PurchaseLineEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.PurchaseId", PurchaseId = new PurchaseIdField($"{identifier}.PurchaseId", this));
-            Fields.Add($"{identifier}.ProductId", ProductId = new ProductIdField($"{identifier}.ProductId", this));
-            Fields.Add($"{identifier}.PurchasePrice", PurchasePrice = new PurchasePriceField($"{identifier}.PurchasePrice", this));
-            Fields.Add($"{identifier}.Quantity", Quantity = new QuantityField($"{identifier}.Quantity", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.PurchaseId", PurchaseId = new PurchaseIdField($"{identifier}.PurchaseId", "PurchaseId", this));
+            Fields.Add($"{identifier}.ProductId", ProductId = new ProductIdField($"{identifier}.ProductId", "ProductId", this));
+            Fields.Add($"{identifier}.PurchasePrice", PurchasePrice = new PurchasePriceField($"{identifier}.PurchasePrice", "PurchasePrice", this));
+            Fields.Add($"{identifier}.Quantity", Quantity = new QuantityField($"{identifier}.Quantity", "Quantity", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", "DateUpdated", this));
         }
         #endregion
 
         #region methods
         public PurchaseLineEntity As(string name)
-            => new PurchaseLineEntity(this.identifier, this.schema, name);
+            => new PurchaseLineEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -4450,6 +4422,38 @@ namespace SimpleConsole.dboDataService
                 ,new DateTimeSelectExpression(DateCreated)
                 ,new DateTimeSelectExpression(DateUpdated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(PurchaseId));
+            set &= aliased != nameof(PurchaseId) ? new Int32SelectExpression(PurchaseId).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(PurchaseId));
+
+            aliased = alias(nameof(ProductId));
+            set &= aliased != nameof(ProductId) ? new Int32SelectExpression(ProductId).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ProductId));
+
+            aliased = alias(nameof(PurchasePrice));
+            set &= aliased != nameof(PurchasePrice) ? new DecimalSelectExpression(PurchasePrice).As(aliased) as DecimalSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(PurchasePrice));
+
+            aliased = alias(nameof(Quantity));
+            set &= aliased != nameof(Quantity) ? new Int32SelectExpression(Quantity).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Quantity));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            aliased = alias(nameof(DateUpdated));
+            set &= aliased != nameof(DateUpdated) ? new DateTimeSelectExpression(DateUpdated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateUpdated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<PurchaseLine> GetInclusiveInsertExpression(PurchaseLine purchaseLine)
@@ -4473,7 +4477,7 @@ namespace SimpleConsole.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(PurchaseLine purchaseLine, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, PurchaseLine purchaseLine)
         {
 			purchaseLine.Id = reader.ReadField().GetValue<int>();
 			purchaseLine.PurchaseId = reader.ReadField().GetValue<int>();
@@ -4490,12 +4494,7 @@ namespace SimpleConsole.dboDataService
         public partial class IdField : Int32FieldExpression<PurchaseLine>
         {
             #region constructors
-            public IdField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4517,12 +4516,7 @@ namespace SimpleConsole.dboDataService
         public partial class PurchaseIdField : Int32FieldExpression<PurchaseLine>
         {
             #region constructors
-            public PurchaseIdField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PurchaseIdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PurchaseIdField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4546,12 +4540,7 @@ namespace SimpleConsole.dboDataService
         public partial class ProductIdField : Int32FieldExpression<PurchaseLine>
         {
             #region constructors
-            public ProductIdField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ProductIdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ProductIdField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4575,12 +4564,7 @@ namespace SimpleConsole.dboDataService
         public partial class PurchasePriceField : DecimalFieldExpression<PurchaseLine>
         {
             #region constructors
-            public PurchasePriceField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PurchasePriceField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PurchasePriceField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4604,12 +4588,7 @@ namespace SimpleConsole.dboDataService
         public partial class QuantityField : Int32FieldExpression<PurchaseLine>
         {
             #region constructors
-            public QuantityField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private QuantityField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public QuantityField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4633,12 +4612,7 @@ namespace SimpleConsole.dboDataService
         public partial class DateCreatedField : DateTimeFieldExpression<PurchaseLine>
         {
             #region constructors
-            public DateCreatedField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4660,12 +4634,7 @@ namespace SimpleConsole.dboDataService
         public partial class DateUpdatedField : DateTimeFieldExpression<PurchaseLine>
         {
             #region constructors
-            public DateUpdatedField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateUpdatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateUpdatedField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4755,25 +4724,25 @@ namespace SimpleConsole.dboDataService
         #endregion
 
         #region constructors
-        private PersonTotalPurchasesViewEntity() : base(null, null, null)
+        private PersonTotalPurchasesViewEntity() : base(null, null, null, null)
         {
         }
 
-		public PersonTotalPurchasesViewEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public PersonTotalPurchasesViewEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private PersonTotalPurchasesViewEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private PersonTotalPurchasesViewEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.TotalAmount", TotalAmount = new TotalAmountField($"{identifier}.TotalAmount", this));
-            Fields.Add($"{identifier}.TotalCount", TotalCount = new TotalCountField($"{identifier}.TotalCount", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.TotalAmount", TotalAmount = new TotalAmountField($"{identifier}.TotalAmount", "TotalAmount", this));
+            Fields.Add($"{identifier}.TotalCount", TotalCount = new TotalCountField($"{identifier}.TotalCount", "TotalCount", this));
         }
         #endregion
 
         #region methods
         public PersonTotalPurchasesViewEntity As(string name)
-            => new PersonTotalPurchasesViewEntity(this.identifier, this.schema, name);
+            => new PersonTotalPurchasesViewEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -4782,6 +4751,26 @@ namespace SimpleConsole.dboDataService
                 ,new NullableDoubleSelectExpression(TotalAmount)
                 ,new NullableInt32SelectExpression(TotalCount)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(TotalAmount));
+            set &= aliased != nameof(TotalAmount) ? new NullableDoubleSelectExpression(TotalAmount).As(aliased) as NullableDoubleSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(TotalAmount));
+
+            aliased = alias(nameof(TotalCount));
+            set &= aliased != nameof(TotalCount) ? new NullableInt32SelectExpression(TotalCount).As(aliased) as NullableInt32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(TotalCount));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<PersonTotalPurchasesView> GetInclusiveInsertExpression(PersonTotalPurchasesView personTotalPurchasesView)
@@ -4797,7 +4786,7 @@ namespace SimpleConsole.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(PersonTotalPurchasesView personTotalPurchasesView, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, PersonTotalPurchasesView personTotalPurchasesView)
         {
 			personTotalPurchasesView.Id = reader.ReadField().GetValue<int>();
 			personTotalPurchasesView.TotalAmount = reader.ReadField().GetValue<double?>();
@@ -4810,12 +4799,7 @@ namespace SimpleConsole.dboDataService
         public partial class IdField : Int32FieldExpression<PersonTotalPurchasesView>
         {
             #region constructors
-            public IdField(string identifier, PersonTotalPurchasesViewEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, PersonTotalPurchasesViewEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4837,12 +4821,7 @@ namespace SimpleConsole.dboDataService
         public partial class TotalAmountField : NullableDoubleFieldExpression<PersonTotalPurchasesView>
         {
             #region constructors
-            public TotalAmountField(string identifier, PersonTotalPurchasesViewEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private TotalAmountField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public TotalAmountField(string identifier, string name, PersonTotalPurchasesViewEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4864,12 +4843,7 @@ namespace SimpleConsole.dboDataService
         public partial class TotalCountField : NullableInt32FieldExpression<PersonTotalPurchasesView>
         {
             #region constructors
-            public TotalCountField(string identifier, PersonTotalPurchasesViewEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private TotalCountField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public TotalCountField(string identifier, string name, PersonTotalPurchasesViewEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -5088,7 +5062,7 @@ namespace SimpleConsole.secDataService
         #region constructors
         public secSchemaExpression(string identifier) : base(identifier, null)
         {
-            Entities.Add($"{identifier}.Person", Person = new PersonEntity($"{identifier}.Person", this));
+            Entities.Add($"{identifier}.Person", Person = new PersonEntity($"{identifier}.Person", "Person", this));
         }
         #endregion
     }
@@ -5187,26 +5161,26 @@ namespace SimpleConsole.secDataService
         #endregion
 
         #region constructors
-        private PersonEntity() : base(null, null, null)
+        private PersonEntity() : base(null, null, null, null)
         {
         }
 
-		public PersonEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public PersonEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private PersonEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private PersonEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.SSN", SSN = new SSNField($"{identifier}.SSN", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.SSN", SSN = new SSNField($"{identifier}.SSN", "SSN", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", "DateUpdated", this));
         }
         #endregion
 
         #region methods
         public PersonEntity As(string name)
-            => new PersonEntity(this.identifier, this.schema, name);
+            => new PersonEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -5216,6 +5190,29 @@ namespace SimpleConsole.secDataService
                 ,new DateTimeSelectExpression(DateCreated)
                 ,new DateTimeSelectExpression(DateUpdated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(SSN));
+            set &= aliased != nameof(SSN) ? new StringSelectExpression(SSN).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(SSN));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            aliased = alias(nameof(DateUpdated));
+            set &= aliased != nameof(DateUpdated) ? new DateTimeSelectExpression(DateUpdated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateUpdated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<Person> GetInclusiveInsertExpression(Person person)
@@ -5235,7 +5232,7 @@ namespace SimpleConsole.secDataService
             return expr;
         }
 
-        protected override void HydrateEntity(Person person, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, Person person)
         {
 			person.Id = reader.ReadField().GetValue<int>();
 			person.SSN = reader.ReadField().GetValue<string>();
@@ -5249,12 +5246,7 @@ namespace SimpleConsole.secDataService
         public partial class IdField : Int32FieldExpression<Person>
         {
             #region constructors
-            public IdField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -5278,12 +5270,7 @@ namespace SimpleConsole.secDataService
         public partial class SSNField : StringFieldExpression<Person>
         {
             #region constructors
-            public SSNField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private SSNField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public SSNField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -5307,12 +5294,7 @@ namespace SimpleConsole.secDataService
         public partial class DateCreatedField : DateTimeFieldExpression<Person>
         {
             #region constructors
-            public DateCreatedField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -5334,12 +5316,7 @@ namespace SimpleConsole.secDataService
         public partial class DateUpdatedField : DateTimeFieldExpression<Person>
         {
             #region constructors
-            public DateUpdatedField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateUpdatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateUpdatedField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }

--- a/samples/mssql/ServerSideBlazorApp/Data/_Generated/DbExDataService.generated.cs
+++ b/samples/mssql/ServerSideBlazorApp/Data/_Generated/DbExDataService.generated.cs
@@ -7,6 +7,7 @@ using HatTrick.DbEx.Sql.Expression;
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.Linq;
 
 #pragma warning disable IDE1006 // Naming Styles
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
@@ -466,7 +467,7 @@ namespace ServerSideBlazorApp.DataService
         /// <param name="element1">Any expression</param>
         /// <param name="element2">Any expression</param>
         /// <param name="elements">Any expression</param>
-        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{ExpandoObject}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<ExpandoObject> SelectOne(AnyElement element1, AnyElement element2, params AnyElement[] elements)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element1, element2, elements);
 
@@ -478,9 +479,21 @@ namespace ServerSideBlazorApp.DataService
         /// </summary>
         /// <param name="element1">Any expression</param>
         /// <param name="elements">A list of any expression</param>
-        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{ExpandoObject}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<ExpandoObject> SelectOne(IEnumerable<AnyElement> elements)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, elements);
+
+        /// <summary>
+        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="AnyElement" /> method parameters.
+        /// <para>
+        /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
+        /// </para>
+        /// </summary>
+        /// <param name="elements">A list of any expression that is valid for a SELECT query expression.</param>
+        /// <param name="additionalElements">Any additional fields to select as part of the SELECT query expression.</param>
+        /// <returns><see cref="SelectValues{ExpandoObject}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        public static SelectValue<ExpandoObject> SelectOne(IEnumerable<AnyElement> elements, params AnyElement[] additionalElements)
+            => expressionBuilderFactory.CreateSelectValueBuilder(config, (elements ?? throw new ArgumentNullException($"{nameof(elements)} is required.")).Concat(additionalElements));
         #endregion
 
         #region select many
@@ -899,7 +912,7 @@ namespace ServerSideBlazorApp.DataService
         /// <param name="element1">Any expression</param>
         /// <param name="element2">Any expression</param>
         /// <param name="elements">Any expression</param>
-        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{ExpandoObject}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<ExpandoObject> SelectMany(AnyElement element1, AnyElement element2, params AnyElement[] elements)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element1, element2, elements);
 
@@ -910,9 +923,21 @@ namespace ServerSideBlazorApp.DataService
         /// </para>
         /// </summary>
         /// <param name="elements">A list of any expression</param>
-        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{ExpandoObject}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<ExpandoObject> SelectMany(IEnumerable<AnyElement> elements)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, elements);
+
+            /// <summary>
+        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="AnyElement" /> method parameters.
+        /// <para>
+        /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
+        /// </para>
+        /// </summary>
+        /// <param name="elements">A list of any expression that is valid for a SELECT query expression.</param>
+        /// <param name="additionalElements">Any additional fields to select as part of the SELECT query expression.</param>
+        /// <returns><see cref="SelectValues{ExpandoObject}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        public static SelectValues<ExpandoObject> SelectMany(IEnumerable<AnyElement> elements, params AnyElement[] additionalElements)
+            => expressionBuilderFactory.CreateSelectValuesBuilder(config, (elements ?? throw new ArgumentNullException($"{nameof(elements)} is required.")).Concat(additionalElements));
         #endregion
 
         #region update
@@ -1060,13 +1085,13 @@ namespace ServerSideBlazorApp.dboDataService
         #region constructors
         public dboSchemaExpression(string identifier) : base(identifier, null)
         {
-            Entities.Add($"{identifier}.Address", Address = new AddressEntity($"{identifier}.Address", this));
-            Entities.Add($"{identifier}.Person", Customer = new CustomerEntity($"{identifier}.Person", this));
-            Entities.Add($"{identifier}.Person_Address", CustomerAddress = new CustomerAddressEntity($"{identifier}.Person_Address", this));
-            Entities.Add($"{identifier}.Product", Product = new ProductEntity($"{identifier}.Product", this));
-            Entities.Add($"{identifier}.Purchase", Purchase = new PurchaseEntity($"{identifier}.Purchase", this));
-            Entities.Add($"{identifier}.PurchaseLine", PurchaseLine = new PurchaseLineEntity($"{identifier}.PurchaseLine", this));
-            Entities.Add($"{identifier}.PersonTotalPurchasesView", PersonTotalPurchasesView = new PersonTotalPurchasesViewEntity($"{identifier}.PersonTotalPurchasesView", this));
+            Entities.Add($"{identifier}.Address", Address = new AddressEntity($"{identifier}.Address", "Address", this));
+            Entities.Add($"{identifier}.Person", Customer = new CustomerEntity($"{identifier}.Person", "Person", this));
+            Entities.Add($"{identifier}.Person_Address", CustomerAddress = new CustomerAddressEntity($"{identifier}.Person_Address", "Person_Address", this));
+            Entities.Add($"{identifier}.Product", Product = new ProductEntity($"{identifier}.Product", "Product", this));
+            Entities.Add($"{identifier}.Purchase", Purchase = new PurchaseEntity($"{identifier}.Purchase", "Purchase", this));
+            Entities.Add($"{identifier}.PurchaseLine", PurchaseLine = new PurchaseLineEntity($"{identifier}.PurchaseLine", "PurchaseLine", this));
+            Entities.Add($"{identifier}.PersonTotalPurchasesView", PersonTotalPurchasesView = new PersonTotalPurchasesViewEntity($"{identifier}.PersonTotalPurchasesView", "PersonTotalPurchasesView", this));
         }
         #endregion
     }
@@ -1263,31 +1288,31 @@ namespace ServerSideBlazorApp.dboDataService
         #endregion
 
         #region constructors
-        private AddressEntity() : base(null, null, null)
+        private AddressEntity() : base(null, null, null, null)
         {
         }
 
-		public AddressEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public AddressEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private AddressEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private AddressEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.AddressType", AddressType = new AddressTypeField($"{identifier}.AddressType", this));
-            Fields.Add($"{identifier}.Line1", Line1 = new Line1Field($"{identifier}.Line1", this));
-            Fields.Add($"{identifier}.Line2", Line2 = new Line2Field($"{identifier}.Line2", this));
-            Fields.Add($"{identifier}.City", City = new CityField($"{identifier}.City", this));
-            Fields.Add($"{identifier}.State", State = new StateField($"{identifier}.State", this));
-            Fields.Add($"{identifier}.Zip", Zip = new ZipField($"{identifier}.Zip", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.AddressType", AddressType = new AddressTypeField($"{identifier}.AddressType", "AddressType", this));
+            Fields.Add($"{identifier}.Line1", Line1 = new Line1Field($"{identifier}.Line1", "Line1", this));
+            Fields.Add($"{identifier}.Line2", Line2 = new Line2Field($"{identifier}.Line2", "Line2", this));
+            Fields.Add($"{identifier}.City", City = new CityField($"{identifier}.City", "City", this));
+            Fields.Add($"{identifier}.State", State = new StateField($"{identifier}.State", "State", this));
+            Fields.Add($"{identifier}.Zip", Zip = new ZipField($"{identifier}.Zip", "Zip", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", "DateUpdated", this));
         }
         #endregion
 
         #region methods
         public AddressEntity As(string name)
-            => new AddressEntity(this.identifier, this.schema, name);
+            => new AddressEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -1302,6 +1327,44 @@ namespace ServerSideBlazorApp.dboDataService
                 ,new DateTimeSelectExpression(DateCreated)
                 ,new DateTimeSelectExpression(DateUpdated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(AddressType));
+            set &= aliased != nameof(AddressType) ? new NullableEnumSelectExpression<ServerSideBlazorApp.Data.AddressType>(AddressType).As(aliased) as NullableEnumSelectExpression<ServerSideBlazorApp.Data.AddressType> : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(AddressType));
+
+            aliased = alias(nameof(Line1));
+            set &= aliased != nameof(Line1) ? new StringSelectExpression(Line1).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Line1));
+
+            aliased = alias(nameof(Line2));
+            set &= aliased != nameof(Line2) ? new NullableStringSelectExpression(Line2).As(aliased) as NullableStringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Line2));
+
+            aliased = alias(nameof(City));
+            set &= aliased != nameof(City) ? new StringSelectExpression(City).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(City));
+
+            aliased = alias(nameof(State));
+            set &= aliased != nameof(State) ? new StringSelectExpression(State).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(State));
+
+            aliased = alias(nameof(Zip));
+            set &= aliased != nameof(Zip) ? new StringSelectExpression(Zip).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Zip));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            aliased = alias(nameof(DateUpdated));
+            set &= aliased != nameof(DateUpdated) ? new DateTimeSelectExpression(DateUpdated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateUpdated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<Address> GetInclusiveInsertExpression(Address address)
@@ -1329,7 +1392,7 @@ namespace ServerSideBlazorApp.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(Address address, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, Address address)
         {
 			address.Id = reader.ReadField().GetValue<int>();
 			address.AddressType = reader.ReadField().GetValue<ServerSideBlazorApp.Data.AddressType?>();
@@ -1348,12 +1411,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class IdField : Int32FieldExpression<Address>
         {
             #region constructors
-            public IdField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1375,12 +1433,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class AddressTypeField : NullableEnumFieldExpression<Address, ServerSideBlazorApp.Data.AddressType>
         {
             #region constructors
-            public AddressTypeField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private AddressTypeField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public AddressTypeField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1407,12 +1460,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class Line1Field : StringFieldExpression<Address>
         {
             #region constructors
-            public Line1Field(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private Line1Field(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public Line1Field(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1436,12 +1484,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class Line2Field : NullableStringFieldExpression<Address>
         {
             #region constructors
-            public Line2Field(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private Line2Field(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public Line2Field(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1467,12 +1510,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class CityField : StringFieldExpression<Address>
         {
             #region constructors
-            public CityField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private CityField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public CityField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1496,12 +1534,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class StateField : StringFieldExpression<Address>
         {
             #region constructors
-            public StateField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private StateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public StateField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1525,12 +1558,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class ZipField : StringFieldExpression<Address>
         {
             #region constructors
-            public ZipField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ZipField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ZipField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1554,12 +1582,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class DateCreatedField : DateTimeFieldExpression<Address>
         {
             #region constructors
-            public DateCreatedField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1581,12 +1604,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class DateUpdatedField : DateTimeFieldExpression<Address>
         {
             #region constructors
-            public DateUpdatedField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateUpdatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateUpdatedField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1840,33 +1858,33 @@ namespace ServerSideBlazorApp.dboDataService
         #endregion
 
         #region constructors
-        private CustomerEntity() : base(null, null, null)
+        private CustomerEntity() : base(null, null, null, null)
         {
         }
 
-		public CustomerEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public CustomerEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private CustomerEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private CustomerEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.FirstName", FirstName = new FirstNameField($"{identifier}.FirstName", this));
-            Fields.Add($"{identifier}.LastName", LastName = new LastNameField($"{identifier}.LastName", this));
-            Fields.Add($"{identifier}.BirthDate", BirthDate = new BirthDateField($"{identifier}.BirthDate", this));
-            Fields.Add($"{identifier}.GenderType", GenderType = new GenderTypeField($"{identifier}.GenderType", this));
-            Fields.Add($"{identifier}.CreditLimit", CreditLimit = new CreditLimitField($"{identifier}.CreditLimit", this));
-            Fields.Add($"{identifier}.YearOfLastCreditLimitReview", YearOfLastCreditLimitReview = new YearOfLastCreditLimitReviewField($"{identifier}.YearOfLastCreditLimitReview", this));
-            Fields.Add($"{identifier}.RegistrationDate", RegistrationDate = new RegistrationDateField($"{identifier}.RegistrationDate", this));
-            Fields.Add($"{identifier}.LastLoginDate", LastLoginDate = new LastLoginDateField($"{identifier}.LastLoginDate", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.FirstName", FirstName = new FirstNameField($"{identifier}.FirstName", "FirstName", this));
+            Fields.Add($"{identifier}.LastName", LastName = new LastNameField($"{identifier}.LastName", "LastName", this));
+            Fields.Add($"{identifier}.BirthDate", BirthDate = new BirthDateField($"{identifier}.BirthDate", "BirthDate", this));
+            Fields.Add($"{identifier}.GenderType", GenderType = new GenderTypeField($"{identifier}.GenderType", "GenderType", this));
+            Fields.Add($"{identifier}.CreditLimit", CreditLimit = new CreditLimitField($"{identifier}.CreditLimit", "CreditLimit", this));
+            Fields.Add($"{identifier}.YearOfLastCreditLimitReview", YearOfLastCreditLimitReview = new YearOfLastCreditLimitReviewField($"{identifier}.YearOfLastCreditLimitReview", "YearOfLastCreditLimitReview", this));
+            Fields.Add($"{identifier}.RegistrationDate", RegistrationDate = new RegistrationDateField($"{identifier}.RegistrationDate", "RegistrationDate", this));
+            Fields.Add($"{identifier}.LastLoginDate", LastLoginDate = new LastLoginDateField($"{identifier}.LastLoginDate", "LastLoginDate", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", "DateUpdated", this));
         }
         #endregion
 
         #region methods
         public CustomerEntity As(string name)
-            => new CustomerEntity(this.identifier, this.schema, name);
+            => new CustomerEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -1883,6 +1901,50 @@ namespace ServerSideBlazorApp.dboDataService
                 ,new DateTimeSelectExpression(DateCreated)
                 ,new DateTimeSelectExpression(DateUpdated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(FirstName));
+            set &= aliased != nameof(FirstName) ? new StringSelectExpression(FirstName).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(FirstName));
+
+            aliased = alias(nameof(LastName));
+            set &= aliased != nameof(LastName) ? new StringSelectExpression(LastName).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(LastName));
+
+            aliased = alias(nameof(BirthDate));
+            set &= aliased != nameof(BirthDate) ? new NullableDateTimeSelectExpression(BirthDate).As(aliased) as NullableDateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(BirthDate));
+
+            aliased = alias(nameof(GenderType));
+            set &= aliased != nameof(GenderType) ? new EnumSelectExpression<ServerSideBlazorApp.Data.GenderType>(GenderType).As(aliased) as EnumSelectExpression<ServerSideBlazorApp.Data.GenderType> : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(GenderType));
+
+            aliased = alias(nameof(CreditLimit));
+            set &= aliased != nameof(CreditLimit) ? new NullableInt32SelectExpression(CreditLimit).As(aliased) as NullableInt32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(CreditLimit));
+
+            aliased = alias(nameof(YearOfLastCreditLimitReview));
+            set &= aliased != nameof(YearOfLastCreditLimitReview) ? new NullableInt32SelectExpression(YearOfLastCreditLimitReview).As(aliased) as NullableInt32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(YearOfLastCreditLimitReview));
+
+            aliased = alias(nameof(RegistrationDate));
+            set &= aliased != nameof(RegistrationDate) ? new DateTimeOffsetSelectExpression(RegistrationDate).As(aliased) as DateTimeOffsetSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(RegistrationDate));
+
+            aliased = alias(nameof(LastLoginDate));
+            set &= aliased != nameof(LastLoginDate) ? new NullableDateTimeOffsetSelectExpression(LastLoginDate).As(aliased) as NullableDateTimeOffsetSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(LastLoginDate));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            aliased = alias(nameof(DateUpdated));
+            set &= aliased != nameof(DateUpdated) ? new DateTimeSelectExpression(DateUpdated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateUpdated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<Customer> GetInclusiveInsertExpression(Customer customer)
@@ -1914,7 +1976,7 @@ namespace ServerSideBlazorApp.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(Customer customer, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, Customer customer)
         {
 			customer.Id = reader.ReadField().GetValue<int>();
 			customer.FirstName = reader.ReadField().GetValue<string>();
@@ -1935,12 +1997,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class IdField : Int32FieldExpression<Customer>
         {
             #region constructors
-            public IdField(string identifier, CustomerEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, CustomerEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1962,12 +2019,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class FirstNameField : StringFieldExpression<Customer>
         {
             #region constructors
-            public FirstNameField(string identifier, CustomerEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private FirstNameField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public FirstNameField(string identifier, string name, CustomerEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1991,12 +2043,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class LastNameField : StringFieldExpression<Customer>
         {
             #region constructors
-            public LastNameField(string identifier, CustomerEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private LastNameField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public LastNameField(string identifier, string name, CustomerEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2020,12 +2067,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class BirthDateField : NullableDateTimeFieldExpression<Customer>
         {
             #region constructors
-            public BirthDateField(string identifier, CustomerEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private BirthDateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public BirthDateField(string identifier, string name, CustomerEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2052,12 +2094,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class GenderTypeField : EnumFieldExpression<Customer, ServerSideBlazorApp.Data.GenderType>
         {
             #region constructors
-            public GenderTypeField(string identifier, CustomerEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private GenderTypeField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public GenderTypeField(string identifier, string name, CustomerEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2081,12 +2118,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class CreditLimitField : NullableInt32FieldExpression<Customer>
         {
             #region constructors
-            public CreditLimitField(string identifier, CustomerEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private CreditLimitField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public CreditLimitField(string identifier, string name, CustomerEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2113,12 +2145,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class YearOfLastCreditLimitReviewField : NullableInt32FieldExpression<Customer>
         {
             #region constructors
-            public YearOfLastCreditLimitReviewField(string identifier, CustomerEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private YearOfLastCreditLimitReviewField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public YearOfLastCreditLimitReviewField(string identifier, string name, CustomerEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2145,12 +2172,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class RegistrationDateField : DateTimeOffsetFieldExpression<Customer>
         {
             #region constructors
-            public RegistrationDateField(string identifier, CustomerEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private RegistrationDateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public RegistrationDateField(string identifier, string name, CustomerEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2174,12 +2196,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class LastLoginDateField : NullableDateTimeOffsetFieldExpression<Customer>
         {
             #region constructors
-            public LastLoginDateField(string identifier, CustomerEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private LastLoginDateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public LastLoginDateField(string identifier, string name, CustomerEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2206,12 +2223,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class DateCreatedField : DateTimeFieldExpression<Customer>
         {
             #region constructors
-            public DateCreatedField(string identifier, CustomerEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, CustomerEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2233,12 +2245,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class DateUpdatedField : DateTimeFieldExpression<Customer>
         {
             #region constructors
-            public DateUpdatedField(string identifier, CustomerEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateUpdatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateUpdatedField(string identifier, string name, CustomerEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2353,26 +2360,26 @@ namespace ServerSideBlazorApp.dboDataService
         #endregion
 
         #region constructors
-        private CustomerAddressEntity() : base(null, null, null)
+        private CustomerAddressEntity() : base(null, null, null, null)
         {
         }
 
-		public CustomerAddressEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public CustomerAddressEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private CustomerAddressEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private CustomerAddressEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.PersonId", CustomerId = new CustomerIdField($"{identifier}.PersonId", this));
-            Fields.Add($"{identifier}.AddressId", AddressId = new AddressIdField($"{identifier}.AddressId", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.PersonId", CustomerId = new CustomerIdField($"{identifier}.PersonId", "CustomerId", this));
+            Fields.Add($"{identifier}.AddressId", AddressId = new AddressIdField($"{identifier}.AddressId", "AddressId", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
         }
         #endregion
 
         #region methods
         public CustomerAddressEntity As(string name)
-            => new CustomerAddressEntity(this.identifier, this.schema, name);
+            => new CustomerAddressEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -2382,6 +2389,29 @@ namespace ServerSideBlazorApp.dboDataService
                 ,new Int32SelectExpression(AddressId)
                 ,new DateTimeSelectExpression(DateCreated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(CustomerId));
+            set &= aliased != nameof(CustomerId) ? new Int32SelectExpression(CustomerId).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(CustomerId));
+
+            aliased = alias(nameof(AddressId));
+            set &= aliased != nameof(AddressId) ? new Int32SelectExpression(AddressId).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(AddressId));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<CustomerAddress> GetInclusiveInsertExpression(CustomerAddress customerAddress)
@@ -2401,7 +2431,7 @@ namespace ServerSideBlazorApp.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(CustomerAddress customerAddress, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, CustomerAddress customerAddress)
         {
 			customerAddress.Id = reader.ReadField().GetValue<int>();
 			customerAddress.CustomerId = reader.ReadField().GetValue<int>();
@@ -2415,12 +2445,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class IdField : Int32FieldExpression<CustomerAddress>
         {
             #region constructors
-            public IdField(string identifier, CustomerAddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, CustomerAddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2442,12 +2467,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class CustomerIdField : Int32FieldExpression<CustomerAddress>
         {
             #region constructors
-            public CustomerIdField(string identifier, CustomerAddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private CustomerIdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public CustomerIdField(string identifier, string name, CustomerAddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2471,12 +2491,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class AddressIdField : Int32FieldExpression<CustomerAddress>
         {
             #region constructors
-            public AddressIdField(string identifier, CustomerAddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private AddressIdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public AddressIdField(string identifier, string name, CustomerAddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2500,12 +2515,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class DateCreatedField : DateTimeFieldExpression<CustomerAddress>
         {
             #region constructors
-            public DateCreatedField(string identifier, CustomerAddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, CustomerAddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2870,39 +2880,39 @@ namespace ServerSideBlazorApp.dboDataService
         #endregion
 
         #region constructors
-        private ProductEntity() : base(null, null, null)
+        private ProductEntity() : base(null, null, null, null)
         {
         }
 
-		public ProductEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public ProductEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private ProductEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private ProductEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.ProductCategoryType", ProductCategoryType = new ProductCategoryTypeField($"{identifier}.ProductCategoryType", this));
-            Fields.Add($"{identifier}.Name", Name = new NameField($"{identifier}.Name", this));
-            Fields.Add($"{identifier}.Description", Description = new DescriptionField($"{identifier}.Description", this));
-            Fields.Add($"{identifier}.ListPrice", ListPrice = new ListPriceField($"{identifier}.ListPrice", this));
-            Fields.Add($"{identifier}.Price", Price = new PriceField($"{identifier}.Price", this));
-            Fields.Add($"{identifier}.Quantity", Quantity = new QuantityField($"{identifier}.Quantity", this));
-            Fields.Add($"{identifier}.Image", Image = new ImageField($"{identifier}.Image", this));
-            Fields.Add($"{identifier}.Height", Height = new HeightField($"{identifier}.Height", this));
-            Fields.Add($"{identifier}.Width", Width = new WidthField($"{identifier}.Width", this));
-            Fields.Add($"{identifier}.Depth", Depth = new DepthField($"{identifier}.Depth", this));
-            Fields.Add($"{identifier}.Weight", Weight = new WeightField($"{identifier}.Weight", this));
-            Fields.Add($"{identifier}.ShippingWeight", ShippingWeight = new ShippingWeightField($"{identifier}.ShippingWeight", this));
-            Fields.Add($"{identifier}.ValidStartTimeOfDayForPurchase", ValidStartTimeOfDayForPurchase = new ValidStartTimeOfDayForPurchaseField($"{identifier}.ValidStartTimeOfDayForPurchase", this));
-            Fields.Add($"{identifier}.ValidEndTimeOfDayForPurchase", ValidEndTimeOfDayForPurchase = new ValidEndTimeOfDayForPurchaseField($"{identifier}.ValidEndTimeOfDayForPurchase", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.ProductCategoryType", ProductCategoryType = new ProductCategoryTypeField($"{identifier}.ProductCategoryType", "ProductCategoryType", this));
+            Fields.Add($"{identifier}.Name", Name = new NameField($"{identifier}.Name", "Name", this));
+            Fields.Add($"{identifier}.Description", Description = new DescriptionField($"{identifier}.Description", "Description", this));
+            Fields.Add($"{identifier}.ListPrice", ListPrice = new ListPriceField($"{identifier}.ListPrice", "ListPrice", this));
+            Fields.Add($"{identifier}.Price", Price = new PriceField($"{identifier}.Price", "Price", this));
+            Fields.Add($"{identifier}.Quantity", Quantity = new QuantityField($"{identifier}.Quantity", "Quantity", this));
+            Fields.Add($"{identifier}.Image", Image = new ImageField($"{identifier}.Image", "Image", this));
+            Fields.Add($"{identifier}.Height", Height = new HeightField($"{identifier}.Height", "Height", this));
+            Fields.Add($"{identifier}.Width", Width = new WidthField($"{identifier}.Width", "Width", this));
+            Fields.Add($"{identifier}.Depth", Depth = new DepthField($"{identifier}.Depth", "Depth", this));
+            Fields.Add($"{identifier}.Weight", Weight = new WeightField($"{identifier}.Weight", "Weight", this));
+            Fields.Add($"{identifier}.ShippingWeight", ShippingWeight = new ShippingWeightField($"{identifier}.ShippingWeight", "ShippingWeight", this));
+            Fields.Add($"{identifier}.ValidStartTimeOfDayForPurchase", ValidStartTimeOfDayForPurchase = new ValidStartTimeOfDayForPurchaseField($"{identifier}.ValidStartTimeOfDayForPurchase", "ValidStartTimeOfDayForPurchase", this));
+            Fields.Add($"{identifier}.ValidEndTimeOfDayForPurchase", ValidEndTimeOfDayForPurchase = new ValidEndTimeOfDayForPurchaseField($"{identifier}.ValidEndTimeOfDayForPurchase", "ValidEndTimeOfDayForPurchase", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", "DateUpdated", this));
         }
         #endregion
 
         #region methods
         public ProductEntity As(string name)
-            => new ProductEntity(this.identifier, this.schema, name);
+            => new ProductEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -2925,6 +2935,68 @@ namespace ServerSideBlazorApp.dboDataService
                 ,new DateTimeSelectExpression(DateCreated)
                 ,new DateTimeSelectExpression(DateUpdated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(ProductCategoryType));
+            set &= aliased != nameof(ProductCategoryType) ? new NullableEnumSelectExpression<ServerSideBlazorApp.Data.ProductCategoryType>(ProductCategoryType).As(aliased) as NullableEnumSelectExpression<ServerSideBlazorApp.Data.ProductCategoryType> : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ProductCategoryType));
+
+            aliased = alias(nameof(Name));
+            set &= aliased != nameof(Name) ? new StringSelectExpression(Name).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Name));
+
+            aliased = alias(nameof(Description));
+            set &= aliased != nameof(Description) ? new NullableStringSelectExpression(Description).As(aliased) as NullableStringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Description));
+
+            aliased = alias(nameof(ListPrice));
+            set &= aliased != nameof(ListPrice) ? new DoubleSelectExpression(ListPrice).As(aliased) as DoubleSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ListPrice));
+
+            aliased = alias(nameof(Price));
+            set &= aliased != nameof(Price) ? new DoubleSelectExpression(Price).As(aliased) as DoubleSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Price));
+
+            aliased = alias(nameof(Quantity));
+            set &= aliased != nameof(Quantity) ? new Int32SelectExpression(Quantity).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Quantity));
+
+            aliased = alias(nameof(Image));
+            set &= aliased != nameof(Image) ? new NullableByteArraySelectExpression(Image).As(aliased) as NullableByteArraySelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Image));
+
+            aliased = alias(nameof(Height));
+            set &= aliased != nameof(Height) ? new NullableDecimalSelectExpression(Height).As(aliased) as NullableDecimalSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Height));
+
+            aliased = alias(nameof(Width));
+            set &= aliased != nameof(Width) ? new NullableDecimalSelectExpression(Width).As(aliased) as NullableDecimalSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Width));
+
+            aliased = alias(nameof(Depth));
+            set &= aliased != nameof(Depth) ? new NullableDecimalSelectExpression(Depth).As(aliased) as NullableDecimalSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Depth));
+
+            aliased = alias(nameof(Weight));
+            set &= aliased != nameof(Weight) ? new NullableDecimalSelectExpression(Weight).As(aliased) as NullableDecimalSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Weight));
+
+            aliased = alias(nameof(ShippingWeight));
+            set &= aliased != nameof(ShippingWeight) ? new DecimalSelectExpression(ShippingWeight).As(aliased) as DecimalSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ShippingWeight));
+
+            aliased = alias(nameof(ValidStartTimeOfDayForPurchase));
+            set &= aliased != nameof(ValidStartTimeOfDayForPurchase) ? new NullableTimeSpanSelectExpression(ValidStartTimeOfDayForPurchase).As(aliased) as NullableTimeSpanSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ValidStartTimeOfDayForPurchase));
+
+            aliased = alias(nameof(ValidEndTimeOfDayForPurchase));
+            set &= aliased != nameof(ValidEndTimeOfDayForPurchase) ? new NullableTimeSpanSelectExpression(ValidEndTimeOfDayForPurchase).As(aliased) as NullableTimeSpanSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ValidEndTimeOfDayForPurchase));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            aliased = alias(nameof(DateUpdated));
+            set &= aliased != nameof(DateUpdated) ? new DateTimeSelectExpression(DateUpdated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateUpdated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<Product> GetInclusiveInsertExpression(Product product)
@@ -2968,7 +3040,7 @@ namespace ServerSideBlazorApp.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(Product product, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, Product product)
         {
 			product.Id = reader.ReadField().GetValue<int>();
 			product.ProductCategoryType = reader.ReadField().GetValue<ServerSideBlazorApp.Data.ProductCategoryType?>();
@@ -2995,12 +3067,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class IdField : Int32FieldExpression<Product>
         {
             #region constructors
-            public IdField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3022,12 +3089,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class ProductCategoryTypeField : NullableEnumFieldExpression<Product, ServerSideBlazorApp.Data.ProductCategoryType>
         {
             #region constructors
-            public ProductCategoryTypeField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ProductCategoryTypeField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ProductCategoryTypeField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3054,12 +3116,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class NameField : StringFieldExpression<Product>
         {
             #region constructors
-            public NameField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private NameField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public NameField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3083,12 +3140,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class DescriptionField : NullableStringFieldExpression<Product>
         {
             #region constructors
-            public DescriptionField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DescriptionField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DescriptionField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3114,12 +3166,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class ListPriceField : DoubleFieldExpression<Product>
         {
             #region constructors
-            public ListPriceField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ListPriceField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ListPriceField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3143,12 +3190,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class PriceField : DoubleFieldExpression<Product>
         {
             #region constructors
-            public PriceField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PriceField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PriceField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3172,12 +3214,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class QuantityField : Int32FieldExpression<Product>
         {
             #region constructors
-            public QuantityField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private QuantityField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public QuantityField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3201,12 +3238,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class ImageField : NullableByteArrayFieldExpression<Product>
         {
             #region constructors
-            public ImageField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ImageField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ImageField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3232,12 +3264,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class HeightField : NullableDecimalFieldExpression<Product>
         {
             #region constructors
-            public HeightField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private HeightField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public HeightField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3264,12 +3291,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class WidthField : NullableDecimalFieldExpression<Product>
         {
             #region constructors
-            public WidthField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private WidthField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public WidthField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3296,12 +3318,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class DepthField : NullableDecimalFieldExpression<Product>
         {
             #region constructors
-            public DepthField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DepthField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DepthField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3328,12 +3345,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class WeightField : NullableDecimalFieldExpression<Product>
         {
             #region constructors
-            public WeightField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private WeightField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public WeightField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3360,12 +3372,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class ShippingWeightField : DecimalFieldExpression<Product>
         {
             #region constructors
-            public ShippingWeightField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ShippingWeightField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ShippingWeightField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3389,12 +3396,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class ValidStartTimeOfDayForPurchaseField : NullableTimeSpanFieldExpression<Product>
         {
             #region constructors
-            public ValidStartTimeOfDayForPurchaseField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ValidStartTimeOfDayForPurchaseField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ValidStartTimeOfDayForPurchaseField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3421,12 +3423,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class ValidEndTimeOfDayForPurchaseField : NullableTimeSpanFieldExpression<Product>
         {
             #region constructors
-            public ValidEndTimeOfDayForPurchaseField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ValidEndTimeOfDayForPurchaseField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ValidEndTimeOfDayForPurchaseField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3453,12 +3450,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class DateCreatedField : DateTimeFieldExpression<Product>
         {
             #region constructors
-            public DateCreatedField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3480,12 +3472,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class DateUpdatedField : DateTimeFieldExpression<Product>
         {
             #region constructors
-            public DateUpdatedField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateUpdatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateUpdatedField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3774,35 +3761,35 @@ namespace ServerSideBlazorApp.dboDataService
         #endregion
 
         #region constructors
-        private PurchaseEntity() : base(null, null, null)
+        private PurchaseEntity() : base(null, null, null, null)
         {
         }
 
-		public PurchaseEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public PurchaseEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private PurchaseEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private PurchaseEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.PersonId", CustomerId = new CustomerIdField($"{identifier}.PersonId", this));
-            Fields.Add($"{identifier}.OrderNumber", OrderNumber = new OrderNumberField($"{identifier}.OrderNumber", this));
-            Fields.Add($"{identifier}.TotalPurchaseQuantity", TotalPurchaseQuantity = new TotalPurchaseQuantityField($"{identifier}.TotalPurchaseQuantity", this));
-            Fields.Add($"{identifier}.TotalPurchaseAmount", TotalPurchaseAmount = new TotalPurchaseAmountField($"{identifier}.TotalPurchaseAmount", this));
-            Fields.Add($"{identifier}.PurchaseDate", PurchaseDate = new PurchaseDateField($"{identifier}.PurchaseDate", this));
-            Fields.Add($"{identifier}.ShipDate", ShipDate = new ShipDateField($"{identifier}.ShipDate", this));
-            Fields.Add($"{identifier}.ExpectedDeliveryDate", ExpectedDeliveryDate = new ExpectedDeliveryDateField($"{identifier}.ExpectedDeliveryDate", this));
-            Fields.Add($"{identifier}.TrackingIdentifier", TrackingIdentifier = new TrackingIdentifierField($"{identifier}.TrackingIdentifier", this));
-            Fields.Add($"{identifier}.PaymentMethodType", PaymentMethodType = new PaymentMethodTypeField($"{identifier}.PaymentMethodType", this));
-            Fields.Add($"{identifier}.PaymentSourceType", PaymentSourceType = new PaymentSourceTypeField($"{identifier}.PaymentSourceType", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.PersonId", CustomerId = new CustomerIdField($"{identifier}.PersonId", "CustomerId", this));
+            Fields.Add($"{identifier}.OrderNumber", OrderNumber = new OrderNumberField($"{identifier}.OrderNumber", "OrderNumber", this));
+            Fields.Add($"{identifier}.TotalPurchaseQuantity", TotalPurchaseQuantity = new TotalPurchaseQuantityField($"{identifier}.TotalPurchaseQuantity", "TotalPurchaseQuantity", this));
+            Fields.Add($"{identifier}.TotalPurchaseAmount", TotalPurchaseAmount = new TotalPurchaseAmountField($"{identifier}.TotalPurchaseAmount", "TotalPurchaseAmount", this));
+            Fields.Add($"{identifier}.PurchaseDate", PurchaseDate = new PurchaseDateField($"{identifier}.PurchaseDate", "PurchaseDate", this));
+            Fields.Add($"{identifier}.ShipDate", ShipDate = new ShipDateField($"{identifier}.ShipDate", "ShipDate", this));
+            Fields.Add($"{identifier}.ExpectedDeliveryDate", ExpectedDeliveryDate = new ExpectedDeliveryDateField($"{identifier}.ExpectedDeliveryDate", "ExpectedDeliveryDate", this));
+            Fields.Add($"{identifier}.TrackingIdentifier", TrackingIdentifier = new TrackingIdentifierField($"{identifier}.TrackingIdentifier", "TrackingIdentifier", this));
+            Fields.Add($"{identifier}.PaymentMethodType", PaymentMethodType = new PaymentMethodTypeField($"{identifier}.PaymentMethodType", "PaymentMethodType", this));
+            Fields.Add($"{identifier}.PaymentSourceType", PaymentSourceType = new PaymentSourceTypeField($"{identifier}.PaymentSourceType", "PaymentSourceType", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", "DateUpdated", this));
         }
         #endregion
 
         #region methods
         public PurchaseEntity As(string name)
-            => new PurchaseEntity(this.identifier, this.schema, name);
+            => new PurchaseEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -3821,6 +3808,56 @@ namespace ServerSideBlazorApp.dboDataService
                 ,new DateTimeSelectExpression(DateCreated)
                 ,new DateTimeSelectExpression(DateUpdated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(CustomerId));
+            set &= aliased != nameof(CustomerId) ? new Int32SelectExpression(CustomerId).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(CustomerId));
+
+            aliased = alias(nameof(OrderNumber));
+            set &= aliased != nameof(OrderNumber) ? new StringSelectExpression(OrderNumber).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(OrderNumber));
+
+            aliased = alias(nameof(TotalPurchaseQuantity));
+            set &= aliased != nameof(TotalPurchaseQuantity) ? new Int32SelectExpression(TotalPurchaseQuantity).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(TotalPurchaseQuantity));
+
+            aliased = alias(nameof(TotalPurchaseAmount));
+            set &= aliased != nameof(TotalPurchaseAmount) ? new DoubleSelectExpression(TotalPurchaseAmount).As(aliased) as DoubleSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(TotalPurchaseAmount));
+
+            aliased = alias(nameof(PurchaseDate));
+            set &= aliased != nameof(PurchaseDate) ? new DateTimeSelectExpression(PurchaseDate).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(PurchaseDate));
+
+            aliased = alias(nameof(ShipDate));
+            set &= aliased != nameof(ShipDate) ? new NullableDateTimeSelectExpression(ShipDate).As(aliased) as NullableDateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ShipDate));
+
+            aliased = alias(nameof(ExpectedDeliveryDate));
+            set &= aliased != nameof(ExpectedDeliveryDate) ? new NullableDateTimeSelectExpression(ExpectedDeliveryDate).As(aliased) as NullableDateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ExpectedDeliveryDate));
+
+            aliased = alias(nameof(TrackingIdentifier));
+            set &= aliased != nameof(TrackingIdentifier) ? new NullableGuidSelectExpression(TrackingIdentifier).As(aliased) as NullableGuidSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(TrackingIdentifier));
+
+            aliased = alias(nameof(PaymentMethodType));
+            set &= aliased != nameof(PaymentMethodType) ? new EnumSelectExpression<ServerSideBlazorApp.Data.PaymentMethodType>(PaymentMethodType).As(aliased) as EnumSelectExpression<ServerSideBlazorApp.Data.PaymentMethodType> : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(PaymentMethodType));
+
+            aliased = alias(nameof(PaymentSourceType));
+            set &= aliased != nameof(PaymentSourceType) ? new NullableEnumSelectExpression<ServerSideBlazorApp.Data.PaymentSourceType>(PaymentSourceType).As(aliased) as NullableEnumSelectExpression<ServerSideBlazorApp.Data.PaymentSourceType> : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(PaymentSourceType));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            aliased = alias(nameof(DateUpdated));
+            set &= aliased != nameof(DateUpdated) ? new DateTimeSelectExpression(DateUpdated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateUpdated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<Purchase> GetInclusiveInsertExpression(Purchase purchase)
@@ -3856,7 +3893,7 @@ namespace ServerSideBlazorApp.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(Purchase purchase, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, Purchase purchase)
         {
 			purchase.Id = reader.ReadField().GetValue<int>();
 			purchase.CustomerId = reader.ReadField().GetValue<int>();
@@ -3879,12 +3916,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class IdField : Int32FieldExpression<Purchase>
         {
             #region constructors
-            public IdField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3906,12 +3938,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class CustomerIdField : Int32FieldExpression<Purchase>
         {
             #region constructors
-            public CustomerIdField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private CustomerIdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public CustomerIdField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3935,12 +3962,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class OrderNumberField : StringFieldExpression<Purchase>
         {
             #region constructors
-            public OrderNumberField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private OrderNumberField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public OrderNumberField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3964,12 +3986,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class TotalPurchaseQuantityField : Int32FieldExpression<Purchase>
         {
             #region constructors
-            public TotalPurchaseQuantityField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private TotalPurchaseQuantityField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public TotalPurchaseQuantityField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3993,12 +4010,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class TotalPurchaseAmountField : DoubleFieldExpression<Purchase>
         {
             #region constructors
-            public TotalPurchaseAmountField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private TotalPurchaseAmountField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public TotalPurchaseAmountField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4022,12 +4034,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class PurchaseDateField : DateTimeFieldExpression<Purchase>
         {
             #region constructors
-            public PurchaseDateField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PurchaseDateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PurchaseDateField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4051,12 +4058,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class ShipDateField : NullableDateTimeFieldExpression<Purchase>
         {
             #region constructors
-            public ShipDateField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ShipDateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ShipDateField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4083,12 +4085,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class ExpectedDeliveryDateField : NullableDateTimeFieldExpression<Purchase>
         {
             #region constructors
-            public ExpectedDeliveryDateField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ExpectedDeliveryDateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ExpectedDeliveryDateField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4115,12 +4112,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class TrackingIdentifierField : NullableGuidFieldExpression<Purchase>
         {
             #region constructors
-            public TrackingIdentifierField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private TrackingIdentifierField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public TrackingIdentifierField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4147,12 +4139,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class PaymentMethodTypeField : EnumFieldExpression<Purchase, ServerSideBlazorApp.Data.PaymentMethodType>
         {
             #region constructors
-            public PaymentMethodTypeField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PaymentMethodTypeField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PaymentMethodTypeField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4176,12 +4163,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class PaymentSourceTypeField : NullableEnumFieldExpression<Purchase, ServerSideBlazorApp.Data.PaymentSourceType>
         {
             #region constructors
-            public PaymentSourceTypeField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PaymentSourceTypeField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PaymentSourceTypeField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4208,12 +4190,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class DateCreatedField : DateTimeFieldExpression<Purchase>
         {
             #region constructors
-            public DateCreatedField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4235,12 +4212,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class DateUpdatedField : DateTimeFieldExpression<Purchase>
         {
             #region constructors
-            public DateUpdatedField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateUpdatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateUpdatedField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4415,29 +4387,29 @@ namespace ServerSideBlazorApp.dboDataService
         #endregion
 
         #region constructors
-        private PurchaseLineEntity() : base(null, null, null)
+        private PurchaseLineEntity() : base(null, null, null, null)
         {
         }
 
-		public PurchaseLineEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public PurchaseLineEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private PurchaseLineEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private PurchaseLineEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.PurchaseId", PurchaseId = new PurchaseIdField($"{identifier}.PurchaseId", this));
-            Fields.Add($"{identifier}.ProductId", ProductId = new ProductIdField($"{identifier}.ProductId", this));
-            Fields.Add($"{identifier}.PurchasePrice", PurchasePrice = new PurchasePriceField($"{identifier}.PurchasePrice", this));
-            Fields.Add($"{identifier}.Quantity", Quantity = new QuantityField($"{identifier}.Quantity", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.PurchaseId", PurchaseId = new PurchaseIdField($"{identifier}.PurchaseId", "PurchaseId", this));
+            Fields.Add($"{identifier}.ProductId", ProductId = new ProductIdField($"{identifier}.ProductId", "ProductId", this));
+            Fields.Add($"{identifier}.PurchasePrice", PurchasePrice = new PurchasePriceField($"{identifier}.PurchasePrice", "PurchasePrice", this));
+            Fields.Add($"{identifier}.Quantity", Quantity = new QuantityField($"{identifier}.Quantity", "Quantity", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", "DateUpdated", this));
         }
         #endregion
 
         #region methods
         public PurchaseLineEntity As(string name)
-            => new PurchaseLineEntity(this.identifier, this.schema, name);
+            => new PurchaseLineEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -4450,6 +4422,38 @@ namespace ServerSideBlazorApp.dboDataService
                 ,new DateTimeSelectExpression(DateCreated)
                 ,new DateTimeSelectExpression(DateUpdated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(PurchaseId));
+            set &= aliased != nameof(PurchaseId) ? new Int32SelectExpression(PurchaseId).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(PurchaseId));
+
+            aliased = alias(nameof(ProductId));
+            set &= aliased != nameof(ProductId) ? new Int32SelectExpression(ProductId).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ProductId));
+
+            aliased = alias(nameof(PurchasePrice));
+            set &= aliased != nameof(PurchasePrice) ? new DecimalSelectExpression(PurchasePrice).As(aliased) as DecimalSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(PurchasePrice));
+
+            aliased = alias(nameof(Quantity));
+            set &= aliased != nameof(Quantity) ? new Int32SelectExpression(Quantity).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Quantity));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            aliased = alias(nameof(DateUpdated));
+            set &= aliased != nameof(DateUpdated) ? new DateTimeSelectExpression(DateUpdated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateUpdated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<PurchaseLine> GetInclusiveInsertExpression(PurchaseLine purchaseLine)
@@ -4473,7 +4477,7 @@ namespace ServerSideBlazorApp.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(PurchaseLine purchaseLine, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, PurchaseLine purchaseLine)
         {
 			purchaseLine.Id = reader.ReadField().GetValue<int>();
 			purchaseLine.PurchaseId = reader.ReadField().GetValue<int>();
@@ -4490,12 +4494,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class IdField : Int32FieldExpression<PurchaseLine>
         {
             #region constructors
-            public IdField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4517,12 +4516,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class PurchaseIdField : Int32FieldExpression<PurchaseLine>
         {
             #region constructors
-            public PurchaseIdField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PurchaseIdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PurchaseIdField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4546,12 +4540,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class ProductIdField : Int32FieldExpression<PurchaseLine>
         {
             #region constructors
-            public ProductIdField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ProductIdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ProductIdField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4575,12 +4564,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class PurchasePriceField : DecimalFieldExpression<PurchaseLine>
         {
             #region constructors
-            public PurchasePriceField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PurchasePriceField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PurchasePriceField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4604,12 +4588,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class QuantityField : Int32FieldExpression<PurchaseLine>
         {
             #region constructors
-            public QuantityField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private QuantityField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public QuantityField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4633,12 +4612,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class DateCreatedField : DateTimeFieldExpression<PurchaseLine>
         {
             #region constructors
-            public DateCreatedField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4660,12 +4634,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class DateUpdatedField : DateTimeFieldExpression<PurchaseLine>
         {
             #region constructors
-            public DateUpdatedField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateUpdatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateUpdatedField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4755,25 +4724,25 @@ namespace ServerSideBlazorApp.dboDataService
         #endregion
 
         #region constructors
-        private PersonTotalPurchasesViewEntity() : base(null, null, null)
+        private PersonTotalPurchasesViewEntity() : base(null, null, null, null)
         {
         }
 
-		public PersonTotalPurchasesViewEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public PersonTotalPurchasesViewEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private PersonTotalPurchasesViewEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private PersonTotalPurchasesViewEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.TotalAmount", TotalAmount = new TotalAmountField($"{identifier}.TotalAmount", this));
-            Fields.Add($"{identifier}.TotalCount", TotalCount = new TotalCountField($"{identifier}.TotalCount", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.TotalAmount", TotalAmount = new TotalAmountField($"{identifier}.TotalAmount", "TotalAmount", this));
+            Fields.Add($"{identifier}.TotalCount", TotalCount = new TotalCountField($"{identifier}.TotalCount", "TotalCount", this));
         }
         #endregion
 
         #region methods
         public PersonTotalPurchasesViewEntity As(string name)
-            => new PersonTotalPurchasesViewEntity(this.identifier, this.schema, name);
+            => new PersonTotalPurchasesViewEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -4782,6 +4751,26 @@ namespace ServerSideBlazorApp.dboDataService
                 ,new NullableDoubleSelectExpression(TotalAmount)
                 ,new NullableInt32SelectExpression(TotalCount)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(TotalAmount));
+            set &= aliased != nameof(TotalAmount) ? new NullableDoubleSelectExpression(TotalAmount).As(aliased) as NullableDoubleSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(TotalAmount));
+
+            aliased = alias(nameof(TotalCount));
+            set &= aliased != nameof(TotalCount) ? new NullableInt32SelectExpression(TotalCount).As(aliased) as NullableInt32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(TotalCount));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<PersonTotalPurchasesView> GetInclusiveInsertExpression(PersonTotalPurchasesView personTotalPurchasesView)
@@ -4797,7 +4786,7 @@ namespace ServerSideBlazorApp.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(PersonTotalPurchasesView personTotalPurchasesView, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, PersonTotalPurchasesView personTotalPurchasesView)
         {
 			personTotalPurchasesView.Id = reader.ReadField().GetValue<int>();
 			personTotalPurchasesView.TotalAmount = reader.ReadField().GetValue<double?>();
@@ -4810,12 +4799,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class IdField : Int32FieldExpression<PersonTotalPurchasesView>
         {
             #region constructors
-            public IdField(string identifier, PersonTotalPurchasesViewEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, PersonTotalPurchasesViewEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4837,12 +4821,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class TotalAmountField : NullableDoubleFieldExpression<PersonTotalPurchasesView>
         {
             #region constructors
-            public TotalAmountField(string identifier, PersonTotalPurchasesViewEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private TotalAmountField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public TotalAmountField(string identifier, string name, PersonTotalPurchasesViewEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4864,12 +4843,7 @@ namespace ServerSideBlazorApp.dboDataService
         public partial class TotalCountField : NullableInt32FieldExpression<PersonTotalPurchasesView>
         {
             #region constructors
-            public TotalCountField(string identifier, PersonTotalPurchasesViewEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private TotalCountField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public TotalCountField(string identifier, string name, PersonTotalPurchasesViewEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -5088,7 +5062,7 @@ namespace ServerSideBlazorApp.secDataService
         #region constructors
         public secSchemaExpression(string identifier) : base(identifier, null)
         {
-            Entities.Add($"{identifier}.Person", Person = new PersonEntity($"{identifier}.Person", this));
+            Entities.Add($"{identifier}.Person", Person = new PersonEntity($"{identifier}.Person", "Person", this));
         }
         #endregion
     }
@@ -5187,26 +5161,26 @@ namespace ServerSideBlazorApp.secDataService
         #endregion
 
         #region constructors
-        private PersonEntity() : base(null, null, null)
+        private PersonEntity() : base(null, null, null, null)
         {
         }
 
-		public PersonEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public PersonEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private PersonEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private PersonEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.SSN", SSN = new SSNField($"{identifier}.SSN", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.SSN", SSN = new SSNField($"{identifier}.SSN", "SSN", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", "DateUpdated", this));
         }
         #endregion
 
         #region methods
         public PersonEntity As(string name)
-            => new PersonEntity(this.identifier, this.schema, name);
+            => new PersonEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -5216,6 +5190,29 @@ namespace ServerSideBlazorApp.secDataService
                 ,new DateTimeSelectExpression(DateCreated)
                 ,new DateTimeSelectExpression(DateUpdated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(SSN));
+            set &= aliased != nameof(SSN) ? new StringSelectExpression(SSN).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(SSN));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            aliased = alias(nameof(DateUpdated));
+            set &= aliased != nameof(DateUpdated) ? new DateTimeSelectExpression(DateUpdated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateUpdated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<Person> GetInclusiveInsertExpression(Person person)
@@ -5235,7 +5232,7 @@ namespace ServerSideBlazorApp.secDataService
             return expr;
         }
 
-        protected override void HydrateEntity(Person person, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, Person person)
         {
 			person.Id = reader.ReadField().GetValue<int>();
 			person.SSN = reader.ReadField().GetValue<string>();
@@ -5249,12 +5246,7 @@ namespace ServerSideBlazorApp.secDataService
         public partial class IdField : Int32FieldExpression<Person>
         {
             #region constructors
-            public IdField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -5278,12 +5270,7 @@ namespace ServerSideBlazorApp.secDataService
         public partial class SSNField : StringFieldExpression<Person>
         {
             #region constructors
-            public SSNField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private SSNField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public SSNField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -5307,12 +5294,7 @@ namespace ServerSideBlazorApp.secDataService
         public partial class DateCreatedField : DateTimeFieldExpression<Person>
         {
             #region constructors
-            public DateCreatedField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -5334,12 +5316,7 @@ namespace ServerSideBlazorApp.secDataService
         public partial class DateUpdatedField : DateTimeFieldExpression<Person>
         {
             #region constructors
-            public DateUpdatedField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateUpdatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateUpdatedField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }

--- a/samples/mssql/ServerSideBlazorApp/Service/CustomerService.cs
+++ b/samples/mssql/ServerSideBlazorApp/Service/CustomerService.cs
@@ -104,7 +104,7 @@ namespace ServerSideBlazorApp.Service
             );
         }
 
-        private static CustomerSummaryModel MapToCustomerSummary(ISqlRow row)
+        private static CustomerSummaryModel MapToCustomerSummary(ISqlFieldReader row)
             => new CustomerSummaryModel
             {
                 Id = row.ReadField().GetValue<int>(),
@@ -120,7 +120,7 @@ namespace ServerSideBlazorApp.Service
         /// </summary>
         public async Task<CustomerDetailModel> GetCustomerDetailAsync(int customerId)
         {
-            static AddressModel mapAddress(AddressType addressType, ISqlRow sqlRow)
+            static AddressModel mapAddress(AddressType addressType, ISqlFieldReader sqlRow)
                 =>  new AddressModel
                 {
                     Type = addressType,
@@ -208,20 +208,20 @@ namespace ServerSideBlazorApp.Service
                 ).As(shippingAddress).On(dbo.Customer.Id == dbex.Alias(nameof(CustomerDetailModel.ShippingAddress), nameof(CustomerSummaryModel.Id)))
                 .Where(dbo.Customer.Id == customerId)
                 .ExecuteAsync(
-                    sqlRow => 
+                    reader => 
                     {
-                        customer.Id = sqlRow.ReadField().GetValue<int>();
-                        customer.FirstName = sqlRow.ReadField().GetValue<string>();
-                        customer.LastName = sqlRow.ReadField().GetValue<string>();
-                        customer.LifetimeValue = sqlRow.ReadField().GetValue<double>();
-                        customer.Gender = sqlRow.ReadField().GetValue<GenderType>();
-                        customer.CreditLimit = sqlRow.ReadField().GetValue<int?>();
-                        customer.YearOfLastCreditLimitReview = sqlRow.ReadField().GetValue<int?>();
-                        customer.BirthDate = sqlRow.ReadField().GetValue<DateTime?>();
-                        customer.CurrentAge = sqlRow.ReadField().GetValue<short?>();
-                        customer.MailingAddress = mapAddress(AddressType.Mailing, sqlRow);
-                        customer.BillingAddress = mapAddress(AddressType.Billing, sqlRow);
-                        customer.ShippingAddress = mapAddress(AddressType.Shipping, sqlRow);
+                        customer.Id = reader.ReadField().GetValue<int>();
+                        customer.FirstName = reader.ReadField().GetValue<string>();
+                        customer.LastName = reader.ReadField().GetValue<string>();
+                        customer.LifetimeValue = reader.ReadField().GetValue<double>();
+                        customer.Gender = reader.ReadField().GetValue<GenderType>();
+                        customer.CreditLimit = reader.ReadField().GetValue<int?>();
+                        customer.YearOfLastCreditLimitReview = reader.ReadField().GetValue<int?>();
+                        customer.BirthDate = reader.ReadField().GetValue<DateTime?>();
+                        customer.CurrentAge = reader.ReadField().GetValue<short?>();
+                        customer.MailingAddress = mapAddress(AddressType.Mailing, reader);
+                        customer.BillingAddress = mapAddress(AddressType.Billing, reader);
+                        customer.ShippingAddress = mapAddress(AddressType.Shipping, reader);
                         customer.IsVIP = customer.LifetimeValue >= Rules.LifetimeValueAmountToBeAVIPCustomer;
                         return customer;
                     }

--- a/samples/mssql/ServerSideBlazorApp/Service/OrderService.cs
+++ b/samples/mssql/ServerSideBlazorApp/Service/OrderService.cs
@@ -57,18 +57,18 @@ namespace ServerSideBlazorApp.Service
                     pagingParameters.Sorting?.Select(s => s.Direction == OrderExpressionDirection.ASC ? OrderSummarySortingFields[s.Field].Asc : OrderSummarySortingFields[s.Field].Desc)
                 )
                 .Skip(pagingParameters.Offset).Limit(pagingParameters.Limit)
-                .ExecuteAsync(row =>
+                .ExecuteAsync(reader =>
                     new OrderSummaryModel
                     {
-                        Id = row.ReadField().GetValue<int>(),
-                        CustomerId = row.ReadField().GetValue<int>(),
-                        CustomerName = row.ReadField().GetValue<string>(),
-                        IsVIP = row.ReadField().GetValue<double>() >= Rules.LifetimeValueAmountToBeAVIPCustomer,
-                        OrderNumber = row.ReadField().GetValue<string>(),
-                        PaymentMethod = row.ReadField().GetValue<PaymentMethodType>(),
-                        TotalPurchaseAmount = row.ReadField().GetValue<double>(),
-                        PurchaseDate = row.ReadField().GetValue<DateTime>(),
-                        ShipDate = row.ReadField().GetValue<DateTime?>()
+                        Id = reader.ReadField().GetValue<int>(),
+                        CustomerId = reader.ReadField().GetValue<int>(),
+                        CustomerName = reader.ReadField().GetValue<string>(),
+                        IsVIP = reader.ReadField().GetValue<double>() >= Rules.LifetimeValueAmountToBeAVIPCustomer,
+                        OrderNumber = reader.ReadField().GetValue<string>(),
+                        PaymentMethod = reader.ReadField().GetValue<PaymentMethodType>(),
+                        TotalPurchaseAmount = reader.ReadField().GetValue<double>(),
+                        PurchaseDate = reader.ReadField().GetValue<DateTime>(),
+                        ShipDate = reader.ReadField().GetValue<DateTime?>()
                     }
                 );
 
@@ -113,18 +113,18 @@ namespace ServerSideBlazorApp.Service
                     pagingParameters.Sorting?.Select(s => s.Direction == OrderExpressionDirection.ASC ? OrderSummarySortingFields[s.Field].Asc : OrderSummarySortingFields[s.Field].Desc)
                 )
                 .Skip(pagingParameters.Offset).Limit(pagingParameters.Limit)
-                .ExecuteAsync(row =>
+                .ExecuteAsync(reader =>
                     new OrderSummaryModel
                     {
-                        Id = row.ReadField().GetValue<int>(),
-                        CustomerId = row.ReadField().GetValue<int>(),
-                        CustomerName = row.ReadField().GetValue<string>(),
-                        IsVIP = row.ReadField().GetValue<double>() >= Rules.LifetimeValueAmountToBeAVIPCustomer,
-                        OrderNumber = row.ReadField().GetValue<string>(),
-                        PaymentMethod = row.ReadField().GetValue<PaymentMethodType>(),
-                        TotalPurchaseAmount = row.ReadField().GetValue<double>(),
-                        PurchaseDate = row.ReadField().GetValue<DateTime>(),
-                        ShipDate = row.ReadField().GetValue<DateTime?>()
+                        Id = reader.ReadField().GetValue<int>(),
+                        CustomerId = reader.ReadField().GetValue<int>(),
+                        CustomerName = reader.ReadField().GetValue<string>(),
+                        IsVIP = reader.ReadField().GetValue<double>() >= Rules.LifetimeValueAmountToBeAVIPCustomer,
+                        OrderNumber = reader.ReadField().GetValue<string>(),
+                        PaymentMethod = reader.ReadField().GetValue<PaymentMethodType>(),
+                        TotalPurchaseAmount = reader.ReadField().GetValue<double>(),
+                        PurchaseDate = reader.ReadField().GetValue<DateTime>(),
+                        ShipDate = reader.ReadField().GetValue<DateTime?>()
                     }
                 );
 
@@ -208,36 +208,36 @@ namespace ServerSideBlazorApp.Service
             ).As(shippingAddress).On(dbo.Customer.Id == dbex.Alias(shippingAddress, nameof(OrderDetailModel.CustomerId)))
             .Where(dbo.Purchase.Id == orderId)
             .ExecuteAsync(
-                row => new OrderDetailModel
+                reader => new OrderDetailModel
                     {
-                        Id = row.ReadField().GetValue<int>(),
-                        CustomerId = row.ReadField().GetValue<int>(),
-                        CustomerName = row.ReadField().GetValue<string>(),
-                        IsVIP = row.ReadField().GetValue<double>() >= Rules.LifetimeValueAmountToBeAVIPCustomer,
-                        OrderNumber = row.ReadField().GetValue<string>(),
-                        TotalPurchaseAmount = row.ReadField().GetValue<double>(),
-                        PurchaseDate = row.ReadField().GetValue<DateTime>(),
-                        ShipDate = row.ReadField().GetValue<DateTime?>(),
-                        PaymentMethod = row.ReadField().GetValue<PaymentMethodType>(),
-                        ExpectedDeliveryDate = row.ReadField().GetValue<DateTime?>(),
-                        TrackingIdentifier = row.ReadField().GetValue<Guid?>(),
+                        Id = reader.ReadField().GetValue<int>(),
+                        CustomerId = reader.ReadField().GetValue<int>(),
+                        CustomerName = reader.ReadField().GetValue<string>(),
+                        IsVIP = reader.ReadField().GetValue<double>() >= Rules.LifetimeValueAmountToBeAVIPCustomer,
+                        OrderNumber = reader.ReadField().GetValue<string>(),
+                        TotalPurchaseAmount = reader.ReadField().GetValue<double>(),
+                        PurchaseDate = reader.ReadField().GetValue<DateTime>(),
+                        ShipDate = reader.ReadField().GetValue<DateTime?>(),
+                        PaymentMethod = reader.ReadField().GetValue<PaymentMethodType>(),
+                        ExpectedDeliveryDate = reader.ReadField().GetValue<DateTime?>(),
+                        TrackingIdentifier = reader.ReadField().GetValue<Guid?>(),
                         BillingAddress = new AddressModel
                         {
                             Type = AddressType.Billing,
-                            Line1 = row.ReadField().GetValue<string>(),
-                            Line2 = row.ReadField().GetValue<string>(),
-                            City = row.ReadField().GetValue<string>(),
-                            State = row.ReadField().GetValue<string>(),
-                            ZIP = row.ReadField().GetValue<string>()
+                            Line1 = reader.ReadField().GetValue<string>(),
+                            Line2 = reader.ReadField().GetValue<string>(),
+                            City = reader.ReadField().GetValue<string>(),
+                            State = reader.ReadField().GetValue<string>(),
+                            ZIP = reader.ReadField().GetValue<string>()
                         },
                         ShippingAddress = new AddressModel
                         {
                             Type = AddressType.Shipping,
-                            Line1 = row.ReadField().GetValue<string>(),
-                            Line2 = row.ReadField().GetValue<string>(),
-                            City = row.ReadField().GetValue<string>(),
-                            State = row.ReadField().GetValue<string>(),
-                            ZIP = row.ReadField().GetValue<string>()
+                            Line1 = reader.ReadField().GetValue<string>(),
+                            Line2 = reader.ReadField().GetValue<string>(),
+                            City = reader.ReadField().GetValue<string>(),
+                            State = reader.ReadField().GetValue<string>(),
+                            ZIP = reader.ReadField().GetValue<string>()
                         }
                     }
             );

--- a/samples/mssql/ServerSideBlazorApp/Service/ProductService.cs
+++ b/samples/mssql/ServerSideBlazorApp/Service/ProductService.cs
@@ -46,15 +46,15 @@ namespace ServerSideBlazorApp.Service
                     pagingParameters.Sorting?.Select(s => s.Direction == OrderExpressionDirection.ASC ? ProductSummarySortingFields[s.Field].Asc : ProductSummarySortingFields[s.Field].Desc)
                 )
                 .Skip(pagingParameters.Offset).Limit(pagingParameters.Limit)
-                .ExecuteAsync(row =>
+                .ExecuteAsync(reader =>
                     new ProductSummaryModel
                     {
-                        Id = row.ReadField().GetValue<int>(),
-                        Category = row.ReadField().GetValue<ProductCategoryType?>(),
-                        Name = row.ReadField().GetValue<string>(),
-                        ListPrice = row.ReadField().GetValue<double>(),
-                        Price = row.ReadField().GetValue<double>(),
-                        QuantityOnHand = row.ReadField().GetValue<int>()
+                        Id = reader.ReadField().GetValue<int>(),
+                        Category = reader.ReadField().GetValue<ProductCategoryType?>(),
+                        Name = reader.ReadField().GetValue<string>(),
+                        ListPrice = reader.ReadField().GetValue<double>(),
+                        Price = reader.ReadField().GetValue<double>(),
+                        QuantityOnHand = reader.ReadField().GetValue<int>()
                     }
                 );
 
@@ -95,22 +95,22 @@ namespace ServerSideBlazorApp.Service
                 )
                 .From(dbo.Product)
                 .Where(dbo.Product.Id == productId)
-                .ExecuteAsync(row =>
+                .ExecuteAsync(reader =>
                     new ProductDetailModel
                     {
-                        Id = row.ReadField().GetValue<int>(),
-                        Category = row.ReadField().GetValue<ProductCategoryType?>(),
-                        Name = row.ReadField().GetValue<string>(),
-                        Description = row.ReadField().GetValue<string>(),
-                        ListPrice = row.ReadField().GetValue<double>(),
-                        Price = row.ReadField().GetValue<double>(),
-                        QuantityOnHand = row.ReadField().GetValue<int>(),
-                        Height = row.ReadField().GetValue<decimal?>(),
-                        Width = row.ReadField().GetValue<decimal?>(),
-                        Depth = row.ReadField().GetValue<decimal?>(),
-                        Weight = row.ReadField().GetValue<decimal?>(),
-                        ShippingWeight = row.ReadField().GetValue<decimal>(),
-                        Image = Convert.ToBase64String(row.ReadField().GetValue<byte[]>() ?? new byte[0])
+                        Id = reader.ReadField().GetValue<int>(),
+                        Category = reader.ReadField().GetValue<ProductCategoryType?>(),
+                        Name = reader.ReadField().GetValue<string>(),
+                        Description = reader.ReadField().GetValue<string>(),
+                        ListPrice = reader.ReadField().GetValue<double>(),
+                        Price = reader.ReadField().GetValue<double>(),
+                        QuantityOnHand = reader.ReadField().GetValue<int>(),
+                        Height = reader.ReadField().GetValue<decimal?>(),
+                        Width = reader.ReadField().GetValue<decimal?>(),
+                        Depth = reader.ReadField().GetValue<decimal?>(),
+                        Weight = reader.ReadField().GetValue<decimal?>(),
+                        ShippingWeight = reader.ReadField().GetValue<decimal>(),
+                        Image = Convert.ToBase64String(reader.ReadField().GetValue<byte[]>() ?? new byte[0])
                     }
                 );
         }

--- a/src/HatTrick.DbEx.MsSql/Assembler/MsSqlSelectSqlStatementAssembler.cs
+++ b/src/HatTrick.DbEx.MsSql/Assembler/MsSqlSelectSqlStatementAssembler.cs
@@ -61,7 +61,7 @@ namespace HatTrick.DbEx.MsSql.Assembler
             //end CTE
             builder.Appender.Indent().Write("AS ")
                     .Write(context.Configuration.IdentifierDelimiter.Begin)
-                    .Write((expression.BaseEntity as ISqlMetadataIdentifier).Identifier)
+                    .Write((expression.BaseEntity as ISqlMetadataIdentifierProvider).Identifier)
                     .Write(context.Configuration.IdentifierDelimiter.End)
                     .LineBreak()
                 .Indentation--.Indent().Write("WHERE").LineBreak()

--- a/src/HatTrick.DbEx.MsSql/Builder/MsSqlQueryExpressionBuilderFactory.cs
+++ b/src/HatTrick.DbEx.MsSql/Builder/MsSqlQueryExpressionBuilderFactory.cs
@@ -16,7 +16,6 @@ namespace HatTrick.DbEx.MsSql.Builder
         {
             var expression = (configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.")).QueryExpressionFactory?.CreateQueryExpression<SelectQueryExpression>() ?? throw new DbExpressionConfigurationException($"Expected query expression factory to return a query expression.");
             expression.Top = 1;
-            expression.Select = new SelectExpressionSet();
             return new MsSqlSelectEntityQueryExpressionBuilder<TEntity>(configuration, expression);
         }
 
@@ -25,10 +24,10 @@ namespace HatTrick.DbEx.MsSql.Builder
             var expression = (configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.")).QueryExpressionFactory?.CreateQueryExpression<SelectQueryExpression>() ?? throw new DbExpressionConfigurationException($"Expected query expression factory to return a query expression.");
             var expressions = new List<SelectExpression>(fields.Length + 2)
             {
-                field1 as SelectExpression ?? new SelectExpression(field1),
-                field2 as SelectExpression ?? new SelectExpression(field2)
+                field1?.ToSelectExpression(configuration.MetadataProvider) ?? throw new ArgumentNullException($"{nameof(field1)} is required."),
+                field2?.ToSelectExpression(configuration.MetadataProvider) ?? throw new ArgumentNullException($"{nameof(field2)} is required.")
             };
-            expressions.AddRange(fields.Select(field => field as SelectExpression ?? new SelectExpression(field)));
+            expressions.AddRange(fields.Select(field => field.ToSelectExpression(configuration.MetadataProvider)));
             expression.Top = 1;
             expression.Select = new SelectExpressionSet(expressions);
             return new MsSqlSelectValueSelectQueryExpressionBuilder<ExpandoObject>(configuration, expression);
@@ -37,7 +36,7 @@ namespace HatTrick.DbEx.MsSql.Builder
         public SelectValue<ExpandoObject> CreateSelectValueBuilder(RuntimeSqlDatabaseConfiguration configuration, IEnumerable<AnyElement> fields)
         {
             var expression = (configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.")).QueryExpressionFactory?.CreateQueryExpression<SelectQueryExpression>() ?? throw new DbExpressionConfigurationException($"Expected query expression factory to return a query expression.");
-            expression.Select = new SelectExpressionSet(fields.Select(field => field as SelectExpression ?? new SelectExpression(field)));
+            expression.Select = new SelectExpressionSet(fields.Select(field => field?.ToSelectExpression(configuration.MetadataProvider) ?? throw new ArgumentNullException($"{nameof(field)} is required.")));
             return new MsSqlSelectValueSelectQueryExpressionBuilder<ExpandoObject>(configuration, expression);
         }
 
@@ -46,7 +45,7 @@ namespace HatTrick.DbEx.MsSql.Builder
         {
             var expression = (configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.")).QueryExpressionFactory?.CreateQueryExpression<SelectQueryExpression>() ?? throw new DbExpressionConfigurationException($"Expected query expression factory to return a query expression.");
             expression.Top = 1;
-            expression.Select = new SelectExpressionSet(field as SelectExpression ?? new SelectExpression<TEnum>(field));
+            expression.Select = new SelectExpressionSet(field?.ToSelectExpression(configuration.MetadataProvider) ?? throw new ArgumentNullException($"{nameof(field)} is required."));
             return new MsSqlSelectValueSelectQueryExpressionBuilder<TEnum>(configuration, expression);
         }
 
@@ -55,7 +54,7 @@ namespace HatTrick.DbEx.MsSql.Builder
         {
             var expression = (configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.")).QueryExpressionFactory?.CreateQueryExpression<SelectQueryExpression>() ?? throw new DbExpressionConfigurationException($"Expected query expression factory to return a query expression.");
             expression.Top = 1;
-            expression.Select = new SelectExpressionSet(field as SelectExpression ?? new SelectExpression<TEnum?>(field));
+            expression.Select = new SelectExpressionSet(field?.ToSelectExpression(configuration.MetadataProvider) ?? throw new ArgumentNullException($"{nameof(field)} is required."));
             return new MsSqlSelectValueSelectQueryExpressionBuilder<TEnum?>(configuration, expression);
         }
 
@@ -150,7 +149,7 @@ namespace HatTrick.DbEx.MsSql.Builder
         {
             var expression = (configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.")).QueryExpressionFactory?.CreateQueryExpression<SelectQueryExpression>() ?? throw new DbExpressionConfigurationException($"Expected query expression factory to return a query expression.");
             expression.Top = 1;
-            expression.Select = new SelectExpressionSet(field as SelectExpression ?? new SelectExpression<TValue>(field));
+            expression.Select = new SelectExpressionSet(field?.ToSelectExpression(configuration.MetadataProvider) ?? throw new ArgumentNullException($"{nameof(field)} is required."));
             return new MsSqlSelectValueSelectQueryExpressionBuilder<TValue>(configuration, expression);
         }
         #endregion
@@ -160,7 +159,6 @@ namespace HatTrick.DbEx.MsSql.Builder
             where TEntity : class, IDbEntity
         {
             var expression = (configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.")).QueryExpressionFactory?.CreateQueryExpression<SelectQueryExpression>() ?? throw new DbExpressionConfigurationException($"Expected query expression factory to return a query expression.");
-            expression.Select = new SelectExpressionSet();
             return new MsSqlSelectEntitiesSelectQueryExpressionBuilder<TEntity>(configuration, expression);
         }
 
@@ -169,10 +167,10 @@ namespace HatTrick.DbEx.MsSql.Builder
             var expression = (configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.")).QueryExpressionFactory?.CreateQueryExpression<SelectQueryExpression>() ?? throw new DbExpressionConfigurationException($"Expected query expression factory to return a query expression.");
             var expressions = new List<SelectExpression>(fields.Length + 2)
             {
-                field1 as SelectExpression ?? new SelectExpression(field1),
-                field2 as SelectExpression ?? new SelectExpression(field2)
+                field1?.ToSelectExpression(configuration.MetadataProvider) ?? throw new ArgumentNullException($"{nameof(field1)} is required."),
+                field2?.ToSelectExpression(configuration.MetadataProvider) ?? throw new ArgumentNullException($"{nameof(field2)} is required.")
             };
-            expressions.AddRange(fields.Select(field => field as SelectExpression ?? new SelectExpression(field)));
+            expressions.AddRange(fields.Select(field => field.ToSelectExpression(configuration.MetadataProvider)));
             expression.Select = new SelectExpressionSet(expressions);
             return new MsSqlSelectValuesSelectQueryExpressionBuilder<ExpandoObject>(configuration, expression);
         }
@@ -180,7 +178,7 @@ namespace HatTrick.DbEx.MsSql.Builder
         public SelectValues<ExpandoObject> CreateSelectValuesBuilder(RuntimeSqlDatabaseConfiguration configuration, IEnumerable<AnyElement> fields)
         {
             var expression = (configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.")).QueryExpressionFactory?.CreateQueryExpression<SelectQueryExpression>() ?? throw new DbExpressionConfigurationException($"Expected query expression factory to return a query expression.");
-            expression.Select = new SelectExpressionSet(fields.Select(field => field as SelectExpression ?? new SelectExpression(field)));
+            expression.Select = new SelectExpressionSet(fields.Select(field => field?.ToSelectExpression(configuration.MetadataProvider) ?? throw new ArgumentNullException($"{nameof(field)} is required.")));
             return new MsSqlSelectValuesSelectQueryExpressionBuilder<ExpandoObject>(configuration, expression);
         }
 
@@ -188,7 +186,7 @@ namespace HatTrick.DbEx.MsSql.Builder
             where TEnum : struct, Enum, IComparable
         {
             var expression = (configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.")).QueryExpressionFactory?.CreateQueryExpression<SelectQueryExpression>() ?? throw new DbExpressionConfigurationException($"Expected query expression factory to return a query expression.");
-            expression.Select = new SelectExpressionSet(field as SelectExpression ?? new SelectExpression<TEnum>(field));
+            expression.Select = new SelectExpressionSet(field?.ToSelectExpression(configuration.MetadataProvider) ?? throw new ArgumentNullException($"{nameof(field)} is required."));
             return new MsSqlSelectValuesSelectQueryExpressionBuilder<TEnum>(configuration, expression);
         }
 
@@ -196,7 +194,7 @@ namespace HatTrick.DbEx.MsSql.Builder
             where TEnum : struct, Enum, IComparable
         {
             var expression = (configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.")).QueryExpressionFactory?.CreateQueryExpression<SelectQueryExpression>() ?? throw new DbExpressionConfigurationException($"Expected query expression factory to return a query expression.");
-            expression.Select = new SelectExpressionSet(field as SelectExpression ?? new SelectExpression<TEnum?>(field));
+            expression.Select = new SelectExpressionSet(field?.ToSelectExpression(configuration.MetadataProvider) ?? throw new ArgumentNullException($"{nameof(field)} is required."));
             return new MsSqlSelectValuesSelectQueryExpressionBuilder<TEnum?>(configuration, expression);
         }
 
@@ -293,7 +291,7 @@ namespace HatTrick.DbEx.MsSql.Builder
         private SelectValues<TValue> CreateSelectValuesBuilder<TValue>(RuntimeSqlDatabaseConfiguration configuration, AnyElement field)
         {
             var expression = (configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.")).QueryExpressionFactory?.CreateQueryExpression<SelectQueryExpression>() ?? throw new DbExpressionConfigurationException($"Expected query expression factory to return a query expression.");
-            expression.Select = new SelectExpressionSet(field as SelectExpression ?? new SelectExpression<TValue>(field));
+            expression.Select = new SelectExpressionSet(field?.ToSelectExpression(configuration.MetadataProvider) ?? throw new ArgumentNullException($"{nameof(field)} is required."));
             return new MsSqlSelectValuesSelectQueryExpressionBuilder<TValue>(configuration, expression);
         }
         #endregion
@@ -314,7 +312,7 @@ namespace HatTrick.DbEx.MsSql.Builder
         public UpdateEntities CreateUpdateExpressionBuilder(RuntimeSqlDatabaseConfiguration configuration, IEnumerable<EntityFieldAssignment> assignments)
         {
             var expression = (configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.")).QueryExpressionFactory?.CreateQueryExpression<UpdateQueryExpression>() ?? throw new DbExpressionConfigurationException($"Expected query expression factory to return a query expression.");
-            expression.Assign = new AssignmentExpressionSet(assignments.Select(x => x as AssignmentExpression ?? throw new DbExpressionException($"Expected all {nameof(assignments)} to be assignable to {typeof(AssignmentExpression)}.")));
+            expression.Assign = new AssignmentExpressionSet((assignments ?? throw new ArgumentNullException($"{nameof(assignments)} is required.")).Select(x => x as AssignmentExpression ?? throw new DbExpressionException($"Expected all {nameof(assignments)} to be assignable to {typeof(AssignmentExpression)}.")));
             return new MsSqlUpdateQueryExpressionBuilder(configuration, expression);
         }
 
@@ -326,7 +324,7 @@ namespace HatTrick.DbEx.MsSql.Builder
 
         public InsertEntity<TEntity> CreateInsertExpressionBuilder<TEntity>(RuntimeSqlDatabaseConfiguration configuration, TEntity instance)
             where TEntity : class, IDbEntity
-            => new MsSqlInsertQueryExpressionBuilder<TEntity>(configuration, (configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.")).QueryExpressionFactory?.CreateQueryExpression<InsertQueryExpression>() ?? throw new DbExpressionConfigurationException($"Expected query expression factory to return a query expression."), new List<TEntity> { instance });
+            => new MsSqlInsertQueryExpressionBuilder<TEntity>(configuration, (configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.")).QueryExpressionFactory?.CreateQueryExpression<InsertQueryExpression>() ?? throw new DbExpressionConfigurationException($"Expected query expression factory to return a query expression."), new List<TEntity> { instance ?? throw new ArgumentNullException($"{nameof(instance)} is required.") });
 
         public InsertEntities<TEntity> CreateInsertExpressionBuilder<TEntity>(RuntimeSqlDatabaseConfiguration configuration, TEntity entity, params TEntity[] entities)
             where TEntity : class, IDbEntity
@@ -338,7 +336,7 @@ namespace HatTrick.DbEx.MsSql.Builder
 
         public InsertEntities<TEntity> CreateInsertExpressionBuilder<TEntity>(RuntimeSqlDatabaseConfiguration configuration, IEnumerable<TEntity> instances)
             where TEntity : class, IDbEntity
-            => new MsSqlInsertQueryExpressionBuilder<TEntity>(configuration, (configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.")).QueryExpressionFactory?.CreateQueryExpression<InsertQueryExpression>() ?? throw new DbExpressionConfigurationException($"Expected query expression factory to return a query expression."), instances);
+            => new MsSqlInsertQueryExpressionBuilder<TEntity>(configuration, (configuration ?? throw new ArgumentNullException($"{nameof(configuration)} is required.")).QueryExpressionFactory?.CreateQueryExpression<InsertQueryExpression>() ?? throw new DbExpressionConfigurationException($"Expected query expression factory to return a query expression."), instances ?? throw new ArgumentNullException($"{nameof(instances)} is required."));
 
     }
 }

--- a/src/HatTrick.DbEx.MsSql/_Extensions/ExpressionElementExtensions.cs
+++ b/src/HatTrick.DbEx.MsSql/_Extensions/ExpressionElementExtensions.cs
@@ -1,0 +1,45 @@
+﻿using HatTrick.DbEx.Sql;
+using HatTrick.DbEx.Sql.Expression;
+using System;
+
+namespace HatTrick.DbEx.MsSql
+{
+    internal static class ExpressionElementExtensions
+    {
+        internal static FieldExpression AsFieldExpression(this IExpressionElement expression)
+        {
+            if (expression is FieldExpression field)
+                return field;
+
+            if (expression is SelectExpression select)
+                return AsFieldExpression(select.Expression);
+
+            if (expression is ExpressionMediator mediator)
+                return AsFieldExpression(mediator.Expression);
+
+            return null;
+        }
+
+        internal static SelectExpression ToSelectExpression(this IExpressionElement expression, ISqlDatabaseMetadataProvider metadata)
+        {
+            if (expression is null)
+                throw new ArgumentNullException($"{nameof(expression)} is required.");
+
+            if (expression is SelectExpression select)
+                return select;
+
+            var field = expression.AsFieldExpression();
+
+            if (field is null)
+                return new SelectExpression(expression);
+
+            if (metadata is null)
+                throw new ArgumentNullException($"{nameof(metadata)} is required.");
+
+            var dbName = metadata.FindFieldMetadata((field as ISqlMetadataIdentifierProvider).Identifier)?.Name ?? throw new DbExpressionException($"Cannot resolve metadata for {expression}.");
+            var codeName = (field as IExpressionNameProvider).Name;
+
+            return dbName == codeName ? new SelectExpression(expression) : new SelectExpression(expression, codeName);
+        }
+    }
+}

--- a/src/HatTrick.DbEx.Sql/Assembler/SqlStatementBuilder.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/SqlStatementBuilder.cs
@@ -83,8 +83,8 @@ namespace HatTrick.DbEx.Sql.Assembler
 
         public string GenerateAlias() => $"_t{++_currentAliasCounter}";
 
-        public ISqlSchemaMetadata FindMetadata(SchemaExpression schema) => DatabaseMetadata.FindSchemaMetadata((schema as ISqlMetadataIdentifier).Identifier);
-        public ISqlEntityMetadata FindMetadata(EntityExpression entity) => DatabaseMetadata.FindEntityMetadata((entity as ISqlMetadataIdentifier).Identifier);
-        public ISqlFieldMetadata FindMetadata(FieldExpression field) => DatabaseMetadata.FindFieldMetadata((field as ISqlMetadataIdentifier).Identifier);
+        public ISqlSchemaMetadata FindMetadata(SchemaExpression schema) => DatabaseMetadata.FindSchemaMetadata((schema as ISqlMetadataIdentifierProvider).Identifier);
+        public ISqlEntityMetadata FindMetadata(EntityExpression entity) => DatabaseMetadata.FindEntityMetadata((entity as ISqlMetadataIdentifierProvider).Identifier);
+        public ISqlFieldMetadata FindMetadata(FieldExpression field) => DatabaseMetadata.FindFieldMetadata((field as ISqlMetadataIdentifierProvider).Identifier);
     }
 }

--- a/src/HatTrick.DbEx.Sql/Configuration/_Entities/_Mapping/IMapperFactoryContinuationConfigurationBuilder.cs
+++ b/src/HatTrick.DbEx.Sql/Configuration/_Entities/_Mapping/IMapperFactoryContinuationConfigurationBuilder.cs
@@ -6,11 +6,11 @@ namespace HatTrick.DbEx.Sql.Configuration
     public interface IMapperFactoryContinuationConfigurationBuilder
     {
         /// <summary>
-        /// Override the default behaviour of mapping retrieved values from the target database to an <typeparamref name="TEntity"/> instance. 
+        /// Override the default behaviour of mapping retrieved rowsets from the database to a <typeparamref name="TEntity"/> instance. 
         /// </summary>
         /// <typeparam name="TEntity">The type of the entity.</typeparam>
         /// <param name="mapping">The delegate that iterates a field reader and maps the field values to <typeparamref name="TEntity"/> properties.</typeparam>
-        IMapperFactoryContinuationConfigurationBuilder OverrideForEntity<TEntity>(Action<TEntity, ISqlFieldReader> mapping)
+        IMapperFactoryContinuationConfigurationBuilder OverrideForEntity<TEntity>(Action<ISqlFieldReader, TEntity> mapping)
             where TEntity : class, IDbEntity;        
     }
 }

--- a/src/HatTrick.DbEx.Sql/Configuration/_Entities/_Mapping/MapperFactoryConfigurationBuilder.cs
+++ b/src/HatTrick.DbEx.Sql/Configuration/_Entities/_Mapping/MapperFactoryConfigurationBuilder.cs
@@ -63,7 +63,7 @@ namespace HatTrick.DbEx.Sql.Configuration
             return caller;
         }
 
-        public IMapperFactoryContinuationConfigurationBuilder OverrideForEntity<TEntity>(Action<TEntity, ISqlFieldReader> mapping)
+        public IMapperFactoryContinuationConfigurationBuilder OverrideForEntity<TEntity>(Action<ISqlFieldReader, TEntity> mapping)
             where TEntity : class, IDbEntity
         {
             (configuration.EntityFactory as MapperFactory).RegisterEntityMapper(mapping);

--- a/src/HatTrick.DbEx.Sql/Executor/AsyncDataReaderWrapper.cs
+++ b/src/HatTrick.DbEx.Sql/Executor/AsyncDataReaderWrapper.cs
@@ -32,7 +32,7 @@ namespace HatTrick.DbEx.Sql.Executor
         #endregion
 
         #region methods
-        public async Task<ISqlRow> ReadRowAsync()
+        public async Task<ISqlFieldReader> ReadRowAsync()
         {
             CancellationToken.ThrowIfCancellationRequested();
 

--- a/src/HatTrick.DbEx.Sql/Executor/DataReaderWrapper.cs
+++ b/src/HatTrick.DbEx.Sql/Executor/DataReaderWrapper.cs
@@ -25,7 +25,7 @@ namespace HatTrick.DbEx.Sql.Executor
         #endregion
 
         #region methods
-        public ISqlRow ReadRow()
+        public ISqlFieldReader ReadRow()
         {
             try
             {

--- a/src/HatTrick.DbEx.Sql/Executor/IAsyncSqlRowReader.cs
+++ b/src/HatTrick.DbEx.Sql/Executor/IAsyncSqlRowReader.cs
@@ -5,7 +5,7 @@ namespace HatTrick.DbEx.Sql.Executor
 {
     public interface IAsyncSqlRowReader : IDisposable
     {
-        Task<ISqlRow> ReadRowAsync();
+        Task<ISqlFieldReader> ReadRowAsync();
         void Close();
     }
 }

--- a/src/HatTrick.DbEx.Sql/Executor/ISqlFieldReader.cs
+++ b/src/HatTrick.DbEx.Sql/Executor/ISqlFieldReader.cs
@@ -1,7 +1,35 @@
-﻿namespace HatTrick.DbEx.Sql.Executor
+﻿using System.Collections.Generic;
+
+namespace HatTrick.DbEx.Sql.Executor
 {
     public interface ISqlFieldReader
     {
+        /// <summary>
+        /// Get a rowset field and increments the current field index.  The next call to this method would return the next field in the rowset.
+        /// </summary>
+        /// <returns>An <see cref="ISqlField"/> containing the retrieved value and metadata for the field.</returns>
         ISqlField ReadField();
+
+        /// <summary>
+        /// Get a rowset field at the provided index.
+        /// </summary>
+        /// <returns>The <see cref="ISqlField"/> value of the field converted to <typeparamref name="T"/>.</returns>
+        T GetValue<T>(int index);
+
+        /// <summary>
+        /// Get all fields from the rowset.  This method does NOT increment the current index of the reader.
+        /// </summary>
+        /// <returns>An enumerable of <see cref="ISqlField"/>s.</returns>
+        IEnumerable<ISqlField> GetFields();
+
+        /// <summary>
+        /// Gets the total number of fields in the rowset.
+        /// </summary>
+        int FieldCount { get; }
+
+        /// <summary>
+        /// Gets the current index of the reader.  The index value is incremented only through a call to the <see cref="ReadField"/> method.
+        /// </summary>
+        int CurrentFieldIndex { get; }
     }
 }

--- a/src/HatTrick.DbEx.Sql/Executor/ISqlRow.cs
+++ b/src/HatTrick.DbEx.Sql/Executor/ISqlRow.cs
@@ -1,8 +1,0 @@
-﻿namespace HatTrick.DbEx.Sql.Executor
-{
-    public interface ISqlRow : ISqlFieldReader
-    {
-        int FieldCount { get; }
-        int Index { get; }
-    }
-}

--- a/src/HatTrick.DbEx.Sql/Executor/ISqlRowReader.cs
+++ b/src/HatTrick.DbEx.Sql/Executor/ISqlRowReader.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using System.Threading.Tasks;
 
 namespace HatTrick.DbEx.Sql.Executor
 {
     public interface ISqlRowReader : IDisposable
     {
-        ISqlRow ReadRow();
+        ISqlFieldReader ReadRow();
         void Close();
     }
 }

--- a/src/HatTrick.DbEx.Sql/Executor/Row.cs
+++ b/src/HatTrick.DbEx.Sql/Executor/Row.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace HatTrick.DbEx.Sql.Executor
 {
-    public class Row : ISqlRow
+    public class Row : ISqlFieldReader
     {
         #region internals
         private int fieldIndex;
@@ -13,13 +13,14 @@ namespace HatTrick.DbEx.Sql.Executor
         #region interface
         public int Index { get; private set; }
         public int FieldCount => fields.Count;
+        public int CurrentFieldIndex => fieldIndex;
         #endregion
 
         #region constructors
         public Row(int index, IList<ISqlField> fields)
         {
             Index = index;
-            this.fields = fields;
+            this.fields = fields ?? throw new ArgumentNullException($"{nameof(fields)} is required.");
         }
         #endregion
 
@@ -27,13 +28,14 @@ namespace HatTrick.DbEx.Sql.Executor
         public ISqlField ReadField() => fieldIndex >= fields.Count ? null : fields[fieldIndex++];
 
         public T GetValue<T>(int index)
-            where T : IComparable
         {
             var field = fields[index];
             if (field.Value == default)
                 return default;
-            return (T)Convert.ChangeType(field.Value, typeof(T));
+            return field.GetValue<T>();
         }
+
+        public IEnumerable<ISqlField> GetFields() => fields;
         #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/EntityExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/EntityExpression.cs
@@ -7,27 +7,30 @@ namespace HatTrick.DbEx.Sql.Expression
     public abstract class EntityExpression : 
         IEntityExpression,
         AnyEntity,
-        ISqlMetadataIdentifier,
+        ISqlMetadataIdentifierProvider,
         IExpressionProvider<SchemaExpression>,
         IExpressionListProvider<FieldExpression>,
         IExpressionAliasProvider,
+        IExpressionNameProvider,
         IDbEntityTypeProvider,
         IEquatable<EntityExpression>
    {
         #region internals
-        protected readonly Type dbEntityType;
         protected readonly string identifier;
+        protected readonly string name;
+        protected readonly Type dbEntityType;
         protected readonly SchemaExpression schema;
         protected IDictionary<string, FieldExpression> Fields { get; } = new Dictionary<string, FieldExpression>();
         protected readonly string alias;
         #endregion
 
         #region interface
+        string ISqlMetadataIdentifierProvider.Identifier => identifier;
         Type IDbEntityTypeProvider.EntityType => dbEntityType;
-        string ISqlMetadataIdentifier.Identifier => identifier;
         SchemaExpression IExpressionProvider<SchemaExpression>.Expression => schema;
         IList<FieldExpression> IExpressionListProvider<FieldExpression>.Expressions => Fields.Values.ToList();
         string IExpressionAliasProvider.Alias => alias;
+        string IExpressionNameProvider.Name => name;
         #endregion
 
         #region constructors
@@ -36,10 +39,11 @@ namespace HatTrick.DbEx.Sql.Expression
 
         }
         
-        protected EntityExpression(Type dbEntityType, string identifier, SchemaExpression schema, string alias)
+        protected EntityExpression(string identifier, string name, Type dbEntityType, SchemaExpression schema, string alias)
         {
-            this.dbEntityType = dbEntityType ?? throw new ArgumentNullException($"{nameof(dbEntityType)} is required.");
             this.identifier = identifier ?? throw new ArgumentNullException($"{nameof(identifier)} is required.");
+            this.name = name ?? throw new ArgumentNullException($"{nameof(name)} is required.");
+            this.dbEntityType = dbEntityType ?? throw new ArgumentNullException($"{nameof(dbEntityType)} is required.");
             this.schema = schema ?? throw new ArgumentNullException($"{nameof(schema)} is required.");
             this.alias = alias;
         }

--- a/src/HatTrick.DbEx.Sql/Expression/EntityExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/EntityExpression{T}.cs
@@ -9,13 +9,13 @@ namespace HatTrick.DbEx.Sql.Expression
         where T : class, IDbEntity
     {
         #region constructors
-        private EntityExpression() : base(typeof(T), null, null, null)
+        private EntityExpression() : base(null, null, typeof(T), null, null)
         { 
         
         }
 
-        protected EntityExpression(string identifier, SchemaExpression schema, string alias)
-            : base(typeof(T), identifier, schema, alias)
+        protected EntityExpression(string identifier, string name, SchemaExpression schema, string alias)
+            : base(identifier, name, typeof(T), schema, alias)
         {
 
         }
@@ -23,20 +23,23 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region interface
         SelectExpressionSet IEntityExpression<T>.BuildInclusiveSelectExpression()
-            => GetInclusiveSelectExpression();        
+            => GetInclusiveSelectExpression();
+        SelectExpressionSet IEntityExpression<T>.BuildInclusiveSelectExpression(Func<string, string> alias)
+            => GetInclusiveSelectExpression(alias);
         InsertExpressionSet<T> IEntityExpression<T>.BuildInclusiveInsertExpression(T entity)
             => GetInclusiveInsertExpression(entity);
         AssignmentExpressionSet IEntityExpression<T>.BuildAssignmentExpression(T target, T source)
             => GetAssignmentExpression(target, source);
-        void IEntityExpression<T>.HydrateEntity(T entity, ISqlFieldReader reader)
-            => HydrateEntity(entity, reader);
+        void IEntityExpression<T>.HydrateEntity(ISqlFieldReader reader, T entity)
+            => HydrateEntity(reader, entity);
         #endregion
 
         #region methods
         protected abstract SelectExpressionSet GetInclusiveSelectExpression();
+        protected abstract SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias);
         protected abstract InsertExpressionSet<T> GetInclusiveInsertExpression(T entity);
         protected abstract AssignmentExpressionSet GetAssignmentExpression(T from, T to);
-        protected abstract void HydrateEntity(T entity, ISqlFieldReader reader);
+        protected abstract void HydrateEntity(ISqlFieldReader reader, T entity);
         #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/IEntityExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/IEntityExpression{T}.cs
@@ -1,12 +1,14 @@
 ﻿using HatTrick.DbEx.Sql.Executor;
+using System;
 
 namespace HatTrick.DbEx.Sql.Expression
 {
     public interface IEntityExpression<T> : IEntityExpression
     {
         SelectExpressionSet BuildInclusiveSelectExpression();
+        SelectExpressionSet BuildInclusiveSelectExpression(Func<string, string> alias);
         InsertExpressionSet<T> BuildInclusiveInsertExpression(T entity);
         AssignmentExpressionSet BuildAssignmentExpression(T from, T to);
-        void HydrateEntity(T entity, ISqlFieldReader reader);
+        void HydrateEntity(ISqlFieldReader reader, T entity);
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/IExpressionNameProvider.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/IExpressionNameProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace HatTrick.DbEx.Sql.Expression
+{
+    public interface IExpressionNameProvider
+    {
+        string Name { get; }
+    }
+}

--- a/src/HatTrick.DbEx.Sql/Expression/SchemaExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/SchemaExpression.cs
@@ -6,7 +6,7 @@ namespace HatTrick.DbEx.Sql.Expression
 {
     public abstract class SchemaExpression : 
         IExpressionElement,
-        ISqlMetadataIdentifier,
+        ISqlMetadataIdentifierProvider,
         IExpressionListProvider<EntityExpression>,
         IEquatable<SchemaExpression>
     {

--- a/src/HatTrick.DbEx.Sql/Expression/SelectExpressionSet.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/SelectExpressionSet.cs
@@ -13,14 +13,14 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region constructor
-        internal SelectExpressionSet()
+        private SelectExpressionSet()
         {
 
         }
 
         public SelectExpressionSet(params SelectExpression[] expressions)
         {
-            Expressions = expressions.ToList();
+            Expressions = (expressions ?? throw new ArgumentNullException($"{nameof(expressions)} is required")).ToList();
         }
 
         public SelectExpressionSet(SelectExpression selectExpression)

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/BooleanFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/BooleanFieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<BooleanFieldExpression>
     {
         #region constructors
-        protected BooleanFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(bool), entity)
-        {
-
-        }
-
-        protected BooleanFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(bool), entity, alias)
+        protected BooleanFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, typeof(bool), entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/BooleanFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/BooleanFieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public BooleanFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected BooleanFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public BooleanFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override BooleanElement As(string alias)
-            => new BooleanFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new BooleanSelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/ByteArrayFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/ByteArrayFieldExpression.cs
@@ -9,11 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<ByteArrayFieldExpression>
     {
         #region constructors
-        protected ByteArrayFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(byte[]), entity)
-        {
-        }
-
-        protected ByteArrayFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(byte[]), entity, alias)
+        protected ByteArrayFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, typeof(byte[]), entity)
         {
         }
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/ByteArrayFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/ByteArrayFieldExpression{T}.cs
@@ -8,18 +8,15 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public ByteArrayFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
+        public ByteArrayFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
-        }
 
-        protected ByteArrayFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
-        {
         }
         #endregion
 
         #region as
         public override ByteArrayElement As(string alias)
-            => new ByteArrayFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new ByteArraySelectExpression(this).As(alias);
         #endregion
 
         #region in value set

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/ByteFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/ByteFieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<ByteFieldExpression>
     {
         #region constructors
-        protected ByteFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(string), entity)
-        {
-
-        }
-
-        protected ByteFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(string), entity, alias)
+        protected ByteFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, typeof(string), entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/ByteFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/ByteFieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public ByteFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected ByteFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public ByteFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override ByteElement As(string alias)
-            => new ByteFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new ByteSelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/DateTimeFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/DateTimeFieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<DateTimeFieldExpression>
     {
         #region constructors
-        protected DateTimeFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(DateTime), entity)
-        {
-
-        }
-
-        protected DateTimeFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(DateTime), entity, alias)
+        protected DateTimeFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, typeof(DateTime), entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/DateTimeFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/DateTimeFieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public DateTimeFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected DateTimeFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public DateTimeFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override DateTimeElement As(string alias)
-            => new DateTimeFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new DateTimeSelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/DateTimeOffsetFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/DateTimeOffsetFieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<DateTimeOffsetFieldExpression>
     {
         #region constructors
-        protected DateTimeOffsetFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(DateTimeOffset), entity)
-        {
-
-        }
-
-        protected DateTimeOffsetFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(DateTimeOffset), entity, alias)
+        protected DateTimeOffsetFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, typeof(DateTimeOffset), entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/DateTimeOffsetFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/DateTimeOffsetFieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public DateTimeOffsetFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected DateTimeOffsetFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public DateTimeOffsetFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override DateTimeOffsetElement As(string alias)
-            => new DateTimeOffsetFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new DateTimeOffsetSelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/DecimalFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/DecimalFieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<DecimalFieldExpression>
     {
         #region constructors
-        protected DecimalFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(decimal), entity)
-        {
-
-        }
-
-        protected DecimalFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(decimal), entity, alias)
+        protected DecimalFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, typeof(decimal), entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/DecimalFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/DecimalFieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public DecimalFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected DecimalFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public DecimalFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override DecimalElement As(string alias)
-            => new DecimalFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new DecimalSelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/DoubleFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/DoubleFieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<DoubleFieldExpression>
     {
         #region constructors
-        protected DoubleFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(double), entity)
-        {
-
-        }
-
-        protected DoubleFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(double), entity, alias)
+        protected DoubleFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, typeof(double), entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/DoubleFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/DoubleFieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public DoubleFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected DoubleFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public DoubleFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override DoubleElement As(string alias)
-            => new DoubleFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new DoubleSelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/EnumFieldExpression{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/EnumFieldExpression{T,U}.cs
@@ -9,11 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEnum : struct, Enum, IComparable
     {
         #region constructors
-        public EnumFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(TEnum), entity)
-        {
-        }
-
-        protected EnumFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(TEnum), entity, alias)
+        public EnumFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, typeof(TEnum), entity)
         {
 
         }
@@ -21,7 +17,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override EnumElement<TEnum> As(string alias)
-            => new EnumFieldExpression<TEntity, TEnum>(base.identifier, base.entity, alias);
+            => new EnumSelectExpression<TEnum>(this).As(alias);
         #endregion
 
         #region in value set

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/EnumFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/EnumFieldExpression{T}.cs
@@ -9,11 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEnum : struct, Enum, IComparable
     {
         #region constructors
-        protected EnumFieldExpression(string identifier, Type declaredType, EntityExpression entity) : base(identifier, declaredType, entity)
-        {
-        }
-
-        protected EnumFieldExpression(string identifier, Type declaredType, EntityExpression entity, string alias) : base(identifier, declaredType, entity, alias)
+        protected EnumFieldExpression(string identifier, string name, Type declaredType, EntityExpression entity) : base(identifier, name, declaredType, entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/FieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/FieldExpression.cs
@@ -7,46 +7,37 @@ namespace HatTrick.DbEx.Sql.Expression
         AnyOrderByClause,
         AnyGroupByClause,
         IExpressionTypeProvider,
-        ISqlMetadataIdentifier,
+        ISqlMetadataIdentifierProvider,
+        IExpressionNameProvider,
         IExpressionProvider<EntityExpression>,
         IEquatable<FieldExpression>
     {
         #region internals
         protected readonly string identifier;
         protected readonly Type declaredType;
+        protected readonly string name;
         protected readonly EntityExpression entity;
-        protected readonly string alias;
         #endregion
 
         #region interface
-        string ISqlMetadataIdentifier.Identifier => identifier;
+        string ISqlMetadataIdentifierProvider.Identifier => identifier;
+        string IExpressionNameProvider.Name => name;
         Type IExpressionTypeProvider.DeclaredType => declaredType;
         EntityExpression IExpressionProvider<EntityExpression>.Expression => entity;
         #endregion
 
         #region constructors
-        protected FieldExpression(string identifier, Type declaredType, EntityExpression entity) : this(identifier, declaredType, entity, null)
-        {
-        }
-
-        protected FieldExpression(string identifier, Type declaredType, EntityExpression entity, string alias)
+        protected FieldExpression(string identifier, string name, Type declaredType, EntityExpression entity)
         {
             this.identifier = identifier ?? throw new ArgumentNullException($"{nameof(identifier)} is required.");
+            this.name = name ?? throw new ArgumentNullException($"{nameof(name)} is required.");
             this.declaredType = declaredType ?? throw new ArgumentNullException($"{nameof(declaredType)} is required.");
             this.entity = entity ?? throw new ArgumentNullException($"{nameof(entity)} is required.");
         }
         #endregion
 
         #region to string
-        public override string ToString() => this.ToString(false);
-
-        public string ToString(bool ignoreAlias = false)
-        {
-            if (ignoreAlias || string.IsNullOrWhiteSpace(alias))
-                return identifier;
-
-            return $"{identifier} AS {alias}";
-        }
+        public override string ToString() => identifier;
         #endregion
 
         #region order

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/FieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/FieldExpression{T}.cs
@@ -7,12 +7,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IExpressionElement<TValue>
     {
         #region constructors
-        protected FieldExpression(string identifier, Type declaredType, EntityExpression entity) : base(identifier, declaredType, entity)
-        {
-
-        }
-
-        protected FieldExpression(string identifier, Type declaredType, EntityExpression entity, string alias) : base(identifier, declaredType, entity, alias)
+        protected FieldExpression(string identifier, string name, Type declaredType, EntityExpression entity) : base(identifier, name, declaredType, entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/GuidFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/GuidFieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<GuidFieldExpression>
     {
         #region constructors
-        protected GuidFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(Guid), entity)
-        {
-
-        }
-
-        protected GuidFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(Guid), entity, alias)
+        protected GuidFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, typeof(Guid), entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/GuidFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/GuidFieldExpression{T}.cs
@@ -8,20 +8,15 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public GuidFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected GuidFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public GuidFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
         #endregion
 
         #region as
-        public override GuidElement As(string alias)
-            => new GuidFieldExpression<TEntity>(base.identifier, base.entity, alias);
+        public override GuidElement As(string alias) 
+            => new GuidSelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/Int16FieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/Int16FieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<Int16FieldExpression>
     {
         #region constructors
-        protected Int16FieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(short), entity)
-        {
-
-        }
-
-        protected Int16FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(short), entity, alias)
+        protected Int16FieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, typeof(short), entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/Int16FieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/Int16FieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public Int16FieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected Int16FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public Int16FieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override Int16Element As(string alias)
-            => new Int16FieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new Int16SelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/Int32FieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/Int32FieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<Int32FieldExpression>
     {
         #region constructors
-        protected Int32FieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(int), entity)
-        {
-
-        }
-
-        protected Int32FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(int), entity, alias)
+        protected Int32FieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, typeof(int), entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/Int32FieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/Int32FieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public Int32FieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected Int32FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public Int32FieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override Int32Element As(string alias)
-            => new Int32FieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new Int32SelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/Int64FieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/Int64FieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<Int64FieldExpression>
     {
         #region constructors
-        protected Int64FieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(long), entity)
-        {
-
-        }
-
-        protected Int64FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(long), entity, alias)
+        protected Int64FieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, typeof(long), entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/Int64FieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/Int64FieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public Int64FieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected Int64FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public Int64FieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override Int64Element As(string alias)
-            => new Int64FieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new Int64SelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableBooleanFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableBooleanFieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableBooleanFieldExpression>
     {
         #region constructors
-        protected NullableBooleanFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableBooleanFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableBooleanFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableBooleanFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableBooleanFieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public NullableBooleanFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableBooleanFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public NullableBooleanFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override NullableBooleanElement As(string alias)
-            => new NullableBooleanFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new NullableBooleanSelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableByteArrayFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableByteArrayFieldExpression.cs
@@ -10,12 +10,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableByteArrayFieldExpression>
     {
         #region constructors
-        protected NullableByteArrayFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(byte[]), entity)
-        {
-
-        }
-
-        protected NullableByteArrayFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(byte[]), entity, alias)
+        protected NullableByteArrayFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, typeof(byte[]), entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableByteArrayFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableByteArrayFieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public NullableByteArrayFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableByteArrayFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public NullableByteArrayFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override NullableByteArrayElement As(string alias)
-            => new NullableByteArrayFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new NullableByteArraySelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableByteFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableByteFieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableByteFieldExpression>
     {
         #region constructors
-        protected NullableByteFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableByteFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableByteFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableByteFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableByteFieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public NullableByteFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableByteFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public NullableByteFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override NullableByteElement As(string alias)
-            => new NullableByteFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new NullableByteSelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDateTimeFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDateTimeFieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableDateTimeFieldExpression>
     {
         #region constructors
-        protected NullableDateTimeFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableDateTimeFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableDateTimeFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDateTimeFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDateTimeFieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public NullableDateTimeFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableDateTimeFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public NullableDateTimeFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override NullableDateTimeElement As(string alias)
-            => new NullableDateTimeFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new NullableDateTimeSelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDateTimeOffsetFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDateTimeOffsetFieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableDateTimeOffsetFieldExpression>
     {
         #region constructors
-        protected NullableDateTimeOffsetFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableDateTimeOffsetFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableDateTimeOffsetFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDateTimeOffsetFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDateTimeOffsetFieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public NullableDateTimeOffsetFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableDateTimeOffsetFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public NullableDateTimeOffsetFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override NullableDateTimeOffsetElement As(string alias)
-            => new NullableDateTimeOffsetFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new NullableDateTimeOffsetSelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDecimalFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDecimalFieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableDecimalFieldExpression>
     {
         #region constructors
-        protected NullableDecimalFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableDecimalFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableDecimalFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDecimalFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDecimalFieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public NullableDecimalFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableDecimalFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public NullableDecimalFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override NullableDecimalElement As(string alias)
-            => new NullableDecimalFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new NullableDecimalSelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDoubleFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDoubleFieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableDoubleFieldExpression>
     {
         #region constructors
-        protected NullableDoubleFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableDoubleFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableDoubleFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDoubleFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDoubleFieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public NullableDoubleFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableDoubleFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public NullableDoubleFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override NullableDoubleElement As(string alias)
-            => new NullableDoubleFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new NullableDoubleSelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableEnumFieldExpression{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableEnumFieldExpression{T,U}.cs
@@ -8,18 +8,16 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
         where TEnum : struct, Enum, IComparable
     {
-        public NullableEnumFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-        }
-
-        protected NullableEnumFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        #region constructors
+        public NullableEnumFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
+        #endregion
 
         #region as
         public override NullableEnumElement<TEnum> As(string alias)
-            => new NullableEnumFieldExpression<TEntity, TEnum>(base.identifier, base.entity, alias);
+            => new NullableEnumSelectExpression<TEnum>(this).As(alias);
         #endregion
 
         #region in value set

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableEnumFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableEnumFieldExpression{T}.cs
@@ -11,11 +11,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEnum : struct, Enum, IComparable
     {
         #region constructors
-        protected NullableEnumFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-        }
-
-        protected NullableEnumFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableEnumFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableFieldExpression{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableFieldExpression{T,U}.cs
@@ -7,12 +7,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IExpressionElement<TValue,TNullableValue>
     {
         #region constructors
-        protected NullableFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(TNullableValue), entity)
-        {
-
-        }
-
-        protected NullableFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(TNullableValue), entity, alias)
+        protected NullableFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, typeof(TNullableValue), entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableGuidFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableGuidFieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableGuidFieldExpression>
     {
         #region constructors
-        protected NullableGuidFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableGuidFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableGuidFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableGuidFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableGuidFieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public NullableGuidFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableGuidFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public NullableGuidFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override NullableGuidElement As(string alias)
-            => new NullableGuidFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new NullableGuidSelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt16FieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt16FieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableInt16FieldExpression>
     {
         #region constructors
-        protected NullableInt16FieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableInt16FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableInt16FieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt16FieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt16FieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public NullableInt16FieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableInt16FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public NullableInt16FieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override NullableInt16Element As(string alias)
-            => new NullableInt16FieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new NullableInt16SelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt32FieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt32FieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableInt32FieldExpression>
     {
         #region constructors
-        protected NullableInt32FieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableInt32FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableInt32FieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt32FieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt32FieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public NullableInt32FieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableInt32FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public NullableInt32FieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override NullableInt32Element As(string alias)
-            => new NullableInt32FieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new NullableInt32SelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt64FieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt64FieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableInt64FieldExpression>
     {
         #region constructors
-        protected NullableInt64FieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableInt64FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableInt64FieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt64FieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt64FieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public NullableInt64FieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableInt64FieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public NullableInt64FieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override NullableInt64Element As(string alias)
-            => new NullableInt64FieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new NullableInt64SelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableSingleFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableSingleFieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableSingleFieldExpression>
     {
         #region constructors
-        protected NullableSingleFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableSingleFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableSingleFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name,  entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableSingleFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableSingleFieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public NullableSingleFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableSingleFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public NullableSingleFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override NullableSingleElement As(string alias)
-            => new NullableSingleFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new NullableSingleSelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableStringFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableStringFieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableStringFieldExpression>
     {
         #region constructors
-        protected NullableStringFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(string), entity)
-        {
-
-        }
-
-        protected NullableStringFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(string), entity, alias)
+        protected NullableStringFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, typeof(string), entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableStringFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableStringFieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public NullableStringFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableStringFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public NullableStringFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override NullableStringElement As(string alias)
-            => new NullableStringFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new NullableStringSelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableTimeSpanFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableTimeSpanFieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<NullableTimeSpanFieldExpression>
     {
         #region constructors
-        protected NullableTimeSpanFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableTimeSpanFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        protected NullableTimeSpanFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableTimeSpanFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableTimeSpanFieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public NullableTimeSpanFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected NullableTimeSpanFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public NullableTimeSpanFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override NullableTimeSpanElement As(string alias)
-            => new NullableTimeSpanFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new NullableTimeSpanSelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/SingleFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/SingleFieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<SingleFieldExpression>
     {
         #region constructors
-        protected SingleFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(float), entity)
-        {
-
-        }
-
-        protected SingleFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(float), entity, alias)
+        protected SingleFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, typeof(float), entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/SingleFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/SingleFieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public SingleFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected SingleFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public SingleFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override SingleElement As(string alias)
-            => new SingleFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new SingleSelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/StringFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/StringFieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<StringFieldExpression>
     {
         #region constructors
-        protected StringFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(string), entity)
-        {
-
-        }
-
-        protected StringFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(string), entity, alias)
+        protected StringFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, typeof(string), entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/StringFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/StringFieldExpression{T}.cs
@@ -13,12 +13,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region constructors
-        public StringFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected StringFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public StringFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -26,7 +21,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override StringElement As(string alias)
-            => new StringFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new StringSelectExpression(this).As(alias);
         #endregion
 
         #region like

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/TimeSpanFieldExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/TimeSpanFieldExpression.cs
@@ -9,12 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         IEquatable<TimeSpanFieldExpression>
     {
         #region constructors
-        protected TimeSpanFieldExpression(string identifier, EntityExpression entity) : base(identifier, typeof(TimeSpan), entity)
-        {
-
-        }
-
-        protected TimeSpanFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, typeof(TimeSpan), entity, alias)
+        protected TimeSpanFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, typeof(TimeSpan), entity)
         {
 
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/TimeSpanFieldExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/TimeSpanFieldExpression{T}.cs
@@ -8,12 +8,7 @@ namespace HatTrick.DbEx.Sql.Expression
         where TEntity : class, IDbEntity
     {
         #region constructors
-        public TimeSpanFieldExpression(string identifier, EntityExpression entity) : base(identifier, entity)
-        {
-
-        }
-
-        protected TimeSpanFieldExpression(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+        public TimeSpanFieldExpression(string identifier, string name, EntityExpression entity) : base(identifier, name, entity)
         {
 
         }
@@ -21,7 +16,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         #region as
         public override TimeSpanElement As(string alias)
-            => new TimeSpanFieldExpression<TEntity>(base.identifier, base.entity, alias);
+            => new TimeSpanSelectExpression(this).As(alias);
         #endregion
 
         #region equals

--- a/src/HatTrick.DbEx.Sql/Expression/_Select/SelectExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Select/SelectExpression.cs
@@ -24,7 +24,7 @@ namespace HatTrick.DbEx.Sql.Expression
 
         }
 
-        protected SelectExpression(IExpressionElement expression, string alias)
+        public SelectExpression(IExpressionElement expression, string alias)
         {
             Expression = expression ?? throw new ArgumentNullException($"{nameof(expression)} is required");
             this.Alias = alias;

--- a/src/HatTrick.DbEx.Sql/Expression/_Select/SelectExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Select/SelectExpression{T}.cs
@@ -9,6 +9,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #region constructors
         public SelectExpression(IExpressionElement expression) : base(expression)
         {
+
         }
         #endregion
 

--- a/src/HatTrick.DbEx.Sql/ISqlFieldMetadata.cs
+++ b/src/HatTrick.DbEx.Sql/ISqlFieldMetadata.cs
@@ -1,11 +1,4 @@
-﻿using HatTrick.DbEx.Sql.Expression;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace HatTrick.DbEx.Sql
+﻿namespace HatTrick.DbEx.Sql
 {
     public interface ISqlFieldMetadata : ISqlMetadata
     {

--- a/src/HatTrick.DbEx.Sql/ISqlMetadata.cs
+++ b/src/HatTrick.DbEx.Sql/ISqlMetadata.cs
@@ -1,6 +1,6 @@
 ﻿namespace HatTrick.DbEx.Sql
 {
-    public interface ISqlMetadata : ISqlMetadataIdentifier, ISqlMetadataName
+    public interface ISqlMetadata : ISqlMetadataIdentifierProvider, ISqlMetadataNameProvider
     {
     }
 }

--- a/src/HatTrick.DbEx.Sql/ISqlMetadataIdentifier.cs
+++ b/src/HatTrick.DbEx.Sql/ISqlMetadataIdentifier.cs
@@ -1,8 +1,0 @@
-﻿namespace HatTrick.DbEx.Sql
-{
-    public interface ISqlMetadataIdentifier
-    { 
-        string Identifier { get; }
-    
-    }
-}

--- a/src/HatTrick.DbEx.Sql/ISqlMetadataIdentifierProvider.cs
+++ b/src/HatTrick.DbEx.Sql/ISqlMetadataIdentifierProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace HatTrick.DbEx.Sql
+{
+    public interface ISqlMetadataIdentifierProvider
+    { 
+        string Identifier { get; }    
+    }
+}

--- a/src/HatTrick.DbEx.Sql/ISqlMetadataNameProvider.cs
+++ b/src/HatTrick.DbEx.Sql/ISqlMetadataNameProvider.cs
@@ -1,8 +1,7 @@
 ﻿namespace HatTrick.DbEx.Sql
 {
-    public interface ISqlMetadataName
+    public interface ISqlMetadataNameProvider
     {
         string Name { get; }
-
     }
 }

--- a/src/HatTrick.DbEx.Sql/Mapper/DelegateMapperFactory.cs
+++ b/src/HatTrick.DbEx.Sql/Mapper/DelegateMapperFactory.cs
@@ -1,5 +1,4 @@
-﻿using HatTrick.DbEx.Sql.Executor;
-using HatTrick.DbEx.Sql.Expression;
+﻿using HatTrick.DbEx.Sql.Expression;
 using System;
 
 namespace HatTrick.DbEx.Sql.Mapper
@@ -20,7 +19,7 @@ namespace HatTrick.DbEx.Sql.Mapper
         #endregion
 
         #region methods
-        public IEntityMapper<TEntity> CreateEntityMapper<TEntity>(EntityExpression<TEntity> entity)
+        public IEntityMapper<TEntity> CreateEntityMapper<TEntity>(IEntityExpression<TEntity> entity)
             where TEntity : class, IDbEntity
         {
             var mapper = entityMapperFactory(typeof(TEntity));

--- a/src/HatTrick.DbEx.Sql/Mapper/EntityMapper{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Mapper/EntityMapper{T}.cs
@@ -6,13 +6,13 @@ namespace HatTrick.DbEx.Sql.Mapper
     public class EntityMapper<T> : IEntityMapper<T>
         where T : class, IDbEntity
     {
-        Action<T, ISqlFieldReader> map;
+        Action<ISqlFieldReader, T> map;
 
-        Action<T, ISqlFieldReader> IEntityMapper<T>.Map => map;
+        Action<ISqlFieldReader, T> IEntityMapper<T>.Map => map;
 
-        public Action<IDbEntity, ISqlFieldReader> Map => (entity, reader) => map(entity as T, reader);
+        public Action<ISqlFieldReader, IDbEntity> Map => (reader, entity) => map(reader, entity as T);
 
-        public EntityMapper(Action<T, ISqlFieldReader> map)
+        public EntityMapper(Action<ISqlFieldReader, T> map)
         {
             this.map = map ?? throw new ArgumentNullException($"{nameof(map)} is required.");
         }

--- a/src/HatTrick.DbEx.Sql/Mapper/ExpandoObjectMapper.cs
+++ b/src/HatTrick.DbEx.Sql/Mapper/ExpandoObjectMapper.cs
@@ -7,11 +7,11 @@ namespace HatTrick.DbEx.Sql.Mapper
 {
     public class ExpandoObjectMapper : IExpandoObjectMapper
     {
-        public void Map(ExpandoObject expandoObject, ISqlRow row, IValueConverterFinder finder)
+        public void Map(ExpandoObject expandoObject, ISqlFieldReader reader, IValueConverterFinder finder)
         {
             var expando = expandoObject as IDictionary<string, object>;
             ISqlField field;
-            while ((field = row.ReadField()) is object)
+            while ((field = reader.ReadField()) is object)
             {
                 if (string.IsNullOrWhiteSpace(field.Name))
                 {

--- a/src/HatTrick.DbEx.Sql/Mapper/IEntityMapper.cs
+++ b/src/HatTrick.DbEx.Sql/Mapper/IEntityMapper.cs
@@ -5,6 +5,6 @@ namespace HatTrick.DbEx.Sql.Mapper
 {
     public interface IEntityMapper : IMapper 
     {
-        Action<IDbEntity, ISqlFieldReader> Map { get; }
+        Action<ISqlFieldReader, IDbEntity> Map { get; }
     }
 }

--- a/src/HatTrick.DbEx.Sql/Mapper/IEntityMapper{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Mapper/IEntityMapper{T}.cs
@@ -6,6 +6,6 @@ namespace HatTrick.DbEx.Sql.Mapper
     public interface IEntityMapper<T> : IEntityMapper
         where T : class, IDbEntity
     {
-        new Action<T, ISqlFieldReader> Map { get; }
+        new Action<ISqlFieldReader, T> Map { get; }
     }
 }

--- a/src/HatTrick.DbEx.Sql/Mapper/IExpandoObjectMapper.cs
+++ b/src/HatTrick.DbEx.Sql/Mapper/IExpandoObjectMapper.cs
@@ -5,6 +5,6 @@ namespace HatTrick.DbEx.Sql.Mapper
 {
     public interface IExpandoObjectMapper : IMapper
     {
-        void Map(ExpandoObject xpando, ISqlRow row, IValueConverterFinder finder);
+        void Map(ExpandoObject xpando, ISqlFieldReader reader, IValueConverterFinder finder);
     }
 }

--- a/src/HatTrick.DbEx.Sql/Mapper/IMapperFactory.cs
+++ b/src/HatTrick.DbEx.Sql/Mapper/IMapperFactory.cs
@@ -6,7 +6,7 @@ namespace HatTrick.DbEx.Sql.Mapper
 {
     public interface IMapperFactory
     {
-        IEntityMapper<TEntity> CreateEntityMapper<TEntity>(EntityExpression<TEntity> entity)
+        IEntityMapper<TEntity> CreateEntityMapper<TEntity>(IEntityExpression<TEntity> entity)
             where TEntity : class, IDbEntity;
         IExpandoObjectMapper CreateExpandoObjectMapper();
     }

--- a/src/HatTrick.DbEx.Sql/Mapper/MapperFactory.cs
+++ b/src/HatTrick.DbEx.Sql/Mapper/MapperFactory.cs
@@ -12,7 +12,7 @@ namespace HatTrick.DbEx.Sql.Mapper
         #endregion
 
         #region methods
-        public void RegisterEntityMapper<TEntity>(Action<TEntity, ISqlFieldReader> converter)
+        public void RegisterEntityMapper<TEntity>(Action<ISqlFieldReader, TEntity> converter)
             where TEntity : class, IDbEntity
         {
             if (converter is null)
@@ -21,13 +21,13 @@ namespace HatTrick.DbEx.Sql.Mapper
             entityMappers.AddOrUpdate(typeof(TEntity), () => new EntityMapper<TEntity>(converter), (t, f) => () => new EntityMapper<TEntity>(converter));
         }
 
-        public IEntityMapper<TEntity> CreateEntityMapper<TEntity>(EntityExpression<TEntity> entity)
+        public IEntityMapper<TEntity> CreateEntityMapper<TEntity>(IEntityExpression<TEntity> entity)
             where TEntity : class, IDbEntity
         {
             if (entityMappers.TryGetValue(typeof(TEntity), out Func<IMapper> map))
                 return map() as IEntityMapper<TEntity>;
 
-            var entityMap = new EntityMapper<TEntity>((entity as IEntityExpression<TEntity>).HydrateEntity);
+            var entityMap = new EntityMapper<TEntity>(entity.HydrateEntity);
             entityMappers.TryAdd(typeof(TEntity), () => entityMap);
 
             return entityMap;

--- a/src/HatTrick.DbEx.Sql/Pipeline/ISelectQueryExpressionExecutionPipeline.cs
+++ b/src/HatTrick.DbEx.Sql/Pipeline/ISelectQueryExpressionExecutionPipeline.cs
@@ -2,9 +2,8 @@
 using HatTrick.DbEx.Sql.Executor;
 using HatTrick.DbEx.Sql.Expression;
 using System;
-using System.Data;
 using System.Collections.Generic;
-using System.Data.Common;
+using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,33 +11,115 @@ namespace HatTrick.DbEx.Sql.Pipeline
 {
     public interface ISelectQueryExpressionExecutionPipeline
     {
+        #region entity
         T ExecuteSelectEntity<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand)
             where T : class, IDbEntity, new();
+
+        T ExecuteSelectEntity<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, T> map)
+            where T : class, IDbEntity, new();
+
+        void ExecuteSelectEntity<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader> read)
+            where T : class, IDbEntity, new();
+
+        T ExecuteSelectEntity<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader, T> map)
+            where T : class, IDbEntity, new();
+
         Task<T> ExecuteSelectEntityAsync<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken ct)
             where T : class, IDbEntity, new();
 
+        Task ExecuteSelectEntityAsync<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader> read, CancellationToken ct)
+            where T : class, IDbEntity, new();
+
+        Task<T> ExecuteSelectEntityAsync<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader, T> map, CancellationToken ct)
+            where T : class, IDbEntity, new();
+
+        Task<T> ExecuteSelectEntityAsync<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, T> map, CancellationToken ct)
+            where T : class, IDbEntity, new();
+
+        Task ExecuteSelectEntityAsync<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, Task> read, CancellationToken ct)
+            where T : class, IDbEntity, new();
+
+        Task<T> ExecuteSelectEntityAsync<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, T, Task> map, CancellationToken ct)
+            where T : class, IDbEntity, new();
+        #endregion
+
+        #region entity list
         IList<T> ExecuteSelectEntityList<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand)
             where T : class, IDbEntity, new();
+
+        IList<T> ExecuteSelectEntityList<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, T> map)
+            where T : class, IDbEntity, new();
+
+        void ExecuteSelectEntityList<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader> read)
+            where T : class, IDbEntity, new();
+
+        IList<T> ExecuteSelectEntityList<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader, T> map)
+            where T : class, IDbEntity, new();
+
         Task<IList<T>> ExecuteSelectEntityListAsync<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken ct)
             where T : class, IDbEntity, new();
 
+        Task ExecuteSelectEntityListAsync<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader> read, CancellationToken ct)
+            where T : class, IDbEntity, new();
+
+        Task<IList<T>> ExecuteSelectEntityListAsync<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader, T> map, CancellationToken ct)
+            where T : class, IDbEntity, new();
+
+        Task<IList<T>> ExecuteSelectEntityListAsync<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, T> map, CancellationToken ct)
+            where T : class, IDbEntity, new();
+
+        Task ExecuteSelectEntityListAsync<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, Task> read, CancellationToken ct)
+            where T : class, IDbEntity, new();
+
+        Task<IList<T>> ExecuteSelectEntityListAsync<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, T, Task> map, CancellationToken ct)
+            where T : class, IDbEntity, new();
+        #endregion
+
+        #region value
         T ExecuteSelectValue<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand);
+
         Task<T> ExecuteSelectValueAsync<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken ct);
+        #endregion
 
+        #region value list
         IList<T> ExecuteSelectValueList<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand);
+        void ExecuteSelectValueList(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<object> read);
+
         Task<IList<T>> ExecuteSelectValueListAsync<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken ct);
+        Task ExecuteSelectValueListAsync(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<object> read, CancellationToken ct);
+        Task ExecuteSelectValueListAsync(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<object, Task> read, CancellationToken ct);
+        #endregion
 
+        #region dynamic
         dynamic ExecuteSelectDynamic(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand);
+        void ExecuteSelectDynamic(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader> read);
+
         Task<dynamic> ExecuteSelectDynamicAsync(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken ct);
+        Task ExecuteSelectDynamicAsync(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader> read, CancellationToken ct);
+        Task ExecuteSelectDynamicAsync(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, Task> read, CancellationToken ct);
+        #endregion
 
+        #region dynamic list
         IList<dynamic> ExecuteSelectDynamicList(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand);
+        void ExecuteSelectDynamicList(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader> read);
+
         Task<IList<dynamic>> ExecuteSelectDynamicListAsync(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken ct);
+        Task ExecuteSelectDynamicListAsync(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader> read, CancellationToken ct);
+        Task ExecuteSelectDynamicListAsync(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, Task> read, CancellationToken ct);
+        #endregion
 
-        T ExecuteSelectObject<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlRow, T> map);
-        Task<T> ExecuteSelectObjectAsync<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlRow, T> map, CancellationToken ct);
+        #region object
+        T ExecuteSelectObject<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, T> map);
 
+        Task<T> ExecuteSelectObjectAsync<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, T> map, CancellationToken ct);
+        Task<T> ExecuteSelectObjectAsync<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, Task<T>> map, CancellationToken ct);
+        #endregion
 
-        IList<T> ExecuteSelectObjectList<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlRow, T> map);
-        Task<IList<T>> ExecuteSelectObjectListAsync<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlRow, T> map, CancellationToken ct);
+        #region object list
+        IList<T> ExecuteSelectObjectList<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, T> map);
+
+        Task<IList<T>> ExecuteSelectObjectListAsync<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, T> map, CancellationToken ct);
+        Task<IList<T>> ExecuteSelectObjectListAsync<T>(SelectQueryExpression expression, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, Task<T>> map, CancellationToken ct);
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Pipeline/InsertQueryExpressionExecutionPipeline{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Pipeline/InsertQueryExpressionExecutionPipeline{T}.cs
@@ -77,9 +77,9 @@ namespace HatTrick.DbEx.Sql.Pipeline
                 cmd => afterExecution?.Invoke(new Lazy<AfterExecutionPipelineExecutionContext>(() => new AfterExecutionPipelineExecutionContext(database, expression, cmd)))
             );
 
-            var mapper = database.MapperFactory.CreateEntityMapper(expression.BaseEntity as EntityExpression<T>);
+            var mapper = database.MapperFactory.CreateEntityMapper(expression.BaseEntity as IEntityExpression<T>);
 
-            ISqlRow row;
+            ISqlFieldReader row;
             while ((row = reader.ReadRow()) is object)
             {
                 var index = 0;
@@ -92,7 +92,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
                     throw new DbExpressionException("Expected the execution of the insert statement to return a reader where the first field in the reader is an integer used to locate the in-memory entity for hydrating values.", e);
                 }
                 var entity = expression.Inserts.Single(x => x.Key == Convert.ToInt32(index)).Value.Entity;
-                mapper.Map(entity as T, row);
+                mapper.Map(row, entity as T);
             }
 
             if (afterInsert is object)
@@ -154,9 +154,9 @@ namespace HatTrick.DbEx.Sql.Pipeline
 
             ct.ThrowIfCancellationRequested();
 
-            var mapper = database.MapperFactory.CreateEntityMapper(expression.BaseEntity as EntityExpression<T>);
+            var mapper = database.MapperFactory.CreateEntityMapper(expression.BaseEntity as IEntityExpression<T>);
 
-            ISqlRow row;
+            ISqlFieldReader row;
             while ((row = await reader.ReadRowAsync().ConfigureAwait(false)) is object)
             {
                 var index = 0;
@@ -169,7 +169,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
                     throw new DbExpressionException("Expected the execution of the insert statement to return a reader where the first field in the reader is an integer used to locate the in-memory entity for hydrating values.", e);
                 }
                 var entity = expression.Inserts.Single(x => x.Key == Convert.ToInt32(index)).Value.Entity;
-                mapper.Map(entity as T, row);
+                mapper.Map(row, entity as T);
             }
 
             if (afterInsert is object)

--- a/src/HatTrick.DbEx.Sql/_Extensions/_Builder/SqlExpressionBuilderExtensions.cs
+++ b/src/HatTrick.DbEx.Sql/_Extensions/_Builder/SqlExpressionBuilderExtensions.cs
@@ -18,1404 +18,3488 @@ namespace HatTrick.DbEx.Sql
         #region builder termination
         #region InsertTerminationExpressionBuilder
         /// <summary>
-        /// Execute a sql INSERT query expression as a sql statement to insert <typeparamref name="TEntity"/> entities.
+        /// Assemble and execute a INSERT query to insert <typeparamref name="TEntity"/> entities.
         /// </summary>
         /// <remarks>The inserted entities will be hydrated with any values controlled by the database; for example identity columns, computed columns, defaults where a field was ommitted from the statement.</remarks>
         public static void Execute<TEntity>(this IInsertTerminationExpressionBuilder<TEntity> builder)
             where TEntity : class, IDbEntity
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                builder.ExecutePipeline(connection, null);
+                builder.ExecutePipeline(
+                    connection, 
+                    null
+                );
         }
 
         /// <summary>
-        /// Execute a sql INSERT query expression as a sql statement to insert <typeparamref name="TEntity"/> entities.
+        /// Assemble and execute a INSERT query to insert <typeparamref name="TEntity"/> entities.
         /// </summary>
         /// <remarks>The inserted entities will be hydrated with any values controlled by the database; for example identity columns, computed columns, defaults where a field was ommitted from the statement.</remarks>
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql INSERT statement and generating an error.</param>
         public static void Execute<TEntity>(this IInsertTerminationExpressionBuilder<TEntity> builder, int commandTimeout)
             where TEntity : class, IDbEntity
         {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout);
+                builder.ExecutePipeline(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout
+                );
         }
 
         /// <summary>
-        /// Execute a sql INSERT query expression as a sql statement to insert <typeparamref name="TEntity"/> entities.
+        /// Assemble and execute a INSERT query to insert <typeparamref name="TEntity"/> entities.
         /// </summary>
         /// <remarks>The inserted entities will be hydrated with any values controlled by the database; for example identity columns, computed columns, defaults where a field was ommitted from the statement.</remarks>
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql INSERT statement.</param>
         public static void Execute<TEntity>(this IInsertTerminationExpressionBuilder<TEntity> builder, ISqlConnection connection)
             where TEntity : class, IDbEntity
-            => builder.ExecutePipeline(connection, null);
+        {
+            builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null
+            );
+        }
 
         /// <summary>
-        /// Execute a sql INSERT query expression as a sql statement to insert <typeparamref name="TEntity"/> entities.
+        /// Assemble and execute a INSERT query to insert <typeparamref name="TEntity"/> entities.
         /// </summary>
         /// <remarks>The inserted entities will be hydrated with any values controlled by the database; for example identity columns, computed columns, defaults where a field was ommitted from the statement.</remarks>
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql INSERT statement.</param>
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql INSERT statement and generating an error.</param>
         public static void Execute<TEntity>(this IInsertTerminationExpressionBuilder<TEntity> builder, ISqlConnection connection, int commandTimeout)
             where TEntity : class, IDbEntity
-            => builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout);
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout
+            );
+        }
 
         /// <summary>
-        /// Execute a sql INSERT query expression as a sql statement to insert <typeparamref name="TEntity"/> entities.
+        /// Assemble and execute a INSERT query to insert <typeparamref name="TEntity"/> entities.
         /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the INSERT statement should be cancelled.</param>
         /// <remarks>The inserted entities will be hydrated with any values controlled by the database; for example identity columns, computed columns, defaults where a field was ommitted from the statement.</remarks>
-        public static async Task ExecuteAsync<TEntity>(this IInsertTerminationExpressionBuilder<TEntity> builder)
+        public static async Task ExecuteAsync<TEntity>(this IInsertTerminationExpressionBuilder<TEntity> builder, CancellationToken cancellationToken = default)
             where TEntity : class, IDbEntity
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                await builder.ExecutePipelineAsync(connection, null, CancellationToken.None).ConfigureAwait(false);
+                await builder.ExecutePipelineAsync(
+                    connection, 
+                    null, 
+                    cancellationToken
+                ).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Execute a sql INSERT query expression as a sql statement to insert <typeparamref name="TEntity"/> entities.
+        /// Assemble and execute a INSERT query to insert <typeparamref name="TEntity"/> entities.
         /// </summary>
         /// <remarks>The inserted entities will be hydrated with any values controlled by the database; for example identity columns, computed columns, defaults where a field was ommitted from the statement.</remarks>
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql INSERT statement.</param>
-        public static async Task ExecuteAsync<TEntity>(this IInsertTerminationExpressionBuilder<TEntity> builder, ISqlConnection connection)
-            where TEntity : class, IDbEntity
-            => await builder.ExecutePipelineAsync(connection, null, CancellationToken.None).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql INSERT query expression as a sql statement to insert <typeparamref name="TEntity"/> entities.
-        /// </summary>
-        /// <remarks>The inserted entities will be hydrated with any values controlled by the database; for example identity columns, computed columns, defaults where a field was ommitted from the statement.</remarks>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql INSERT statement.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the INSERT statement should be cancelled.</param>
-        public static async Task ExecuteAsync<TEntity>(this IInsertTerminationExpressionBuilder<TEntity> builder, CancellationToken ct)
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the INSERT statement should be cancelled.</param>
+        public static async Task ExecuteAsync<TEntity>(this IInsertTerminationExpressionBuilder<TEntity> builder, ISqlConnection connection, CancellationToken cancellationToken = default)
             where TEntity : class, IDbEntity
         {
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."),
+                null,
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a INSERT query to insert <typeparamref name="TEntity"/> entities.
+        /// </summary>
+        /// <remarks>The inserted entities will be hydrated with any values controlled by the database; for example identity columns, computed columns, defaults where a field was ommitted from the statement.</remarks>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql INSERT statement and generating an error.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the INSERT statement should be cancelled.</param>
+        public static async Task ExecuteAsync<TEntity>(this IInsertTerminationExpressionBuilder<TEntity> builder, int commandTimeout, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                await builder.ExecutePipelineAsync(connection, null, ct).ConfigureAwait(false);
+                await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    cancellationToken
+                ).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Execute a sql INSERT query expression as a sql statement to insert <typeparamref name="TEntity"/> entities.
-        /// </summary>
-        /// <remarks>The inserted entities will be hydrated with any values controlled by the database; for example identity columns, computed columns, defaults where a field was ommitted from the statement.</remarks>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql INSERT statement.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the INSERT statement should be cancelled.</param>
-        public static async Task ExecuteAsync<TEntity>(this IInsertTerminationExpressionBuilder<TEntity> builder, ISqlConnection connection, CancellationToken ct)
-            where TEntity : class, IDbEntity
-            => await builder.ExecutePipelineAsync(connection, null, ct).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql INSERT query expression as a sql statement to insert <typeparamref name="TEntity"/> entities.
-        /// </summary>
-        /// <remarks>The inserted entities will be hydrated with any values controlled by the database; for example identity columns, computed columns, defaults where a field was ommitted from the statement.</remarks>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql INSERT statement and generating an error.</param>
-        public static async Task ExecuteAsync<TEntity>(this IInsertTerminationExpressionBuilder<TEntity> builder, int commandTimeout)
-            where TEntity : class, IDbEntity
-        {
-            using (var connetion = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                await builder.ExecutePipelineAsync(connetion, command => command.CommandTimeout = commandTimeout, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Execute a sql INSERT query expression as a sql statement to insert <typeparamref name="TEntity"/> entities.
+        /// Assemble and execute a INSERT query to insert <typeparamref name="TEntity"/> entities.
         /// </summary>
         /// <remarks>The inserted entities will be hydrated with any values controlled by the database; for example identity columns, computed columns, defaults where a field was ommitted from the statement.</remarks>
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql INSERT statement.</param>
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql INSERT statement and generating an error.</param>
-        public static async Task ExecuteAsync<TEntity>(this IInsertTerminationExpressionBuilder<TEntity> builder, ISqlConnection connection, int commandTimeout)
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the INSERT statement should be cancelled.</param>
+        public static async Task ExecuteAsync<TEntity>(this IInsertTerminationExpressionBuilder<TEntity> builder, ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default)
            where TEntity : class, IDbEntity
-             => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, CancellationToken.None).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql INSERT query expression as a sql statement to insert <typeparamref name="TEntity"/> entities.
-        /// </summary>
-        /// <remarks>The inserted entities will be hydrated with any values controlled by the database; for example identity columns, computed columns, defaults where a field was ommitted from the statement.</remarks>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql INSERT statement and generating an error.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the INSERT statement should be cancelled.</param>
-        public static async Task ExecuteAsync<TEntity>(this IInsertTerminationExpressionBuilder<TEntity> builder, int commandTimeout, CancellationToken ct)
-            where TEntity : class, IDbEntity
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, ct).ConfigureAwait(false);
-        }
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
 
-        /// <summary>
-        /// Execute a sql INSERT query expression as a sql statement to insert <typeparamref name="TEntity"/> entities.
-        /// </summary>
-        /// <remarks>The inserted entities will be hydrated with any values controlled by the database; for example identity columns, computed columns, defaults where a field was ommitted from the statement.</remarks>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql INSERT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql INSERT statement and generating an error.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the INSERT statement should be cancelled.</param>
-        public static async Task ExecuteAsync<TEntity>(this IInsertTerminationExpressionBuilder<TEntity> builder, ISqlConnection connection, int commandTimeout, CancellationToken ct)
-            where TEntity : class, IDbEntity
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, ct).ConfigureAwait(false);
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
         #endregion
 
         #region UpdateEntitiesTermination
         /// <summary>
-        /// Execute a sql UPDATE query expression as a sql statement to update <typeparamref name="TEntity"/> entities and return the number of records affected.
+        /// Assemble and execute a UPDATE query to update <typeparamref name="TEntity"/> entities and return the number of records affected.
         /// </summary>
         /// <returns>The number of records affected in the database.</returns>
         public static int Execute<TEntity>(this UpdateEntitiesTermination<TEntity> builder)
             where TEntity : class, IDbEntity
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return builder.ExecutePipeline(connection, null);
+                return builder.ExecutePipeline(
+                    connection, 
+                    null
+                );
         }
 
         /// <summary>
-        /// Execute a sql UPDATE query expression as a sql statement to update <typeparamref name="TEntity"/> entities and return the number of records affected.
+        /// Assemble and execute a UPDATE query to update <typeparamref name="TEntity"/> entities and return the number of records affected.
         /// </summary>
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql UPDATE statement and generating an error.</param>
         /// <returns>The number of records affected in the database.</returns>
         public static int Execute<TEntity>(this UpdateEntitiesTermination<TEntity> builder, int commandTimeout)
             where TEntity : class, IDbEntity
         {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout);
+                return builder.ExecutePipeline(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout
+                );
         }
 
         /// <summary>
-        /// Execute a sql UPDATE query expression as a sql statement to update <typeparamref name="TEntity"/> entities and return the number of records affected.
+        /// Assemble and execute a UPDATE query to update <typeparamref name="TEntity"/> entities and return the number of records affected.
         /// </summary>
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql UPDATE statement.</param>
         /// <returns>The number of records affected in the database.</returns>
         public static int Execute<TEntity>(this UpdateEntitiesTermination<TEntity> builder, ISqlConnection connection)
             where TEntity : class, IDbEntity
-            => builder.ExecutePipeline(connection, null);
+        {
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null
+            );
+        }
 
         /// <summary>
-        /// Execute a sql UPDATE query expression as a sql statement to update <typeparamref name="TEntity"/> entities and return the number of records affected.
+        /// Assemble and execute a UPDATE query to update <typeparamref name="TEntity"/> entities and return the number of records affected.
         /// </summary>
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql UPDATE statement.</param>
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql UPDATE statement and generating an error.</param>
         /// <returns>The number of records affected in the database.</returns>
         public static int Execute<TEntity>(this UpdateEntitiesTermination<TEntity> builder, ISqlConnection connection, int commandTimeout)
             where TEntity : class, IDbEntity
-            => builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout);
-
-        /// <summary>
-        /// Execute a sql UPDATE query expression as a sql statement to update <typeparamref name="TEntity"/> entities and return the number of records affected.
-        /// </summary>
-        /// <returns>The number of records affected in the database.</returns>
-        public static async Task<int> ExecuteAsync<TEntity>(this UpdateEntitiesTermination<TEntity> builder)
-            where TEntity : class, IDbEntity
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, null, CancellationToken.None).ConfigureAwait(false);
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout
+            );
         }
 
         /// <summary>
-        /// Execute a sql UPDATE query expression as a sql statement to update <typeparamref name="TEntity"/> entities and return the number of records affected.
+        /// Assemble and execute a UPDATE query to update <typeparamref name="TEntity"/> entities and return the number of records affected.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql UPDATE statement.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the UPDATE statement should be cancelled.</param>
         /// <returns>The number of records affected in the database.</returns>
-        public static async Task<int> ExecuteAsync<TEntity>(this UpdateEntitiesTermination<TEntity> builder, ISqlConnection connection)
-            where TEntity : class, IDbEntity
-            => await builder.ExecutePipelineAsync(connection, null, CancellationToken.None).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql UPDATE query expression as a sql statement to update <typeparamref name="TEntity"/> entities and return the number of records affected.
-        /// </summary>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the UPDATE statement should be cancelled.</param>
-        public static async Task<int> ExecuteAsync<TEntity>(this UpdateEntitiesTermination<TEntity> builder, CancellationToken ct)
+        public static async Task<int> ExecuteAsync<TEntity>(this UpdateEntitiesTermination<TEntity> builder, CancellationToken cancellationToken = default)
             where TEntity : class, IDbEntity
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, null, ct).ConfigureAwait(false);
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    null, 
+                    cancellationToken
+                ).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Execute a sql UPDATE query expression as a sql statement to update <typeparamref name="TEntity"/> entities and return the number of records affected.
+        /// Assemble and execute a UPDATE query to update <typeparamref name="TEntity"/> entities and return the number of records affected.
         /// </summary>
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql UPDATE statement.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the UPDATE statement should be cancelled.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the UPDATE statement should be cancelled.</param>
         /// <returns>The number of records affected in the database.</returns>
-        public static async Task<int> ExecuteAsync<TEntity>(this UpdateEntitiesTermination<TEntity> builder, ISqlConnection connection, CancellationToken ct)
-            where TEntity : class, IDbEntity
-            => await builder.ExecutePipelineAsync(connection, null, ct).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql UPDATE query expression as a sql statement to update <typeparamref name="TEntity"/> entities and return the number of records affected.
-        /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql UPDATE statement and generating an error.</param>
-        /// <returns>The number of records affected in the database.</returns>
-        public static async Task<int> ExecuteAsync<TEntity>(this UpdateEntitiesTermination<TEntity> builder, int commandTimeout)
+        public static async Task<int> ExecuteAsync<TEntity>(this UpdateEntitiesTermination<TEntity> builder, ISqlConnection connection, CancellationToken cancellationToken = default)
             where TEntity : class, IDbEntity
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, CancellationToken.None).ConfigureAwait(false);
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."),
+                null,
+                cancellationToken
+            ).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Execute a sql UPDATE query expression as a sql statement to update <typeparamref name="TEntity"/> entities and return the number of records affected.
-        /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql UPDATE statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql UPDATE statement and generating an error.</param>
-        /// <returns>The number of records affected in the database.</returns>
-        public static async Task<int> ExecuteAsync<TEntity>(this UpdateEntitiesTermination<TEntity> builder, ISqlConnection connection, int commandTimeout)
-            where TEntity : class, IDbEntity
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, CancellationToken.None).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql UPDATE query expression as a sql statement to update <typeparamref name="TEntity"/> entities and return the number of records affected.
+        /// Assemble and execute a UPDATE query to update <typeparamref name="TEntity"/> entities and return the number of records affected.
         /// </summary>
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql UPDATE statement and generating an error.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the UPDATE statement should be cancelled.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the UPDATE statement should be cancelled.</param>
         /// <returns>The number of records affected in the database.</returns>
-        public static async Task<int> ExecuteAsync<TEntity>(this IUpdateTerminationExpressionBuilder<TEntity> builder, int commandTimeout, CancellationToken ct)
+        public static async Task<int> ExecuteAsync<TEntity>(this UpdateEntitiesTermination<TEntity> builder, int commandTimeout, CancellationToken cancellationToken = default)
             where TEntity : class, IDbEntity
         {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, ct).ConfigureAwait(false);
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    cancellationToken
+                ).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Execute a sql UPDATE query expression as a sql statement to update <typeparamref name="TEntity"/> entities and return the number of records affected.
+        /// Assemble and execute a UPDATE query to update <typeparamref name="TEntity"/> entities and return the number of records affected.
         /// </summary>
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql UPDATE statement.</param>
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql UPDATE statement and generating an error.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the UPDATE statement should be cancelled.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the UPDATE statement should be cancelled.</param>
         /// <returns>The number of records affected in the database.</returns>
-        public static async Task<int> ExecuteAsync<TEntity>(this UpdateEntitiesTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, CancellationToken ct)
+        public static async Task<int> ExecuteAsync<TEntity>(this UpdateEntitiesTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default)
             where TEntity : class, IDbEntity
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, ct).ConfigureAwait(false);
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
         #endregion
 
         #region DeleteEntitiesTermination
         /// <summary>
-        /// Execute a sql DELETE query expression as a sql statement to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
+        /// Assemble and execute a DELETE query to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
         /// </summary>
         /// <returns>The number of records removed from the database.</returns>
         public static int Execute<TEntity>(this DeleteEntitiesTermination<TEntity> builder)
             where TEntity : class, IDbEntity
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return builder.ExecutePipeline(connection, null);
+                return builder.ExecutePipeline(
+                    connection, 
+                    null
+                );
         }
 
         /// <summary>
-        /// Execute a sql DELETE query expression as a sql statement to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
+        /// Assemble and execute a DELETE query to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
         /// </summary>
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql DELETE statement and generating an error.</param>
         /// <returns>The number of records removed from the database.</returns>
         public static int Execute<TEntity>(this DeleteEntitiesTermination<TEntity> builder, int commandTimeout)
             where TEntity : class, IDbEntity
         {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+            
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout);
+                return builder.ExecutePipeline(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout
+                );
         }
 
         /// <summary>
-        /// Execute a sql DELETE query expression as a sql statement to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
+        /// Assemble and execute a DELETE query to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
         /// </summary>
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql DELETE statement.</param>
         /// <returns>The number of records removed from the database.</returns>
         public static int Execute<TEntity>(this DeleteEntitiesTermination<TEntity> builder, ISqlConnection connection)
             where TEntity : class, IDbEntity
-            => builder.ExecutePipeline(connection, null);
+        {
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null
+            );
+        }
 
         /// <summary>
-        /// Execute a sql DELETE query expression as a sql statement to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
+        /// Assemble and execute a DELETE query to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
         /// </summary>
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql DELETE statement.</param>
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql DELETE statement and generating an error.</param>
         /// <returns>The number of records removed from the database.</returns>
         public static int Execute<TEntity>(this DeleteEntitiesTermination<TEntity> builder, ISqlConnection connection, int commandTimeout)
             where TEntity : class, IDbEntity
-            => builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout);
-
-        /// <summary>
-        /// Execute a sql DELETE query expression as a sql statement to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
-        /// </summary>
-        /// <returns>The number of records removed from the database.</returns>
-        public static async Task<int> ExecuteAsync<TEntity>(this DeleteEntitiesTermination<TEntity> builder)
-            where TEntity : class, IDbEntity
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, null, CancellationToken.None).ConfigureAwait(false);
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout
+            );
         }
 
         /// <summary>
-        /// Execute a sql DELETE query expression as a sql statement to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
+        /// Assemble and execute a DELETE query to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql DELETE statement.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the DELETE statement should be cancelled.</param>
         /// <returns>The number of records removed from the database.</returns>
-        public static async Task<int> ExecuteAsync<TEntity>(this DeleteEntitiesTermination<TEntity> builder, ISqlConnection connection)
-            where TEntity : class, IDbEntity
-            => await builder.ExecutePipelineAsync(connection, null, CancellationToken.None).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql DELETE query expression as a sql statement to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
-        /// </summary>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the DELETE statement should be cancelled.</param>
-        /// <returns>The number of records removed from the database.</returns>
-        public static async Task<int> ExecuteAsync<TEntity>(this DeleteEntitiesTermination<TEntity> builder, CancellationToken ct)
+        public static async Task<int> ExecuteAsync<TEntity>(this DeleteEntitiesTermination<TEntity> builder, CancellationToken cancellationToken = default)
             where TEntity : class, IDbEntity
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, null, ct).ConfigureAwait(false);
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    null, 
+                    cancellationToken
+                ).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Execute a sql DELETE query expression as a sql statement to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
+        /// Assemble and execute a DELETE query to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
         /// </summary>
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql DELETE statement.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the DELETE statement should be cancelled.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the DELETE statement should be cancelled.</param>
         /// <returns>The number of records removed from the database.</returns>
-        public static async Task<int> ExecuteAsync<TEntity>(this DeleteEntitiesTermination<TEntity> builder, ISqlConnection connection, CancellationToken ct)
-            where TEntity : class, IDbEntity
-            => await builder.ExecutePipelineAsync(connection, null, ct).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql DELETE query expression as a sql statement to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
-        /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql DELETE statement and generating an error.</param>
-        /// <returns>The number of records removed from the database.</returns>
-        public static async Task<int> ExecuteAsync<TEntity>(this DeleteEntitiesTermination<TEntity> builder, int commandTimeout)
+        public static async Task<int> ExecuteAsync<TEntity>(this DeleteEntitiesTermination<TEntity> builder, ISqlConnection connection, CancellationToken cancellationToken = default)
             where TEntity : class, IDbEntity
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, CancellationToken.None).ConfigureAwait(false);
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                cancellationToken
+            ).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Execute a sql DELETE query expression as a sql statement to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
-        /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql DELETE statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql DELETE statement and generating an error.</param>
-        /// <returns>The number of records removed from the database.</returns>
-        public static async Task<int> ExecuteAsync<TEntity>(this DeleteEntitiesTermination<TEntity> builder, ISqlConnection connection, int commandTimeout)
-            where TEntity : class, IDbEntity
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, CancellationToken.None).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql DELETE query expression as a sql statement to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
+        /// Assemble and execute a DELETE query to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
         /// </summary>
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql DELETE statement and generating an error.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the DELETE statement should be cancelled.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the DELETE statement should be cancelled.</param>
         /// <returns>The number of records removed from the database.</returns>
-        public static async Task<int> ExecuteAsync<TEntity>(this DeleteEntitiesTermination<TEntity> builder, int commandTimeout, CancellationToken ct)
+        public static async Task<int> ExecuteAsync<TEntity>(this DeleteEntitiesTermination<TEntity> builder, int commandTimeout, CancellationToken cancellationToken = default)
             where TEntity : class, IDbEntity
         {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+            
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, ct).ConfigureAwait(false);
+                return await builder.ExecutePipelineAsync(
+                    connection,
+                    command => command.CommandTimeout = commandTimeout, 
+                    cancellationToken
+                ).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Execute a sql DELETE query expression as a sql statement to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
+        /// Assemble and execute a DELETE query to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
         /// </summary>
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql DELETE statement.</param>
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql DELETE statement and generating an error.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the DELETE statement should be cancelled.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the DELETE statement should be cancelled.</param>
         /// <returns>The number of records removed from the database.</returns>
-        public static async Task<int> ExecuteAsync<TEntity>(this DeleteEntitiesTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, CancellationToken ct)
+        public static async Task<int> ExecuteAsync<TEntity>(this DeleteEntitiesTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default)
             where TEntity : class, IDbEntity
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, ct).ConfigureAwait(false);
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
         #endregion
 
         #region SelectValueTermination<TValue>
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a single <typeparamref name="TValue"/> value.
+        /// Assemble and execute a SELECT query to retrieve a single <typeparamref name="TValue"/> value.
         /// </summary>
-        /// <returns>The single <typeparamref name="TValue"/> value retrieved from execution of the sql SELECT statement.</returns>
+        /// <returns>The single <typeparamref name="TValue"/> value retrieved from execution of the sql SELECT query.</returns>
         public static TValue Execute<TValue>(this SelectValueTermination<TValue> builder)
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return builder.ExecutePipeline(connection, null);
+                return builder.ExecutePipeline(
+                    connection, 
+                    null
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a single <typeparamref name="TValue"/> value.
+        /// Assemble and execute a SELECT query to retrieve a single <typeparamref name="TValue"/> value.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The single <typeparamref name="TValue"/> value retrieved from execution of the sql SELECT statement.</returns>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <returns>The single <typeparamref name="TValue"/> value retrieved from execution of the sql SELECT query.</returns>
         public static TValue Execute<TValue>(this SelectValueTermination<TValue> builder, int commandTimeout)
         {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+            
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout);
+                return builder.ExecutePipeline(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a single <typeparamref name="TValue"/> value.
+        /// Assemble and execute a SELECT query to retrieve a single <typeparamref name="TValue"/> value.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <returns>The single <typeparamref name="TValue"/> value retrieved from execution of the sql SELECT statement.</returns>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <returns>The single <typeparamref name="TValue"/> value retrieved from execution of the sql SELECT query.</returns>
         public static TValue Execute<TValue>(this SelectValueTermination<TValue> builder, ISqlConnection connection)
-            => builder.ExecutePipeline(connection, null);
+        {
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null
+            );
+        }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a single <typeparamref name="TValue"/> value.
+        /// Assemble and execute a SELECT query to retrieve a single <typeparamref name="TValue"/> value.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The single <typeparamref name="TValue"/> value retrieved from execution of the sql SELECT statement.</returns>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <returns>The single <typeparamref name="TValue"/> value retrieved from execution of the sql SELECT query.</returns>
         public static TValue Execute<TValue>(this SelectValueTermination<TValue> builder, ISqlConnection connection, int commandTimeout)
-            => builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a single <typeparamref name="TValue"/> value.
-        /// </summary>
-        /// <returns>The single <typeparamref name="TValue"/> value retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<TValue> builder)
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, null, CancellationToken.None).ConfigureAwait(false);
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout
+            );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a single <typeparamref name="TValue"/> value.
+        /// Assemble and execute a SELECT query to retrieve a single <typeparamref name="TValue"/> value.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The single <typeparamref name="TValue"/> value retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<TValue> builder, int commandTimeout)
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The single <typeparamref name="TValue"/> value retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<TValue> builder, CancellationToken cancellationToken = default)
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, CancellationToken.None).ConfigureAwait(false);
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    null, 
+                    cancellationToken
+                ).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a single <typeparamref name="TValue"/> value.
+        /// Assemble and execute a SELECT query to retrieve a single <typeparamref name="TValue"/> value.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <returns>The single <typeparamref name="TValue"/> value retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<TValue> builder, ISqlConnection connection)
-            => await builder.ExecutePipelineAsync(connection, null, CancellationToken.None).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a single <typeparamref name="TValue"/> value.
-        /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The single <typeparamref name="TValue"/> value retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<TValue> builder, ISqlConnection connection, int commandTimeout)
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, CancellationToken.None).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a single <typeparamref name="TValue"/> value.
-        /// </summary>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The single <typeparamref name="TValue"/> value retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<TValue> builder, CancellationToken ct)
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The single <typeparamref name="TValue"/> value retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<TValue> builder, int commandTimeout, CancellationToken cancellationToken = default)
         {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+            
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, null, ct).ConfigureAwait(false);
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    cancellationToken
+                ).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a single <typeparamref name="TValue"/> value.
+        /// Assemble and execute a SELECT query to retrieve a single <typeparamref name="TValue"/> value.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The single <typeparamref name="TValue"/> value retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<TValue> builder, int commandTimeout, CancellationToken ct)
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The single <typeparamref name="TValue"/> value retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<TValue> builder, ISqlConnection connection, CancellationToken cancellationToken = default)
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, ct).ConfigureAwait(false);
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                cancellationToken
+            ).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a single <typeparamref name="TValue"/> value.
+        /// Assemble and execute a SELECT query to retrieve a single <typeparamref name="TValue"/> value.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The single <typeparamref name="TValue"/> value retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<TValue> builder, ISqlConnection connection, CancellationToken ct)
-            => await builder.ExecutePipelineAsync(connection, null, ct).ConfigureAwait(false);
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The single <typeparamref name="TValue"/> value retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<TValue> builder, ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
 
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a single <typeparamref name="TValue"/> value.
-        /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The single <typeparamref name="TValue"/> value retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<TValue> builder, ISqlConnection connection, int commandTimeout, CancellationToken ct)
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, ct).ConfigureAwait(false);
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
         #endregion
 
         #region SelectValuesTermination<TValue>
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TValue"/> values.
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
         /// </summary>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement.</returns>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
         public static IList<TValue> Execute<TValue>(this SelectValuesTermination<TValue> builder)
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return builder.ExecutePipeline(connection, null);
+                return builder.ExecutePipeline(
+                    connection, 
+                    null
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TValue"/> values.
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement.</returns>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
         public static IList<TValue> Execute<TValue>(this SelectValuesTermination<TValue> builder, int commandTimeout)
         {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+            
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout);
+                return builder.ExecutePipeline(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TValue"/> values.
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement.</returns>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
         public static IList<TValue> Execute<TValue>(this SelectValuesTermination<TValue> builder, ISqlConnection connection)
-            => builder.ExecutePipeline(connection, null);
+        {
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null
+            );
+        }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TValue"/> values.
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement.</returns>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
         public static IList<TValue> Execute<TValue>(this SelectValuesTermination<TValue> builder, ISqlConnection connection, int commandTimeout)
-            => builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TValue"/> values.
-        /// </summary>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<TValue> builder)
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, null, CancellationToken.None).ConfigureAwait(false);
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout
+            );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TValue"/> values.
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="handleValue"/> delegate to manage the retrieved value.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<TValue> builder, int commandTimeout)
+        /// <param name="handleValue">The delegate to manage the value returned from execution of the query.</param>
+        public static void Execute<TValue>(this SelectValuesTermination<TValue> builder, Action<object> handleValue)
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, CancellationToken.None).ConfigureAwait(false);
+                builder.ExecutePipeline(
+                    connection, 
+                    null, 
+                    handleValue ?? throw new ArgumentNullException($"{nameof(handleValue)} is required.")
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TValue"/> values.
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="handleValue"/> delegate to manage the retrieved value.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<TValue> builder, ISqlConnection connection)
-            => await builder.ExecutePipelineAsync(connection, null, CancellationToken.None).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TValue"/> values.
-        /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<TValue> builder, ISqlConnection connection, int commandTimeout)
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, CancellationToken.None).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TValue"/> values.
-        /// </summary>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<TValue> builder, CancellationToken ct)
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="handleValue">The delegate to manage the value returned from execution of the query.</param>
+        public static void Execute<TValue>(this SelectValuesTermination<TValue> builder, int commandTimeout, Action<object> handleValue)
         {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, null, ct).ConfigureAwait(false);
+                builder.ExecutePipeline(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    handleValue ?? throw new ArgumentNullException($"{nameof(handleValue)} is required.")
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TValue"/> values.
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="handleValue"/> delegate to manage the retrieved value.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<TValue> builder, int commandTimeout, CancellationToken ct)
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="handleValue">The delegate to manage the value returned from execution of the query.</param>
+        public static void Execute<TValue>(this SelectValuesTermination<TValue> builder, ISqlConnection connection, Action<object> handleValue)
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, ct).ConfigureAwait(false);
+            builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                handleValue ?? throw new ArgumentNullException($"{nameof(handleValue)} is required.")
+            );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TValue"/> values.
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="handleValue"/> delegate to manage the retrieved value.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<TValue> builder, ISqlConnection connection, CancellationToken ct)
-            => await builder.ExecutePipelineAsync(connection, null, ct).ConfigureAwait(false);
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="handleValue">The delegate to manage the value returned from execution of the query.</param>
+        public static void Execute<TValue>(this SelectValuesTermination<TValue> builder, ISqlConnection connection, int commandTimeout, Action<object> handleValue)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                handleValue ?? throw new ArgumentNullException($"{nameof(handleValue)} is required.")
+            );
+        }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TValue"/> values.
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<TValue> builder, ISqlConnection connection, int commandTimeout, CancellationToken ct)
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, ct).ConfigureAwait(false);
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<TValue> builder, CancellationToken cancellationToken = default)
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    null, 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<TValue> builder, int commandTimeout, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+            
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<TValue> builder, ISqlConnection connection, CancellationToken cancellationToken = default)
+        {
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<TValue> builder, ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
+        public static async Task ExecuteAsync<TValue>(this SelectValuesTermination<TValue> builder, Action<object> read, CancellationToken cancellationToken = default)
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                await builder.ExecutePipelineAsync(
+                    connection,
+                    null,
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required."),
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
+        public static async Task ExecuteAsync<TValue>(this SelectValuesTermination<TValue> builder, int commandTimeout, Action<object> read, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                await builder.ExecutePipelineAsync(
+                    connection,
+                    command => command.CommandTimeout = commandTimeout,
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required."),
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
+        public static async Task ExecuteAsync<TValue>(this SelectValuesTermination<TValue> builder, ISqlConnection connection, Action<object> read, CancellationToken cancellationToken = default)
+        {
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."),
+                null,
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required."),
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
+        public static async Task ExecuteAsync<TValue>(this SelectValuesTermination<TValue> builder, ISqlConnection connection, int commandTimeout, Action<object> read, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."),
+                command => command.CommandTimeout = commandTimeout,
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required."),
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
+        public static async Task ExecuteAsync<TValue>(this SelectValuesTermination<TValue> builder, Func<object, Task> read, CancellationToken cancellationToken = default)
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                await builder.ExecutePipelineAsync(
+                    connection,
+                    null,
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required."),
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
+        public static async Task ExecuteAsync<TValue>(this SelectValuesTermination<TValue> builder, int commandTimeout, Func<object, Task> read, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                await builder.ExecutePipelineAsync(
+                    connection,
+                    command => command.CommandTimeout = commandTimeout,
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required."),
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
+        public static async Task ExecuteAsync<TValue>(this SelectValuesTermination<TValue> builder, ISqlConnection connection, Func<object, Task> read, CancellationToken cancellationToken = default)
+        {
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."),
+                null,
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required."),
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
+        public static async Task ExecuteAsync<TValue>(this SelectValuesTermination<TValue> builder, ISqlConnection connection, int commandTimeout, Func<object, Task> read, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."),
+                command => command.CommandTimeout = commandTimeout,
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required."),
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
         #endregion
 
         #region SelectValueTermination<ExpandoObject>
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a dynamic object.  The member elements of the SELECT clause determine the properties of the dynamic object.
+        /// Assemble and execute a SELECT query to retrieve a dynamic object.  The member elements of the SELECT clause determine the properties of the dynamic object.
         /// </summary>
-        /// <returns>The dynamic object retrieved from execution of the sql SELECT statement.</returns>
+        /// <returns>The dynamic object retrieved from execution of the sql SELECT query.</returns>
         public static dynamic Execute(this SelectValueTermination<ExpandoObject> builder)
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return builder.ExecutePipeline(connection, null);
+                return builder.ExecutePipeline(
+                    connection, 
+                    null
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a dynamic object.  The member elements of the SELECT clause determine the properties of the dynamic object.
+        /// Assemble and execute a SELECT query to retrieve a dynamic object.  The member elements of the SELECT clause determine the properties of the dynamic object.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The dynamic object retrieved from execution of the sql SELECT statement.</returns>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <returns>The dynamic object retrieved from execution of the sql SELECT query.</returns>
         public static dynamic Execute(this SelectValueTermination<ExpandoObject> builder, int commandTimeout)
         {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+            
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout);
+                return builder.ExecutePipeline(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a dynamic object.  The member elements of the SELECT clause determine the properties of the dynamic object.
+        /// Assemble and execute a SELECT query to retrieve a dynamic object.  The member elements of the SELECT clause determine the properties of the dynamic object.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <returns>The dynamic object retrieved from execution of the sql SELECT statement.</returns>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <returns>The dynamic object retrieved from execution of the sql SELECT query.</returns>
         public static dynamic Execute(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection)
-            => builder.ExecutePipeline(connection, null);
+        {
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null
+            );
+        }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a dynamic object.  The member elements of the SELECT clause determine the properties of the dynamic object.
+        /// Assemble and execute a SELECT query to retrieve a dynamic object.  The member elements of the SELECT clause determine the properties of the dynamic object.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The dynamic object retrieved from execution of the sql SELECT statement.</returns>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <returns>The dynamic object retrieved from execution of the sql SELECT query.</returns>
         public static dynamic Execute(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout)
-            => builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a dynamic object.  The member elements of the SELECT clause determine the properties of the dynamic object.
-        /// </summary>
-        /// <returns>The dynamic object retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<dynamic> ExecuteAsync(this SelectValueTermination<ExpandoObject> builder)
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, null, CancellationToken.None).ConfigureAwait(false);
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout
+            );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a dynamic object.  The member elements of the SELECT clause determine the properties of the dynamic object.
+        /// Assemble and execute a SELECT query to retrieve a dynamic object.  The member elements of the SELECT clause determine the properties of the dynamic object.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The dynamic object retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<dynamic> ExecuteAsync(this SelectValueTermination<ExpandoObject> builder, int commandTimeout)
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of dynamic objects retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<dynamic> ExecuteAsync(this SelectValueTermination<ExpandoObject> builder, CancellationToken cancellationToken = default)
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, CancellationToken.None).ConfigureAwait(false);
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    null, 
+                    cancellationToken
+                ).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a dynamic object.  The member elements of the SELECT clause determine the properties of the dynamic object.
+        /// Assemble and execute a SELECT query to retrieve a dynamic object.  The member elements of the SELECT clause determine the properties of the dynamic object.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <returns>The dynamic object retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<dynamic> ExecuteAsync(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection)
-            => await builder.ExecutePipelineAsync(connection, null, CancellationToken.None).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a dynamic object.  The member elements of the SELECT clause determine the properties of the dynamic object.
-        /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The dynamic object retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<dynamic> ExecuteAsync(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout)
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, CancellationToken.None).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a dynamic object.  The member elements of the SELECT clause determine the properties of the dynamic object.
-        /// </summary>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The list of dynamic objects retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<dynamic> ExecuteAsync(this SelectValueTermination<ExpandoObject> builder, CancellationToken ct)
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The dynamic object retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<dynamic> ExecuteAsync(this SelectValueTermination<ExpandoObject> builder, int commandTimeout, CancellationToken cancellationToken = default)
         {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+            
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, null, ct).ConfigureAwait(false);
+                return await builder.ExecutePipelineAsync(
+                    connection,
+                    command => command.CommandTimeout = commandTimeout, 
+                    cancellationToken
+                ).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a dynamic object.  The member elements of the SELECT clause determine the properties of the dynamic object.
+        /// Assemble and execute a SELECT query to retrieve a dynamic object.  The member elements of the SELECT clause determine the properties of the dynamic object.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The dynamic object retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<dynamic> ExecuteAsync(this SelectValueTermination<ExpandoObject> builder, int commandTimeout, CancellationToken ct)
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The dynamic object retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<dynamic> ExecuteAsync(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, CancellationToken cancellationToken = default)
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, ct).ConfigureAwait(false);
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                cancellationToken
+            ).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a dynamic object.  The member elements of the SELECT clause determine the properties of the dynamic object.
+        /// Assemble and execute a SELECT query to retrieve a dynamic object.  The member elements of the SELECT clause determine the properties of the dynamic object.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The dynamic object retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<dynamic> ExecuteAsync(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, CancellationToken ct)
-            => await builder.ExecutePipelineAsync(connection, null, ct).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a dynamic object.  The member elements of the SELECT clause determine the properties of the dynamic object.
-        /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The dynamic object retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<dynamic> ExecuteAsync(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, CancellationToken ct)
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, ct).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve records and map to a <typeparamref name="TValue"/> using the <paramref name="map"/> function.
-        /// </summary>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
-        /// <returns>The <typeparamref name="TValue"/> retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static TValue Execute<TValue>(this SelectValueTermination<ExpandoObject> builder, Func<ISqlRow, TValue> map)
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The dynamic object retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<dynamic> ExecuteAsync(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default)
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return builder.ExecutePipeline(connection, null, map);
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                cancellationToken
+            ).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve records and map to a <typeparamref name="TValue"/> using the <paramref name="map"/> function.
+        /// Assemble and execute a SELECT query to retrieve records and map to a <typeparamref name="TValue"/> using the <paramref name="map"/> delegate.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
-        /// <returns>The <typeparamref name="TValue"/> retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static TValue Execute<TValue>(this SelectValueTermination<ExpandoObject> builder, int commandTimeout, Func<ISqlRow, TValue> map)
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <returns>The <typeparamref name="TValue"/> retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static TValue Execute<TValue>(this SelectValueTermination<ExpandoObject> builder, Func<ISqlFieldReader, TValue> map)
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout, map);
+                return builder.ExecutePipeline(
+                    connection,
+                    null, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve records and map to a <typeparamref name="TValue"/> using the <paramref name="map"/> function.
+        /// Assemble and execute a SELECT query to retrieve records and map to a <typeparamref name="TValue"/> using the <paramref name="map"/> delegate.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
-        /// <returns>The <typeparamref name="TValue"/> retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static TValue Execute<TValue>(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, Func<ISqlRow, TValue> map)
-            => builder.ExecutePipeline(connection, null, map);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve records and map to a <typeparamref name="TValue"/> using the <paramref name="map"/> function.
-        /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
-        /// <returns>The <typeparamref name="TValue"/> retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static TValue Execute<TValue>(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, Func<ISqlRow, TValue> map)
-            => builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout, map);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve records and map to a <typeparamref name="TValue"/> using the <paramref name="map"/> function.
-        /// </summary>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
-        /// <returns>The <typeparamref name="TValue"/> retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<ExpandoObject> builder, Func<ISqlRow, TValue> map)
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <returns>The <typeparamref name="TValue"/> retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static TValue Execute<TValue>(this SelectValueTermination<ExpandoObject> builder, int commandTimeout, Func<ISqlFieldReader, TValue> map)
         {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+            
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, null, map, CancellationToken.None).ConfigureAwait(false);
+                return builder.ExecutePipeline(
+                    connection,
+                    command => command.CommandTimeout = commandTimeout, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve records and map to a <typeparamref name="TValue"/> using the <paramref name="map"/> function.
+        /// Assemble and execute a SELECT query to retrieve records and map to a <typeparamref name="TValue"/> using the <paramref name="map"/> delegate.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
-        /// <returns>The <typeparamref name="TValue"/> retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<ExpandoObject> builder, int commandTimeout, Func<ISqlRow, TValue> map)
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <returns>The <typeparamref name="TValue"/> retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static TValue Execute<TValue>(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, Func<ISqlFieldReader, TValue> map)
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, map, CancellationToken.None).ConfigureAwait(false);
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+            );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve records and map to a <typeparamref name="TValue"/> using the <paramref name="map"/> function.
+        /// Assemble and execute a SELECT query to retrieve records and map to a <typeparamref name="TValue"/> using the <paramref name="map"/> delegate.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
-        /// <returns>The <typeparamref name="TValue"/> retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, Func<ISqlRow, TValue> map)
-            => await builder.ExecutePipelineAsync(connection, null, map, CancellationToken.None).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve records and map to a <typeparamref name="TValue"/> using the <paramref name="map"/> function.
-        /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
-        /// <returns>The <typeparamref name="TValue"/> retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, Func<ISqlRow, TValue> map)
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, map, CancellationToken.None).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve records and map to a <typeparamref name="TValue"/> using the <paramref name="map"/> function.
-        /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The <typeparamref name="TValue"/> retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<ExpandoObject> builder, Func<ISqlRow, TValue> map, CancellationToken ct)
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <returns>The <typeparamref name="TValue"/> retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static TValue Execute<TValue>(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TValue> map)
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, null, map, ct).ConfigureAwait(false);
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+            );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve records and map to a <typeparamref name="TValue"/> using the <paramref name="map"/> function.
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage the returned rowset.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The <typeparamref name="TValue"/> retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<ExpandoObject> builder, int commandTimeout, Func<ISqlRow, TValue> map, CancellationToken ct)
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        public static void Execute(this SelectValueTermination<ExpandoObject> builder, Action<ISqlFieldReader> read)
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, map, ct).ConfigureAwait(false);
+                builder.ExecutePipeline(
+                    connection, 
+                    null, 
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required.")
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve records and map to a <typeparamref name="TValue"/> using the <paramref name="map"/> function.
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage the returned rowset.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The <typeparamref name="TValue"/> retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, Func<ISqlRow, TValue> map, CancellationToken ct)
-            => await builder.ExecutePipelineAsync(connection, null, map, ct).ConfigureAwait(false);
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        public static void Execute(this SelectValueTermination<ExpandoObject> builder, int commandTimeout, Action<ISqlFieldReader> read)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                builder.ExecutePipeline(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required.")
+                );
+        }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve records and map to a <typeparamref name="TValue"/> using the <paramref name="map"/> function.
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage the returned rowset.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The <typeparamref name="TValue"/> retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, Func<ISqlRow, TValue> map, CancellationToken ct)
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, map, ct).ConfigureAwait(false);
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        public static void Execute(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, Action<ISqlFieldReader> read)
+        {
+            builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."),
+                null,
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required.")
+            );
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        public static void Execute(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, Action<ISqlFieldReader> read)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."),
+                command => command.CommandTimeout = commandTimeout, 
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required.")
+            );
+        }
+        
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map each row from the rowset to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TValue"/>The value mapped using the provided <paramref name="map"/> delegate from execution of the sql SELECT query.</returns>
+        public static async Task ExecuteAsync(this SelectValueTermination<ExpandoObject> builder, Action<ISqlFieldReader> map, CancellationToken cancellationToken = default)
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                await builder.ExecutePipelineAsync(
+                    connection,
+                    null,
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."),
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map each row from the rowset to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TValue"/>The value mapped using the provided <paramref name="map"/> delegate from execution of the sql SELECT query.</returns>
+        public static async Task ExecuteAsync(this SelectValueTermination<ExpandoObject> builder, int commandTimeout, Action<ISqlFieldReader> map, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                await builder.ExecutePipelineAsync(
+                    connection,
+                    command => command.CommandTimeout = commandTimeout,
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."),
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map each row from the rowset to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TValue"/>The value mapped using the provided <paramref name="map"/> delegate from execution of the sql SELECT query.</returns>
+        public static async Task ExecuteAsync(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, Action<ISqlFieldReader> map, CancellationToken cancellationToken = default)
+        {
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."),
+                null,
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."),
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map each row from the rowset to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TValue"/>The value mapped using the provided <paramref name="map"/> delegate from execution of the sql SELECT query.</returns>
+        public static async Task ExecuteAsync(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, Action<ISqlFieldReader> map, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."),
+                command => command.CommandTimeout = commandTimeout,
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."),
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map each row from the rowset to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TValue"/>The value mapped using the provided <paramref name="map"/> delegate from execution of the sql SELECT query.</returns>
+        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<ExpandoObject> builder, Func<ISqlFieldReader, TValue> map, CancellationToken cancellationToken = default)
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection,
+                    null, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map each row from the rowset to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TValue"/>The value mapped using the provided <paramref name="map"/> delegate from execution of the sql SELECT query.</returns>
+        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<ExpandoObject> builder, int commandTimeout, Func<ISqlFieldReader, TValue> map, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection,
+                    command => command.CommandTimeout = commandTimeout, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map each row from the rowset to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TValue"/>The value mapped using the provided <paramref name="map"/> delegate from execution of the sql SELECT query.</returns>
+        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, Func<ISqlFieldReader, TValue> map, CancellationToken cancellationToken = default)
+        {
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map each row from the rowset to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TValue"/>The value mapped using the provided <paramref name="map"/> delegate from execution of the sql SELECT query.</returns>
+        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TValue> map, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync(this SelectValueTermination<ExpandoObject> builder, Func<ISqlFieldReader, Task> read, CancellationToken cancellationToken = default)
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                await builder.ExecutePipelineAsync(
+                    connection, 
+                    null, 
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync(this SelectValueTermination<ExpandoObject> builder, int commandTimeout, Func<ISqlFieldReader, Task> read, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, Func<ISqlFieldReader, Task> read, CancellationToken cancellationToken = default)
+        {
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."),
+                null, 
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, Task> read, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."),
+                command => command.CommandTimeout = commandTimeout, 
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map the returned row to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TValue"/>The value mapped using the provided <paramref name="map"/> delegate from execution of the sql SELECT query.</returns>
+        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<ExpandoObject> builder, Func<ISqlFieldReader, Task<TValue>> map, CancellationToken cancellationToken = default)
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection,
+                    null, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map the returned row to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TValue"/>The value mapped using the provided <paramref name="map"/> delegate from execution of the sql SELECT query.</returns>
+        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<ExpandoObject> builder, int commandTimeout, Func<ISqlFieldReader, Task<TValue>> map, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+            
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection,
+                    command => command.CommandTimeout = commandTimeout, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map the returned row to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TValue"/>The value mapped using the provided <paramref name="map"/> delegate from execution of the sql SELECT query.</returns>
+        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, Func<ISqlFieldReader, Task<TValue>> map, CancellationToken cancellationToken = default)
+        {
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map the returned row to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TValue"/>The value mapped using the provided <paramref name="map"/> delegate from execution of the sql SELECT query.</returns>
+        public static async Task<TValue> ExecuteAsync<TValue>(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, Task<TValue>> map, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
         #endregion
 
         #region SelectValuesTermination<ExpandoObject>
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
+        /// Assemble and execute a SELECT query to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
         /// </summary>
-        /// <returns>The list of dynamic objects retrieved from execution of the sql SELECT statement.</returns>
+        /// <returns>A list of dynamic objects retrieved from execution of the sql SELECT query.</returns>
         public static IList<dynamic> Execute(this SelectValuesTermination<ExpandoObject> builder)
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return builder.ExecutePipeline(connection, null);
+                return builder.ExecutePipeline(
+                    connection,
+                    null
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
+        /// Assemble and execute a SELECT query to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The list of dynamic objects retrieved from execution of the sql SELECT statement.</returns>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <returns>A list of dynamic objects retrieved from execution of the sql SELECT query.</returns>
         public static IList<dynamic> Execute(this SelectValuesTermination<ExpandoObject> builder, int commandTimeout)
         {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout);
+                return builder.ExecutePipeline(
+                    connection,
+                    command => command.CommandTimeout = commandTimeout
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
+        /// Assemble and execute a SELECT query to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <returns>The list of dynamic objects retrieved from execution of the sql SELECT statement.</returns>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <returns>A list of dynamic objects retrieved from execution of the sql SELECT query.</returns>
         public static IList<dynamic> Execute(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection)
-            => builder.ExecutePipeline(connection, null);
+        {
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null
+            );
+        }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
+        /// Assemble and execute a SELECT query to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The list of dynamic objects retrieved from execution of the sql SELECT statement.</returns>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <returns>A list of dynamic objects retrieved from execution of the sql SELECT query.</returns>
         public static IList<dynamic> Execute(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout)
-            => builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
-        /// </summary>
-        /// <returns>The list of dynamic objects retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<dynamic>> ExecuteAsync(this SelectValuesTermination<ExpandoObject> builder)
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, null, CancellationToken.None).ConfigureAwait(false);
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout
+            );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
+        /// Assemble and execute a SELECT query to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The list of dynamic objects retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<dynamic>> ExecuteAsync(this SelectValuesTermination<ExpandoObject> builder, int commandTimeout)
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of dynamic objects retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<IList<dynamic>> ExecuteAsync(this SelectValuesTermination<ExpandoObject> builder, CancellationToken cancellationToken = default)
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, CancellationToken.None).ConfigureAwait(false);
+                return await builder.ExecutePipelineAsync(
+                    connection,
+                    null, 
+                    cancellationToken
+                ).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
+        /// Assemble and execute a SELECT query to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The list of dynamic objects retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<dynamic>> ExecuteAsync(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection)
-            => await builder.ExecutePipelineAsync(connection, null, CancellationToken.None).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
-        /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The list of dynamic objects retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<dynamic>> ExecuteAsync(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout)
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, CancellationToken.None).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
-        /// </summary>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The list of dynamic objects retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<dynamic>> ExecuteAsync(this SelectValuesTermination<ExpandoObject> builder, CancellationToken ct)
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of dynamic objects retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<IList<dynamic>> ExecuteAsync(this SelectValuesTermination<ExpandoObject> builder, int commandTimeout, CancellationToken cancellationToken = default)
         {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, null, ct).ConfigureAwait(false);
+                return await builder.ExecutePipelineAsync(
+                    connection,
+                    command => command.CommandTimeout = commandTimeout, 
+                    cancellationToken
+                ).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
+        /// Assemble and execute a SELECT query to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The list of dynamic objects retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<dynamic>> ExecuteAsync(this SelectValuesTermination<ExpandoObject> builder, int commandTimeout, CancellationToken ct)
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of dynamic objects retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<IList<dynamic>> ExecuteAsync(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, CancellationToken cancellationToken = default)
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, ct).ConfigureAwait(false);
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                cancellationToken
+            ).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
+        /// Assemble and execute a SELECT query to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The list of dynamic objects retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<dynamic>> ExecuteAsync(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, CancellationToken ct)
-            => await builder.ExecutePipelineAsync(connection, null, ct).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
-        /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The list of dynamic objects retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<dynamic>> ExecuteAsync(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, CancellationToken ct)
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, ct).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
-        /// </summary>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database values to values of type <typeparamref name="TValue"/>.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static IList<TValue> Execute<TValue>(this SelectValuesTermination<ExpandoObject> builder, Func<ISqlRow, TValue> map)
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of dynamic objects retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<IList<dynamic>> ExecuteAsync(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default)
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return builder.ExecutePipeline(connection, null, map);
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                cancellationToken
+            ).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
+        /// Assemble and execute a SELECT query to retrieve records and map each row of the returned rowset to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database values to values of type <typeparamref name="TValue"/>.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static IList<TValue> Execute<TValue>(this SelectValuesTermination<ExpandoObject> builder, int commandTimeout, Func<ISqlRow, TValue> map)
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static IList<TValue> Execute<TValue>(this SelectValuesTermination<ExpandoObject> builder, Func<ISqlFieldReader, TValue> map)
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout, map);
+                return builder.ExecutePipeline(
+                    connection,
+                    null, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
+        /// Assemble and execute a SELECT query to retrieve records and map each row of the returned rowset to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database values to values of type <typeparamref name="TValue"/>.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static IList<TValue> Execute<TValue>(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, Func<ISqlRow, TValue> map)
-            => builder.ExecutePipeline(connection, null, map);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
-        /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database values to values of type <typeparamref name="TValue"/>.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static IList<TValue> Execute<TValue>(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, Func<ISqlRow, TValue> map)
-            => builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout, map);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
-        /// </summary>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database values to values of type <typeparamref name="TValue"/>.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<ExpandoObject> builder, Func<ISqlRow, TValue> map)
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static IList<TValue> Execute<TValue>(this SelectValuesTermination<ExpandoObject> builder, int commandTimeout, Func<ISqlFieldReader, TValue> map)
         {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+            
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, null, map, CancellationToken.None).ConfigureAwait(false);
+                return builder.ExecutePipeline(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
+        /// Assemble and execute a SELECT query to retrieve records and map each row of the returned rowset to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database values to values of type <typeparamref name="TValue"/>.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<ExpandoObject> builder, int commandTimeout, Func<ISqlRow, TValue> map)
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static IList<TValue> Execute<TValue>(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, Func<ISqlFieldReader, TValue> map)
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, map, CancellationToken.None).ConfigureAwait(false);
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+            );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
+        /// Assemble and execute a SELECT query to retrieve records and map each row of the returned rowset to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database values to values of type <typeparamref name="TValue"/>.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, Func<ISqlRow, TValue> map)
-            => await builder.ExecutePipelineAsync(connection, null, map, CancellationToken.None).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
-        /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database values to values of type <typeparamref name="TValue"/>.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, Func<ISqlRow, TValue> map)
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, map, CancellationToken.None).ConfigureAwait(false);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
-        /// </summary>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database values to values of type <typeparamref name="TValue"/>.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<ExpandoObject> builder, Func<ISqlRow, TValue> map, CancellationToken ct)
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static IList<TValue> Execute<TValue>(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TValue> map)
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, null, map, ct).ConfigureAwait(false);
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+            );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to manage the returned rowset.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database values to values of type <typeparamref name="TValue"/>.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<ExpandoObject> builder, int commandTimeout, Func<ISqlRow, TValue> map, CancellationToken ct)
+        /// <param name="map">The delegate to manage the rowset returned from execution of the query.</param>
+        public static void Execute(this SelectValuesTermination<ExpandoObject> builder, Action<ISqlFieldReader> map)
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, map, ct).ConfigureAwait(false);
+                builder.ExecutePipeline(
+                    connection, 
+                    null, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to manage the returned rowset.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database values to values of type <typeparamref name="TValue"/>.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, Func<ISqlRow, TValue> map, CancellationToken ct)
-            => await builder.ExecutePipelineAsync(connection, null, map, ct).ConfigureAwait(false);
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">The delegate to manage the rowset returned from execution of the query.</param>
+        public static void Execute(this SelectValuesTermination<ExpandoObject> builder, int commandTimeout, Action<ISqlFieldReader> map)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                builder.ExecutePipeline(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+                );
+        }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage the returned rowset.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="map">A custom mapping function to use for converting the retrieved database values to values of type <typeparamref name="TValue"/>.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT statement and mapped using the provided <paramref name="map"/> function.</returns>
-        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, Func<ISqlRow, TValue> map, CancellationToken ct)
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, map, ct).ConfigureAwait(false);
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        public static void Execute(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, Action<ISqlFieldReader> read)
+        {
+            builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."),
+                null,
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required.")
+            );
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        public static void Execute(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, Action<ISqlFieldReader> read)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."),
+                command => command.CommandTimeout = commandTimeout,
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required.")
+            );
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map each row of the returned rowset to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<ExpandoObject> builder, Func<ISqlFieldReader, TValue> map, CancellationToken cancellationToken = default)
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    null, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map each row of the returned rowset to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<ExpandoObject> builder, int commandTimeout, Func<ISqlFieldReader, TValue> map, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map each row of the returned rowset to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, Func<ISqlFieldReader, TValue> map, CancellationToken cancellationToken = default)
+        {
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map each row of the returned rowset to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TValue> map, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync(this SelectValuesTermination<ExpandoObject> builder, Action<ISqlFieldReader> read, CancellationToken cancellationToken = default)
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                await builder.ExecutePipelineAsync(
+                    connection, 
+                    null, 
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync(this SelectValuesTermination<ExpandoObject> builder, int commandTimeout, Action<ISqlFieldReader> read, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, Action<ISqlFieldReader> read, CancellationToken cancellationToken = default)
+        {
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, Action<ISqlFieldReader> read, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync(this SelectValuesTermination<ExpandoObject> builder, Func<ISqlFieldReader, Task> read, CancellationToken cancellationToken = default)
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                await builder.ExecutePipelineAsync(
+                    connection, 
+                    null, 
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync(this SelectValuesTermination<ExpandoObject> builder, int commandTimeout, Func<ISqlFieldReader, Task> read, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, Func<ISqlFieldReader, Task> read, CancellationToken cancellationToken = default)
+        {
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, Task> read, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."),
+                command => command.CommandTimeout = commandTimeout, 
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map each row of the returned rowset to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<ExpandoObject> builder, Func<ISqlFieldReader, Task<TValue>> map, CancellationToken cancellationToken = default)
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    null, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map each row of the returned rowset to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<ExpandoObject> builder, int commandTimeout, Func<ISqlFieldReader, Task<TValue>> map, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map each row of the returned rowset to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, Func<ISqlFieldReader, Task<TValue>> map, CancellationToken cancellationToken = default)
+        {
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."),
+                null,
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."),
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map each row of the returned rowset to a <typeparamref name="TValue"/> using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="TValue"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<IList<TValue>> ExecuteAsync<TValue>(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, Task<TValue>> map, CancellationToken cancellationToken = default)
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
         #endregion
 
         #region SelectEntityTermination
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a <typeparamref name="TEntity"/> entity.
+        /// Assemble and execute a SELECT query to retrieve a <typeparamref name="TEntity"/> entity.
         /// </summary>
-        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT statement.</returns>
+        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT query.</returns>
         public static TEntity Execute<TEntity>(this SelectEntityTermination<TEntity> builder)
             where TEntity : class, IDbEntity, new()
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return builder.ExecutePipeline(connection, null);
+                return builder.ExecutePipeline(
+                    connection, 
+                    null
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a <typeparamref name="TEntity"/> entity.
+        /// Assemble and execute a SELECT query to retrieve a <typeparamref name="TEntity"/> entity.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT statement.</returns>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT query.</returns>
         public static TEntity Execute<TEntity>(this SelectEntityTermination<TEntity> builder, int commandTimeout)
             where TEntity : class, IDbEntity, new()
         {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout);
+                return builder.ExecutePipeline(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a <typeparamref name="TEntity"/> entity.
+        /// Assemble and execute a SELECT query to retrieve a <typeparamref name="TEntity"/> entity.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT statement.</returns>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT query.</returns>
         public static TEntity Execute<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection)
             where TEntity : class, IDbEntity, new()
-            => builder.ExecutePipeline(connection, null);
+        {
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null
+            );
+        }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a <typeparamref name="TEntity"/> entity.
+        /// Assemble and execute a SELECT query to retrieve a <typeparamref name="TEntity"/> entity.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT statement.</returns>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT query.</returns>
         public static TEntity Execute<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, int commandTimeout)
             where TEntity : class, IDbEntity, new()
-            => builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a <typeparamref name="TEntity"/> entity.
-        /// </summary>
-        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder)
-            where TEntity : class, IDbEntity, new()
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, null, CancellationToken.None).ConfigureAwait(false);
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout
+            );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a <typeparamref name="TEntity"/> entity.
+        /// Assemble and execute a SELECT query to retrieve a record and map the returned rowset to a <typeparamref name="TEntity"/> entity using the provided <paramref name="map"/> delegate.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, int commandTimeout)
+        /// <param name="map">A delegate for mapping the rowset values to a <typeparamref name="TEntity"/> entity.</param>
+        /// <returns>A <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static TEntity Execute<TEntity>(this SelectEntityTermination<TEntity> builder, Func<ISqlFieldReader, TEntity> map)
             where TEntity : class, IDbEntity, new()
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, CancellationToken.None).ConfigureAwait(false);
+                return builder.ExecutePipeline(
+                    connection, 
+                    null, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a <typeparamref name="TEntity"/> entity.
+        /// Assemble and execute a SELECT query to retrieve a record and map the returned rowset to a <typeparamref name="TEntity"/> entity using the provided <paramref name="map"/> delegate.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection)
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for mapping the rowset values to a <typeparamref name="TEntity"/> entity.</param>
+        /// <returns>A <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static TEntity Execute<TEntity>(this SelectEntityTermination<TEntity> builder, int commandTimeout, Func<ISqlFieldReader, TEntity> map)
             where TEntity : class, IDbEntity, new()
-            => await builder.ExecutePipelineAsync(connection, null, CancellationToken.None).ConfigureAwait(false);
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+            
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return builder.ExecutePipeline(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+                );
+        }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a <typeparamref name="TEntity"/> entity.
+        /// Assemble and execute a SELECT query to retrieve a a record and map the returned rowset to a <typeparamref name="TEntity"/> entity using the provided <paramref name="map"/> delegate.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, int commandTimeout)
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="map">A delegate for mapping the rowset values to a <typeparamref name="TEntity"/> entity.</param>
+        /// <returns>A <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static TEntity Execute<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, Func<ISqlFieldReader, TEntity> map)
             where TEntity : class, IDbEntity, new()
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, CancellationToken.None).ConfigureAwait(false);
+        {
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+            );
+        }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a <typeparamref name="TEntity"/> entity.
+        /// Assemble and execute a SELECT query to retrieve a record and map the returned rowset to a <typeparamref name="TEntity"/> entity using the provided <paramref name="map"/> delegate.
         /// </summary>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, CancellationToken ct)
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for mapping the rowset values to a <typeparamref name="TEntity"/> entity.</param>
+        /// <returns>A <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static TEntity Execute<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TEntity> map)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+            );
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        public static void Execute<TEntity>(this SelectEntityTermination<TEntity> builder, Action<ISqlFieldReader> read)
             where TEntity : class, IDbEntity, new()
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, null, ct).ConfigureAwait(false);
+                builder.ExecutePipeline(
+                    connection, 
+                    null, 
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required.")
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a <typeparamref name="TEntity"/> entity.
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="read"/> delegate to manage the returned rowset.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, int commandTimeout, CancellationToken ct)
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        public static void Execute<TEntity>(this SelectEntityTermination<TEntity> builder, int commandTimeout, Action<ISqlFieldReader> read)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                builder.ExecutePipeline(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required.")
+                );
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        public static void Execute<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, Action<ISqlFieldReader> read)
+            where TEntity : class, IDbEntity, new()
+        {
+            builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required.")
+            );
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        public static void Execute<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, Action<ISqlFieldReader> read)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required.")
+            );
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="map">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <returns>A <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static TEntity Execute<TEntity>(this SelectEntityTermination<TEntity> builder, Action<ISqlFieldReader, TEntity> map)
             where TEntity : class, IDbEntity, new()
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, ct).ConfigureAwait(false);
+                return builder.ExecutePipeline(
+                    connection, 
+                    null, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a <typeparamref name="TEntity"/> entity.
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, CancellationToken ct)
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <returns>A <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static TEntity Execute<TEntity>(this SelectEntityTermination<TEntity> builder, int commandTimeout, Action<ISqlFieldReader, TEntity> map)
             where TEntity : class, IDbEntity, new()
-            => await builder.ExecutePipelineAsync(connection, null, ct).ConfigureAwait(false);
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return builder.ExecutePipeline(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+                );
+        }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a <typeparamref name="TEntity"/> entity.
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, CancellationToken ct)
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="map">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <returns>A <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static TEntity Execute<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, Action<ISqlFieldReader, TEntity> map)
             where TEntity : class, IDbEntity, new()
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, ct).ConfigureAwait(false);
+        {
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+            );
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <returns>A <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static TEntity Execute<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, Action<ISqlFieldReader, TEntity> map)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+            );
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a <typeparamref name="TEntity"/> entity.
+        /// </summary>
+        /// /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    null, 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }        
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a <typeparamref name="TEntity"/> entity.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, int commandTimeout, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a <typeparamref name="TEntity"/> entity.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a <typeparamref name="TEntity"/> entity.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="map"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="map">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, Action<ISqlFieldReader> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                await builder.ExecutePipelineAsync(
+                    connection, 
+                    null,
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, int commandTimeout, Action<ISqlFieldReader> read, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, Action<ISqlFieldReader> read, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, Action<ISqlFieldReader> read, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="map">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    null, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, int commandTimeout, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="map">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TEntity"/> entity retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="map">A delegate for converting the retrieved database value to a <typeparamref name="TEntity"/> entity.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TEntity"/> entity mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection,
+                    null, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a <typeparamref name="TEntity"/> entity.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TEntity"/> entity mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, int commandTimeout, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+            
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a <typeparamref name="TEntity"/> entity.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TEntity"/> entity mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."),
+                null,
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."),
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a <typeparamref name="TEntity"/> entity.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TEntity"/> entity mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, Func<ISqlFieldReader, Task> read, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                await builder.ExecutePipelineAsync(
+                    connection, 
+                    null, 
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, int commandTimeout, Func<ISqlFieldReader, Task> read, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, Func<ISqlFieldReader, Task> read, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="read"/> delegate to manage the returned rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage the rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, Task> read, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="map">A delegate for converting the retrieved database value to a <typeparamref name="TEntity"/> entity.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TEntity"/> entity mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    null, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a <typeparamref name="TEntity"/> entity.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TEntity"/> entity mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, int commandTimeout, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a <typeparamref name="TEntity"/> entity.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TEntity"/> entity mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a record and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for converting the retrieved database value to a <typeparamref name="TEntity"/> entity.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>The <typeparamref name="TEntity"/> entity mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<TEntity> ExecuteAsync<TEntity>(this SelectEntityTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
         #endregion
 
         #region SelectEntitiesTermination
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TEntity"/> entities.
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TEntity"/> entities.
         /// </summary>
-        /// <returns>The list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT statement.</returns>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
         public static IList<TEntity> Execute<TEntity>(this SelectEntitiesTermination<TEntity> builder)
             where TEntity : class, IDbEntity, new()
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return builder.ExecutePipeline(connection, null);
+                return builder.ExecutePipeline(
+                    connection,
+                    null
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TEntity"/> entities.
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TEntity"/> entities.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT statement.</returns>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
         public static IList<TEntity> Execute<TEntity>(this SelectEntitiesTermination<TEntity> builder, int commandTimeout)
             where TEntity : class, IDbEntity, new()
         {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout);
+                return builder.ExecutePipeline(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TEntity"/> entities.
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TEntity"/> entities.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <returns>The list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT statement.</returns>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
         public static IList<TEntity> Execute<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection)
             where TEntity : class, IDbEntity, new()
-            => builder.ExecutePipeline(connection, null);
+        {
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null
+            );
+        }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TEntity"/> entities.
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TEntity"/> entities.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT statement.</returns>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
         public static IList<TEntity> Execute<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, int commandTimeout)
             where TEntity : class, IDbEntity, new()
-            => builder.ExecutePipeline(connection, command => command.CommandTimeout = commandTimeout);
-
-        /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TEntity"/> entities.
-        /// </summary>
-        /// <returns>The list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder)
-            where TEntity : class, IDbEntity, new()
         {
-            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, null, CancellationToken.None).ConfigureAwait(false);
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout
+            );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TEntity"/> entities.
+        /// Assemble and execute a SELECT query to retrieve records and map each rowset to a <typeparamref name="TEntity"/> entity using the provided <paramref name="map"/> delegate.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, int commandTimeout)
+        /// <param name="map">A delegate for mapping each rowset to a <typeparamref name="TEntity"/> entity.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static IList<TEntity> Execute<TEntity>(this SelectEntitiesTermination<TEntity> builder, Func<ISqlFieldReader, TEntity> map)
             where TEntity : class, IDbEntity, new()
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, CancellationToken.None).ConfigureAwait(false);
+                return builder.ExecutePipeline(
+                    connection, 
+                    null, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TEntity"/> entities.
+        /// Assemble and execute a SELECT query to retrieve records and map each rowset to a <typeparamref name="TEntity"/> entity using the provided <paramref name="map"/> delegate.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <returns>The list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection)
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for mapping each rowset to a <typeparamref name="TEntity"/> entity.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static IList<TEntity> Execute<TEntity>(this SelectEntitiesTermination<TEntity> builder, int commandTimeout, Func<ISqlFieldReader, TEntity> map)
             where TEntity : class, IDbEntity, new()
-            => await builder.ExecutePipelineAsync(connection, null, CancellationToken.None).ConfigureAwait(false);
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return builder.ExecutePipeline(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+                );
+        }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TEntity"/> entities.
+        /// Assemble and execute a SELECT query to retrieve records and map each rowset to a <typeparamref name="TEntity"/> entity using the provided <paramref name="map"/> delegate.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <returns>The list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, int commandTimeout)
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="map">A delegate for mapping each rowset to a <typeparamref name="TEntity"/> entity.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static IList<TEntity> Execute<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, Func<ISqlFieldReader, TEntity> map)
             where TEntity : class, IDbEntity, new()
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, CancellationToken.None).ConfigureAwait(false);
+        {
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+            );
+        }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TEntity"/> entities.
+        /// Assemble and execute a SELECT query to retrieve records and map each rowset to a <typeparamref name="TEntity"/> entity using the provided <paramref name="map"/> delegate.
         /// </summary>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, CancellationToken ct)
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for mapping each rowset to a <typeparamref name="TEntity"/> entity.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static IList<TEntity> Execute<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TEntity> map)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+            );
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to manage each rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
+        public static void Execute<TEntity>(this SelectEntitiesTermination<TEntity> builder, Action<ISqlFieldReader> map)
             where TEntity : class, IDbEntity, new()
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, null, ct).ConfigureAwait(false);
+                builder.ExecutePipeline(
+                    connection, 
+                    null, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TEntity"/> entities.
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to manage each rowset.
         /// </summary>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, int commandTimeout, CancellationToken ct)
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
+        public static void Execute<TEntity>(this SelectEntitiesTermination<TEntity> builder, int commandTimeout, Action<ISqlFieldReader> map)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                builder.ExecutePipeline(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+                );
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage each rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="read">The delegate to manage each rowset returned from execution of the query.</param>
+        public static void Execute<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, Action<ISqlFieldReader> read)
+            where TEntity : class, IDbEntity, new()
+        {
+            builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required.")
+            );
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage each rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage each rowset returned from execution of the query.</param>
+        public static void Execute<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, Action<ISqlFieldReader> read)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required.")
+            );
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
+        public static IList<TEntity> Execute<TEntity>(this SelectEntitiesTermination<TEntity> builder, Action<ISqlFieldReader, TEntity> map)
             where TEntity : class, IDbEntity, new()
         {
             using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
-                return await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, ct).ConfigureAwait(false);
+                return builder.ExecutePipeline(
+                    connection, 
+                    null, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+                );
         }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TEntity"/> entities.
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, CancellationToken ct)
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
+        public static IList<TEntity> Execute<TEntity>(this SelectEntitiesTermination<TEntity> builder, int commandTimeout, Action<ISqlFieldReader, TEntity> map)
             where TEntity : class, IDbEntity, new()
-            => await builder.ExecutePipelineAsync(connection, null, ct).ConfigureAwait(false);
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return builder.ExecutePipeline(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+                );
+        }
 
         /// <summary>
-        /// Execute a sql SELECT query expression as a sql statement to retrieve a list of <typeparamref name="TEntity"/> entities.
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
         /// </summary>
-        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT statement.</param>
-        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT statement and generating an error.</param>
-        /// <param name="ct">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        /// <returns>The list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT statement.</returns>
-        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, CancellationToken ct)
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
+        public static IList<TEntity> Execute<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, Action<ISqlFieldReader, TEntity> map)
             where TEntity : class, IDbEntity, new()
-            => await builder.ExecutePipelineAsync(connection, command => command.CommandTimeout = commandTimeout, ct).ConfigureAwait(false);
+        {
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+            );
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
+        public static IList<TEntity> Execute<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, Action<ISqlFieldReader, TEntity> map)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return builder.ExecutePipeline(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required.")
+            );
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TEntity"/> entities.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    null, 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TEntity"/> entities.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, int commandTimeout, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TEntity"/> entities.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TEntity"/> entities.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
+        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage each rowset.
+        /// </summary>
+        /// <param name="read">The delegate to manage each rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, Action<ISqlFieldReader> read, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                await builder.ExecutePipelineAsync(
+                    connection, 
+                    null,
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required."),
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage each rowset.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage each rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, int commandTimeout, Action<ISqlFieldReader> read, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage each rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="read">The delegate to manage each rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, Action<ISqlFieldReader> read, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage each rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage each rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, Action<ISqlFieldReader> read, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map each rowset to a <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    null, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map each rowset to a <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, int commandTimeout, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+            
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map each rowset to a <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map each rowset to a <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map each rowset to a <typeparamref name="TEntity"/> entity using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="map">A delegate for mapping each rowset to a <typeparamref name="TEntity"/> entity.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    null, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map each rowset to a <typeparamref name="TEntity"/> entity using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for mapping each rowset to a <typeparamref name="TEntity"/> entity.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, int commandTimeout, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map each rowset to a <typeparamref name="TEntity"/> entity using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="map">A delegate for mapping each rowset to a <typeparamref name="TEntity"/> entity.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and map each rowset to a <typeparamref name="TEntity"/> entity using the provided <paramref name="map"/> delegate.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">A delegate for mapping each rowset to a <typeparamref name="TEntity"/> entity.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
+        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage each rowset.
+        /// </summary>
+        /// <param name="read">The delegate to manage each rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, Func<ISqlFieldReader, Task> read, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                await builder.ExecutePipelineAsync(
+                    connection, 
+                    null, 
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage each rowset.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage each rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, int commandTimeout, Func<ISqlFieldReader, Task> read, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage each rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="read">The delegate to manage each rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, Func<ISqlFieldReader, Task> read, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                null, 
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage each rowset.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="read">The delegate to manage each rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, Task> read, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                read ?? throw new ArgumentNullException($"{nameof(read)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map each rowset to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    null, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map each rowset to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, int commandTimeout, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            using (var connection = new SqlConnector(builder.GetDatabaseConfiguration().ConnectionFactory))
+                return await builder.ExecutePipelineAsync(
+                    connection, 
+                    command => command.CommandTimeout = commandTimeout, 
+                    map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map each rowset to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."),
+                null, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map each rowset to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
+        /// </summary>
+        /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
+        /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
+        /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
+        public static async Task<IList<TEntity>> ExecuteAsync<TEntity>(this SelectEntitiesTermination<TEntity> builder, ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken = default)
+            where TEntity : class, IDbEntity, new()
+        {
+            if (commandTimeout <= 0)
+                throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
+
+            return await builder.ExecutePipelineAsync(
+                connection ?? throw new ArgumentNullException($"{nameof(connection)} is required."), 
+                command => command.CommandTimeout = commandTimeout, 
+                map ?? throw new ArgumentNullException($"{nameof(map)} is required."), 
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
         #endregion
         #endregion
 
@@ -1425,9 +3509,9 @@ namespace HatTrick.DbEx.Sql
            where T : class, IDbEntity
            => builder.CreateInsertExecutionPipeline<T>().ExecuteInsert(builder.GetQueryExpression<InsertQueryExpression>(), connection, configureCommand);
 
-        private static async Task ExecutePipelineAsync<T>(this IInsertTerminationExpressionBuilder<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken ct)
+        private static async Task ExecutePipelineAsync<T>(this IInsertTerminationExpressionBuilder<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken cancellationToken)
             where T : class, IDbEntity
-            => await builder.CreateInsertExecutionPipeline<T>().ExecuteInsertAsync(builder.GetQueryExpression<InsertQueryExpression>(), connection, configureCommand, ct).ConfigureAwait(false);
+            => await builder.CreateInsertExecutionPipeline<T>().ExecuteInsertAsync(builder.GetQueryExpression<InsertQueryExpression>(), connection, configureCommand, cancellationToken).ConfigureAwait(false);
 
         private static IInsertQueryExpressionExecutionPipeline<T> CreateInsertExecutionPipeline<T>(this ITerminationExpressionBuilder builder)
             where T : class, IDbEntity
@@ -1442,9 +3526,9 @@ namespace HatTrick.DbEx.Sql
             where T : class, IDbEntity
             => builder.CreateUpdateExecutionPipeline<T>().ExecuteUpdate(builder.GetQueryExpression<UpdateQueryExpression>(), connection, configureCommand);
 
-        private static async Task<int> ExecutePipelineAsync<T>(this IUpdateTerminationExpressionBuilder<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken ct)
+        private static async Task<int> ExecutePipelineAsync<T>(this IUpdateTerminationExpressionBuilder<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken cancellationToken)
             where T : class, IDbEntity
-            => await builder.CreateUpdateExecutionPipeline<T>().ExecuteUpdateAsync(builder.GetQueryExpression<UpdateQueryExpression>(), connection, configureCommand, ct).ConfigureAwait(false);
+            => await builder.CreateUpdateExecutionPipeline<T>().ExecuteUpdateAsync(builder.GetQueryExpression<UpdateQueryExpression>(), connection, configureCommand, cancellationToken).ConfigureAwait(false);
 
         private static IUpdateQueryExpressionExecutionPipeline<T> CreateUpdateExecutionPipeline<T>(this ITerminationExpressionBuilder builder)
             where T : class, IDbEntity
@@ -1459,9 +3543,9 @@ namespace HatTrick.DbEx.Sql
             where T : class, IDbEntity
             => builder.CreateDeleteExecutionPipeline<T>().ExecuteDelete(builder.GetQueryExpression<DeleteQueryExpression>(), connection, configureCommand);
 
-        private static async Task<int> ExecutePipelineAsync<T>(this DeleteEntitiesTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken ct)
+        private static async Task<int> ExecutePipelineAsync<T>(this DeleteEntitiesTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken cancellationToken)
             where T : class, IDbEntity
-            => await builder.CreateDeleteExecutionPipeline<T>().ExecuteDeleteAsync(builder.GetQueryExpression<DeleteQueryExpression>(), connection, configureCommand, ct).ConfigureAwait(false);
+            => await builder.CreateDeleteExecutionPipeline<T>().ExecuteDeleteAsync(builder.GetQueryExpression<DeleteQueryExpression>(), connection, configureCommand, cancellationToken).ConfigureAwait(false);
 
         private static IDeleteQueryExpressionExecutionPipeline<T> CreateDeleteExecutionPipeline<T>(this ITerminationExpressionBuilder builder)
             where T : class, IDbEntity
@@ -1471,59 +3555,172 @@ namespace HatTrick.DbEx.Sql
         }
         #endregion
 
-        #region SelectValueTermination
+        #region SelectValueTermination (T)
         private static T ExecutePipeline<T>(this SelectValueTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand)
             => builder.CreateSelectExecutionPipeline<T>().ExecuteSelectValue<T>(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand);
 
-        private static async Task<T> ExecutePipelineAsync<T>(this SelectValueTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken ct)
-            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectValueAsync<T>(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, ct).ConfigureAwait(false);
+        private static async Task<T> ExecutePipelineAsync<T>(this SelectValueTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken cancellationToken)
+            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectValueAsync<T>(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, cancellationToken).ConfigureAwait(false);
+        #endregion
 
+        #region SelectValuesTermination (T)
         private static IList<T> ExecutePipeline<T>(this SelectValuesTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand)
             => builder.CreateSelectExecutionPipeline<T>().ExecuteSelectValueList<T>(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand);
 
-        private static async Task<IList<T>> ExecutePipelineAsync<T>(this SelectValuesTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken ct)
-            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectValueListAsync<T>(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, ct).ConfigureAwait(false);
+        private static void ExecutePipeline<T>(this SelectValuesTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<object> read)
+            => builder.CreateSelectExecutionPipeline<T>().ExecuteSelectValueList(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, read);
 
+        private static async Task<IList<T>> ExecutePipelineAsync<T>(this SelectValuesTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken cancellationToken)
+            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectValueListAsync<T>(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, cancellationToken).ConfigureAwait(false);
+
+        private static async Task ExecutePipelineAsync<T>(this SelectValuesTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<object> read, CancellationToken cancellationToken)
+            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectValueListAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, read, cancellationToken);
+
+        private static async Task ExecutePipelineAsync<T>(this SelectValuesTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<object, Task> read, CancellationToken cancellationToken)
+            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectValueListAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, read, cancellationToken);
+        #endregion
+
+        #region SelectValueTermination (ExpandoObject -> dynamic)
         private static dynamic ExecutePipeline(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand)
             => builder.CreateSelectExecutionPipeline<dynamic>().ExecuteSelectDynamic(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand);
 
-        private static async Task<dynamic> ExecutePipelineAsync(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken ct)
-            => await builder.CreateSelectExecutionPipeline<dynamic>().ExecuteSelectDynamicAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, ct).ConfigureAwait(false);
+        private static void ExecutePipeline(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader> read)
+            => builder.CreateSelectExecutionPipeline<ExpandoObject>().ExecuteSelectDynamic(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, read);
 
+
+        private static async Task<dynamic> ExecutePipelineAsync(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken cancellationToken)
+            => await builder.CreateSelectExecutionPipeline<dynamic>().ExecuteSelectDynamicAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, cancellationToken).ConfigureAwait(false);
+
+        private static async Task ExecutePipelineAsync(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader> read, CancellationToken cancellationToken)
+            => await builder.CreateSelectExecutionPipeline<ExpandoObject>().ExecuteSelectDynamicAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, read, cancellationToken).ConfigureAwait(false);
+
+        private static async Task ExecutePipelineAsync(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, Task> read, CancellationToken cancellationToken)
+            => await builder.CreateSelectExecutionPipeline<ExpandoObject>().ExecuteSelectDynamicAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, read, cancellationToken).ConfigureAwait(false);
+        #endregion
+
+        #region SelectValuesTermination (ExpandoObject -> dynamic)
         private static IList<dynamic> ExecutePipeline(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand)
             => builder.CreateSelectExecutionPipeline<dynamic>().ExecuteSelectDynamicList(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand);
 
-        private static async Task<IList<dynamic>> ExecutePipelineAsync(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken ct)
-            => await builder.CreateSelectExecutionPipeline<dynamic>().ExecuteSelectDynamicListAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, ct).ConfigureAwait(false);
+        private static void ExecutePipeline(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader> read)
+            => builder.CreateSelectExecutionPipeline<ExpandoObject>().ExecuteSelectDynamicList(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, read);
 
-        private static T ExecutePipeline<T>(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlRow, T> map)
+
+        private static async Task<IList<dynamic>> ExecutePipelineAsync(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken cancellationToken)
+            => await builder.CreateSelectExecutionPipeline<dynamic>().ExecuteSelectDynamicListAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, cancellationToken).ConfigureAwait(false);
+
+        private static async Task ExecutePipelineAsync(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader> read, CancellationToken cancellationToken)
+            => await builder.CreateSelectExecutionPipeline<ExpandoObject>().ExecuteSelectDynamicListAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, read, cancellationToken).ConfigureAwait(false);
+
+        private static async Task ExecutePipelineAsync(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, Task> read, CancellationToken cancellationToken)
+            => await builder.CreateSelectExecutionPipeline<ExpandoObject>().ExecuteSelectDynamicListAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, read, cancellationToken).ConfigureAwait(false);
+        #endregion
+
+        #region SelectValueTermination (ExpandoObject -> object)
+        private static T ExecutePipeline<T>(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, T> map)
             => builder.CreateSelectExecutionPipeline<T>().ExecuteSelectObject(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, map);
 
-        private static async Task<T> ExecutePipelineAsync<T>(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlRow, T> map, CancellationToken ct)
-            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectObjectAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, map, ct).ConfigureAwait(false);
+        private static async Task<T> ExecutePipelineAsync<T>(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, T> map, CancellationToken cancellationToken)
+            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectObjectAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, map, cancellationToken).ConfigureAwait(false);
 
-        private static IList<T> ExecutePipeline<T>(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlRow, T> map)
-            => builder.CreateSelectExecutionPipeline<T>().ExecuteSelectObjectList(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, map);
+        private static async Task<T> ExecutePipelineAsync<T>(this SelectValueTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, Task<T>> map, CancellationToken cancellationToken)
+            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectObjectAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, map, cancellationToken).ConfigureAwait(false);
+        #endregion
 
-        private static async Task<IList<T>> ExecutePipelineAsync<T>(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlRow, T> map, CancellationToken ct)
-            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectObjectListAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, map, ct).ConfigureAwait(false);
+        #region SelectValuesTermination (ExpandoObject -> object)
+        private static IList<T> ExecutePipeline<T>(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, T> map)
+            => builder.CreateSelectExecutionPipeline<T>().ExecuteSelectObjectList(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, map);               
 
+        private static async Task<IList<T>> ExecutePipelineAsync<T>(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, T> map, CancellationToken cancellationToken)
+            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectObjectListAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, map, cancellationToken).ConfigureAwait(false);
+
+        private static async Task<IList<T>> ExecutePipelineAsync<T>(this SelectValuesTermination<ExpandoObject> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, Task<T>> map, CancellationToken cancellationToken)
+            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectObjectListAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, map, cancellationToken).ConfigureAwait(false);
+        #endregion
+
+        #region SelectEntityTermination
         private static T ExecutePipeline<T>(this SelectEntityTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand)
             where T : class, IDbEntity, new()
             => builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntity<T>(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand);
 
-        private static async Task<T> ExecutePipelineAsync<T>(this SelectEntityTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken ct)
+        private static T ExecutePipeline<T>(this SelectEntityTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, T> map)
             where T : class, IDbEntity, new()
-            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntityAsync<T>(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, ct).ConfigureAwait(false);
+            => builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntity(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, map);
 
+        private static void ExecutePipeline<T>(this SelectEntityTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader> read)
+            where T : class, IDbEntity, new()
+            => builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntity<T>(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, read);
+
+        private static T ExecutePipeline<T>(this SelectEntityTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader, T> map)
+            where T : class, IDbEntity, new()
+            => builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntity(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, map);
+
+        private static async Task<T> ExecutePipelineAsync<T>(this SelectEntityTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken cancellationToken)
+            where T : class, IDbEntity, new()
+            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntityAsync<T>(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, cancellationToken).ConfigureAwait(false);
+
+        private static async Task ExecutePipelineAsync<T>(this SelectEntityTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader> read, CancellationToken cancellationToken)
+            where T : class, IDbEntity, new()
+            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntityAsync<T>(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, read, cancellationToken);
+
+        private static async Task<T> ExecutePipelineAsync<T>(this SelectEntityTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader, T> map, CancellationToken cancellationToken)
+            where T : class, IDbEntity, new()
+            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntityAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, map, cancellationToken).ConfigureAwait(false);
+
+        private static async Task<T> ExecutePipelineAsync<T>(this SelectEntityTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, T> map, CancellationToken cancellationToken)
+            where T : class, IDbEntity, new()
+            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntityAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, map, cancellationToken);
+
+        private static async Task ExecutePipelineAsync<T>(this SelectEntityTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, Task> read, CancellationToken cancellationToken)
+            where T : class, IDbEntity, new()
+            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntityAsync<T>(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, read, cancellationToken);
+
+        private static async Task<T> ExecutePipelineAsync<T>(this SelectEntityTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, T, Task> map, CancellationToken cancellationToken)
+            where T : class, IDbEntity, new()
+            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntityAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, map, cancellationToken).ConfigureAwait(false);
+        #endregion
+
+        #region SelectEntitiesTermination
         private static IList<T> ExecutePipeline<T>(this SelectEntitiesTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand)
             where T : class, IDbEntity, new()
             => builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntityList<T>(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand);
 
-        private static async Task<IList<T>> ExecutePipelineAsync<T>(this SelectEntitiesTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken ct)
+        private static IList<T> ExecutePipeline<T>(this SelectEntitiesTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, T> map)
             where T : class, IDbEntity, new()
-            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntityListAsync<T>(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, ct).ConfigureAwait(false); 
-        
+            => builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntityList(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, map);
+
+        private static void ExecutePipeline<T>(this SelectEntitiesTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader> read)
+            where T : class, IDbEntity, new()
+            => builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntityList<T>(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, read);
+
+        private static IList<T> ExecutePipeline<T>(this SelectEntitiesTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader, T> map)
+            where T : class, IDbEntity, new()
+            => builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntityList(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, map);
+
+        private static async Task<IList<T>> ExecutePipelineAsync<T>(this SelectEntitiesTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, CancellationToken cancellationToken) 
+            where T : class, IDbEntity, new()
+            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntityListAsync<T>(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, cancellationToken).ConfigureAwait(false);
+
+        private static async Task ExecutePipelineAsync<T>(this SelectEntitiesTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader> read, CancellationToken cancellationToken)
+            where T : class, IDbEntity, new()
+            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntityListAsync<T>(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, read, cancellationToken).ConfigureAwait(false);
+
+        private static async Task<IList<T>> ExecutePipelineAsync<T>(this SelectEntitiesTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Action<ISqlFieldReader, T> map, CancellationToken cancellationToken)
+            where T : class, IDbEntity, new()
+            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntityListAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, map, cancellationToken).ConfigureAwait(false);
+
+        private static async Task<IList<T>> ExecutePipelineAsync<T>(this SelectEntitiesTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, T> map, CancellationToken cancellationToken)
+            where T : class, IDbEntity, new()
+            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntityListAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, map, cancellationToken).ConfigureAwait(false);
+
+        private static async Task ExecutePipelineAsync<T>(this SelectEntitiesTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, Task> read, CancellationToken cancellationToken)
+            where T : class, IDbEntity, new()
+            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntityListAsync<T>(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, read, cancellationToken).ConfigureAwait(false);
+
+        private static async Task<IList<T>> ExecutePipelineAsync<T>(this SelectEntitiesTermination<T> builder, ISqlConnection connection, Action<IDbCommand> configureCommand, Func<ISqlFieldReader, T, Task> map, CancellationToken cancellationToken)
+            where T : class, IDbEntity, new()
+            => await builder.CreateSelectExecutionPipeline<T>().ExecuteSelectEntityListAsync(builder.GetQueryExpression<SelectQueryExpression>(), connection, configureCommand, map, cancellationToken).ConfigureAwait(false);
+
         private static ISelectQueryExpressionExecutionPipeline CreateSelectExecutionPipeline<T>(this ITerminationExpressionBuilder builder)
         {
             var config = builder.GetDatabaseConfiguration();

--- a/src/HatTrick.DbEx.Sql/dbex.cs
+++ b/src/HatTrick.DbEx.Sql/dbex.cs
@@ -1,6 +1,9 @@
 ﻿using HatTrick.DbEx.Sql.Builder;
+using HatTrick.DbEx.Sql.Executor;
 using HatTrick.DbEx.Sql.Expression;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace HatTrick.DbEx.Sql
 {
@@ -109,6 +112,62 @@ namespace HatTrick.DbEx.Sql
         public static EntityFieldAssignmentsContinuation<TEntity> BuildAssignmentsFor<TEntity>(Entity<TEntity> entity)
             where TEntity : class, IDbEntity
             => new EntityComparisonAssignmentBuilder<TEntity>(entity);
+
+        /// <summary>
+        /// Get a list of all the columns for an <typeparamref name="TEntity"/> entity for use with a select query expression (effectively a "SELECT *").
+        /// </summary>
+        /// <returns>A <see cref="SelectExpressionSet"/> containing a list of <see cref="SelectExpression"/>s representing all columns for a table.</returns>
+        /// <remarks>The list will not include any fields/columns that were marked to ignore as part of configuration.</remarks>
+        public static IEnumerable<AnyElement> SelectAllFor<TEntity>(Entity<TEntity> entity)
+            where TEntity : class, IDbEntity
+        {
+            if (entity is null)
+                throw new ArgumentNullException($"{nameof(entity)} is required.");
+
+            return entity.BuildInclusiveSelectExpression().Expressions.Cast<AnyElement>();
+        }
+
+        /// <summary>
+        /// Get a list of all the columns for an <typeparamref name="TEntity"/> entity for use with a select query expression (effectively a "SELECT *").
+        /// </summary>
+        /// <returns>A <see cref="SelectExpressionSet"/> containing a list of <see cref="SelectExpression"/>s representing all columns for a table.</returns>
+        /// <remarks>The list will not include any fields/columns that were marked to ignore as part of configuration.</remarks>
+        public static IEnumerable<AnyElement> SelectAllFor<TEntity>(Entity<TEntity> entity, string aliasPrefix)
+            where TEntity : class, IDbEntity
+        {
+            return SelectAllFor(entity, name => $"{aliasPrefix}{name}");
+        }
+
+        /// <summary>
+        /// Get a list of all the columns for an <typeparamref name="TEntity"/> entity for use with a select query expression (effectively a "SELECT *").
+        /// </summary>
+        /// <returns>A <see cref="SelectExpressionSet"/> containing a list of <see cref="SelectExpression"/>s representing all columns for a table.</returns>
+        /// <remarks>The list will not include any fields/columns that were marked to ignore as part of configuration.</remarks>
+        public static IEnumerable<AnyElement> SelectAllFor<TEntity>(Entity<TEntity> entity, Func<string,string> alias)
+            where TEntity : class, IDbEntity
+        {
+            if (entity is null)
+                throw new ArgumentNullException($"{nameof(entity)} is required.");
+
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            return entity.BuildInclusiveSelectExpression(alias).Expressions.Cast<AnyElement>();
+        }
+
+        /// <summary>
+        /// Get the default mapping delegate to map values from a field reader to a <typeparamref name="TEntity"/> entity.
+        /// </summary>
+        /// <returns>A <see cref="SelectExpressionSet"/> containing a list of <see cref="SelectExpression"/>s representing all columns for a table.</returns>
+        /// <remarks>The list will not include any fields/columns that were marked to ignore as part of configuration.</remarks>
+        public static Action<ISqlFieldReader, TEntity> GetDefaultMappingFor<TEntity>(Entity<TEntity> entity)
+            where TEntity : class, IDbEntity
+        {
+            if (entity is null)
+                throw new ArgumentNullException($"{nameof(entity)} is required.");
+
+            return entity.HydrateEntity;
+        }
     }
 #pragma warning restore IDE1006 // Naming Styles
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Code/Builder/WhereClauseExpressionBuilderTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Code/Builder/WhereClauseExpressionBuilderTests.cs
@@ -61,7 +61,7 @@ namespace HatTrick.DbEx.MsSql.Test.Builder
             //when
             exp = db.SelectOne(sec.Person.Id)
                .From(sec.Person)
-               .Where(sec.Person.Id > 0 & sec.Person.SSN == "XXX");
+               .Where(sec.Person.Id > 0 & sec.Person.SocialSecurityNumber == "XXX");
 
             filterSet = ((exp as IQueryExpressionProvider).Expression as SelectQueryExpression).Where;
 
@@ -86,8 +86,8 @@ namespace HatTrick.DbEx.MsSql.Test.Builder
 
             ssnFilter.LeftArg
                 .Should().NotBeNull()
-                .And.BeOfType<PersonEntity.SSNField>()
-                .And.Be(sec.Person.SSN);
+                .And.BeOfType<PersonEntity.SocialSecurityNumberField>()
+                .And.Be(sec.Person.SocialSecurityNumber);
 
             ssnFilter.RightArg
                 .Should().BeOfType<LiteralExpression<string>>()
@@ -112,7 +112,7 @@ namespace HatTrick.DbEx.MsSql.Test.Builder
             //when
             exp = db.SelectOne(sec.Person.Id)
                .From(sec.Person)
-               .Where(sec.Person.Id > 0 & sec.Person.SSN == "XXX" & sec.Person.DateCreated != now);
+               .Where(sec.Person.Id > 0 & sec.Person.SocialSecurityNumber == "XXX" & sec.Person.DateCreated != now);
 
             filterSet = ((exp as IQueryExpressionProvider).Expression as SelectQueryExpression).Where;
 
@@ -138,8 +138,8 @@ namespace HatTrick.DbEx.MsSql.Test.Builder
 
             ssnFilter.LeftArg
                 .Should().NotBeNull()
-                .And.BeOfType<PersonEntity.SSNField>()
-                .And.Be(sec.Person.SSN);
+                .And.BeOfType<PersonEntity.SocialSecurityNumberField>()
+                .And.Be(sec.Person.SocialSecurityNumber);
 
             ssnFilter.RightArg
                 .Should().BeOfType<LiteralExpression<string>>()

--- a/test/HatTrick.DbEx.MsSql.Test.Code/Configuration/EntitiesConfigurationBuilderTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Code/Configuration/EntitiesConfigurationBuilderTests.cs
@@ -140,7 +140,7 @@ namespace HatTrick.DbEx.MsSql.Test.Code.Configuration
         {
             public IExpandoObjectMapper CreateExpandoObjectMapper() => throw new NotImplementedException();
 
-            IEntityMapper<TEntity> IMapperFactory.CreateEntityMapper<TEntity>(EntityExpression<TEntity> entity) => throw new NotImplementedException();
+            IEntityMapper<TEntity> IMapperFactory.CreateEntityMapper<TEntity>(IEntityExpression<TEntity> entity) => throw new NotImplementedException();
         }
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Code/Configuration/SchemaMetadataConfigurationBuilderTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Code/Configuration/SchemaMetadataConfigurationBuilderTests.cs
@@ -74,7 +74,7 @@ namespace HatTrick.DbEx.MsSql.Test.Code.Configuration
             var config = ConfigureForMsSqlVersion(version, builder => builder.SchemaMetadata.Use<NoOpSchemaMetadataProvider>());
 
             //when & then
-            Assert.Throws<NotImplementedException>(() => config.MetadataProvider.FindEntityMetadata((dbo.Person as ISqlMetadataIdentifier).Identifier));
+            Assert.Throws<NotImplementedException>(() => config.MetadataProvider.FindEntityMetadata((dbo.Person as ISqlMetadataIdentifierProvider).Identifier));
         }
 
         [Theory]
@@ -85,7 +85,7 @@ namespace HatTrick.DbEx.MsSql.Test.Code.Configuration
             var config = ConfigureForMsSqlVersion(version, builder => builder.SchemaMetadata.Use<NoOpSchemaMetadataProvider>());
 
             //when & then
-            Assert.Throws<NotImplementedException>(() => config.MetadataProvider.FindFieldMetadata((dbo.Person.Id as ISqlMetadataIdentifier).Identifier));
+            Assert.Throws<NotImplementedException>(() => config.MetadataProvider.FindFieldMetadata((dbo.Person.Id as ISqlMetadataIdentifierProvider).Identifier));
         }
 
         [Theory]
@@ -118,7 +118,7 @@ namespace HatTrick.DbEx.MsSql.Test.Code.Configuration
             var config = ConfigureForMsSqlVersion(version, builder => builder.SchemaMetadata.Use(new NoOpSchemaMetadataProvider()));
 
             //when & then
-            Assert.Throws<NotImplementedException>(() => config.MetadataProvider.FindEntityMetadata((dbo.Person as ISqlMetadataIdentifier).Identifier));
+            Assert.Throws<NotImplementedException>(() => config.MetadataProvider.FindEntityMetadata((dbo.Person as ISqlMetadataIdentifierProvider).Identifier));
         }
 
         [Theory]
@@ -129,7 +129,7 @@ namespace HatTrick.DbEx.MsSql.Test.Code.Configuration
             var config = ConfigureForMsSqlVersion(version, builder => builder.SchemaMetadata.Use(new NoOpSchemaMetadataProvider()));
 
             //when & then
-            Assert.Throws<NotImplementedException>(() => config.MetadataProvider.FindFieldMetadata((dbo.Person.Id as ISqlMetadataIdentifier).Identifier));
+            Assert.Throws<NotImplementedException>(() => config.MetadataProvider.FindFieldMetadata((dbo.Person.Id as ISqlMetadataIdentifierProvider).Identifier));
         }
 
         public class NoOpSchemaMetadataProvider : ISqlDatabaseMetadataProvider

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_ExecuteOverloads/SelectMany.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_ExecuteOverloads/SelectMany.cs
@@ -10,6 +10,7 @@ using Xunit;
 using DbEx.dboData;
 using HatTrick.DbEx.Sql.Connection;
 using System.Data;
+using System;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor
 {
@@ -259,6 +260,117 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
 
             //then
             persons.Should().HaveCount(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_execute_type_list_with_map_delegate_override_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var persons = new HashSet<int>();
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            exp.Execute(row => persons.Add(row.ReadField().GetValue<int>()));
+
+            //then
+            persons.Should().HaveCount(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_execute_type_list_with_commandTimeout_and_map_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+            var persons = new HashSet<int>();
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            exp.Execute(45, row => persons.Add(row.ReadField().GetValue<int>()));
+
+            //then
+            persons.Should().HaveCount(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_execute_type_list_with_connection_and_commandTimeout_and_map_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+            var persons = new HashSet<int>();
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            exp.Execute(conn, 45, row => persons.Add(row.ReadField().GetValue<int>()));
+
+            //then
+            persons.Should().HaveCount(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_execute_type_list_with_map_to_entity_delegate_override_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var persons = exp.Execute((row, person) => person.Id = row.ReadField().GetValue<int>());
+
+            //then
+            persons.Should().HaveCount(expected);
+            persons.Should().NotContain(x => x.Id <= 0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_execute_type_list_with_commandTimeout_and_map_to_entity_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var persons = exp.Execute((row, person) => person.Id = row.ReadField().GetValue<int>());
+
+            //then
+            persons.Should().HaveCount(expected);
+            persons.Should().NotContain(x => x.Id <= 0);
+        }
+
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_execute_type_list_with_connection_and_commandTimeout_and_map_to_entity_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var persons = exp.Execute((row, person) => person.Id = row.ReadField().GetValue<int>());
+
+            //then
+            persons.Should().HaveCount(expected);
+            persons.Should().NotContain(x => x.Id <= 0);
         }
         #endregion
 
@@ -804,6 +916,454 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
 
             //then
             persons.Should().HaveCount(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_list_with_map_delegate_override_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var persons = new HashSet<int>();
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            await exp.ExecuteAsync(row => persons.Add(row.ReadField().GetValue<int>()));
+
+            //then
+            persons.Should().HaveCount(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_list_with_commandTimeout_and_map_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+            var persons = new HashSet<int>();
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            await exp.ExecuteAsync(45, row => persons.Add(row.ReadField().GetValue<int>()));
+
+            //then
+            persons.Should().HaveCount(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_list_with_connection_and_map_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+            var persons = new HashSet<int>();
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            await exp.ExecuteAsync(conn, row => persons.Add(row.ReadField().GetValue<int>()));
+
+            //then
+            persons.Should().HaveCount(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_list_with_connection_and_commandTimeout_and_map_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+            var persons = new HashSet<int>();
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            await exp.ExecuteAsync(conn, 45, row => persons.Add(row.ReadField().GetValue<int>()));
+
+            //then
+            persons.Should().HaveCount(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_list_with_map_to_entity_delegate_override_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var persons = await exp.ExecuteAsync((row, person) => person.Id = row.ReadField().GetValue<int>());
+
+            //then
+            persons.Should().HaveCount(expected);
+            persons.Should().NotContain(x => x.Id <= 0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_list_with_commandTimeout_and_map_to_entity_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var persons = await exp.ExecuteAsync(45, (row, person) => person.Id = row.ReadField().GetValue<int>());
+
+            //then
+            persons.Should().HaveCount(expected);
+            persons.Should().NotContain(x => x.Id <= 0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_list_with_connection_and_map_to_entity_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var persons = await exp.ExecuteAsync(conn, (row, person) => person.Id = row.ReadField().GetValue<int>());
+
+            //then
+            persons.Should().HaveCount(expected);
+            persons.Should().NotContain(x => x.Id <= 0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_list_with_connection_and_commandTimeout_and_map_to_entity_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var persons = await exp.ExecuteAsync(conn, 45, (row, person) => person.Id = row.ReadField().GetValue<int>());
+
+            //then
+            persons.Should().HaveCount(expected);
+            persons.Should().NotContain(x => x.Id <= 0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_list_with_async_map_to_entity_delegate_override_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var persons = await exp.ExecuteAsync(row => 
+                { 
+                    var person = new Person(); 
+                    person.Id = row.ReadField().GetValue<int>(); 
+                    return person; 
+                }
+            );
+
+            //then
+            persons.Should().HaveCount(expected);
+            persons.Should().NotContain(x => x.Id <= 0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_list_with_commandTimeout_and_async_map_to_entity_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var persons = await exp.ExecuteAsync(45, row =>
+                {
+                    var person = new Person();
+                    person.Id = row.ReadField().GetValue<int>();
+                    return person;
+                }
+            );
+
+            //then
+            persons.Should().HaveCount(expected);
+            persons.Should().NotContain(x => x.Id <= 0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_list_with_connection_and_async_map_to_entity_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var persons = await exp.ExecuteAsync(conn, row =>
+                {
+                    var person = new Person();
+                    person.Id = row.ReadField().GetValue<int>();
+                    return person;
+                }
+            );
+
+            //then
+            persons.Should().HaveCount(expected);
+            persons.Should().NotContain(x => x.Id <= 0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_list_with_connection_and_commandTimeout_and_async_map_to_entity_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var persons = await exp.ExecuteAsync(conn, 45, row =>
+                {
+                    var person = new Person();
+                    person.Id = row.ReadField().GetValue<int>();
+                    return person;
+                }
+            );
+
+            //then
+            persons.Should().HaveCount(expected);
+            persons.Should().NotContain(x => x.Id <= 0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_void_with_async_map_to_entity_delegate_override_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var persons = new List<Person>();
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            await exp.ExecuteAsync(async row =>
+                {
+                    var person = new Person();
+                    person.Id = row.ReadField().GetValue<int>();
+                    await Task.Delay(TimeSpan.Zero);
+                    persons.Add(person);
+                }
+            );
+
+            //then
+            persons.Should().HaveCount(expected);
+            persons.Should().NotContain(x => x.Id <= 0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_void_with_commandTimeout_and_async_map_to_entity_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var persons = new List<Person>();
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            await exp.ExecuteAsync(45, async row =>
+                {
+                    var person = new Person();
+                    person.Id = row.ReadField().GetValue<int>();
+                    await Task.Delay(TimeSpan.Zero);
+                    persons.Add(person);
+                }
+            );
+
+            //then
+            persons.Should().HaveCount(expected);
+            persons.Should().NotContain(x => x.Id <= 0);
+        }
+
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_void_with_connection_and_async_map_to_entity_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+            var persons = new List<Person>();
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            await exp.ExecuteAsync(conn, async row =>
+                {
+                    var person = new Person();
+                    person.Id = row.ReadField().GetValue<int>();
+                    await Task.Delay(TimeSpan.Zero);
+                    persons.Add(person);
+                }
+            );
+
+            //then
+            persons.Should().HaveCount(expected);
+            persons.Should().NotContain(x => x.Id <= 0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_void_with_connection_and_commandTimeout_and_async_map_to_entity_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+            var persons = new List<Person>();
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            await exp.ExecuteAsync(conn, 45, async row =>
+                {
+                    var person = new Person();
+                    person.Id = row.ReadField().GetValue<int>();
+                    await Task.Delay(TimeSpan.Zero);
+                    persons.Add(person);
+                }
+            );
+
+            //then
+            persons.Should().HaveCount(expected);
+            persons.Should().NotContain(x => x.Id <= 0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_list_with_async_map_to_factory_created_entity_delegate_override_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var persons = await exp.ExecuteAsync(async (row, person) =>
+                {
+                    person.Id = row.ReadField().GetValue<int>();
+                    await Task.Delay(TimeSpan.Zero);
+                }
+            );
+
+            //then
+            persons.Should().HaveCount(expected);
+            persons.Should().NotContain(x => x.Id <= 0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_list_with_commandTimeout_and_async_map_to_factory_created_entity_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var persons = await exp.ExecuteAsync(45, async (row, person) =>
+                {
+                    person.Id = row.ReadField().GetValue<int>();
+                    await Task.Delay(TimeSpan.Zero);
+                }
+            );
+
+            //then
+            persons.Should().HaveCount(expected);
+            persons.Should().NotContain(x => x.Id <= 0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_list_with_connection_and_async_map_to_factory_created_entity_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var persons = await exp.ExecuteAsync(conn, async (row, person) =>
+                {
+                    person.Id = row.ReadField().GetValue<int>();
+                    await Task.Delay(TimeSpan.Zero);
+                }
+            );
+
+            //then
+            persons.Should().HaveCount(expected);
+            persons.Should().NotContain(x => x.Id <= 0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_list_with_connection_and_commandTimeout_and_async_map_to_factory_created_entity_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var persons = await exp.ExecuteAsync(conn, 45, async (row, person) =>
+                {
+                    person.Id = row.ReadField().GetValue<int>();
+                    await Task.Delay(TimeSpan.Zero);
+                }
+            );
+
+            //then
+            persons.Should().HaveCount(expected);
+            persons.Should().NotContain(x => x.Id <= 0);
         }
         #endregion
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_ExecuteOverloads/SelectOne.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_ExecuteOverloads/SelectOne.cs
@@ -10,6 +10,7 @@ using DbEx.dboData;
 using Moq;
 using HatTrick.DbEx.Sql.Connection;
 using System.Data;
+using System;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor
 {
@@ -135,6 +136,28 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
 
             //when               
             var value = exp.Execute(conn, 45);
+
+            //then
+            value.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_value_with_action_override_succeed(int version, int expected = 1)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+            object value = default;
+
+            var exp = db.SelectOne(dbo.Person.Id, dbo.Person.FirstName)
+                .From(dbo.Person)
+                .Where(dbo.Person.Id == expected);
+
+            //when               
+            await exp.ExecuteAsync(o =>
+                { value = o.ReadField().GetValue<int>(); }
+            );
 
             //then
             value.Should().Be(expected);
@@ -268,6 +291,124 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             //then
             int id = person.Id;
             id.Should().Be(expected);
+        }
+
+
+
+
+
+
+
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_execute_type_with_map_delegate_override_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var id = 0;
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            exp.Execute(row => id = row.ReadField().GetValue<int>());
+
+            //then
+            id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_execute_type_with_commandTimeout_and_map_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+            var id = 0;
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            exp.Execute(45, row => id = row.ReadField().GetValue<int>());
+
+            //then
+            id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_execute_type_with_connection_and_commandTimeout_and_map_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+            var id = 0;
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            exp.Execute(conn, 45, row => id = row.ReadField().GetValue<int>());
+
+            //then
+            id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_execute_type_with_map_to_entity_delegate_override_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var person = exp.Execute((row, person) => person.Id = row.ReadField().GetValue<int>());
+
+            //then
+            person.Should().NotBeNull();
+            person.Id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_execute_type_with_commandTimeout_and_map_to_entity_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var person = exp.Execute((row, person) => person.Id = row.ReadField().GetValue<int>());
+
+            //then
+            person.Should().NotBeNull();
+            person.Id.Should().NotBe(0);
+        }
+
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_execute_type_with_connection_and_commandTimeout_and_map_to_entity_delegate_overrides_succeed(int version, int expected = 50)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var person = exp.Execute((row, person) => person.Id = row.ReadField().GetValue<int>());
+
+            //then
+            person.Should().NotBeNull();
+            person.Id.Should().NotBe(0);
         }
         #endregion
 
@@ -820,6 +961,449 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             //then
             int id = person.Id;
             id.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_with_map_delegate_override_succeed(int version)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var id = 0;
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            await exp.ExecuteAsync(row => id = row.ReadField().GetValue<int>());
+
+            //then
+            id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_with_commandTimeout_and_map_delegate_overrides_succeed(int version)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+            var id = 0;
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            await exp.ExecuteAsync(45, row => id = row.ReadField().GetValue<int>());
+
+            //then
+            id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_with_connection_and_map_delegate_overrides_succeed(int version)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+            var id = 0;
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            await exp.ExecuteAsync(conn, row => id = row.ReadField().GetValue<int>());
+
+            //then
+            id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_with_connection_and_commandTimeout_and_map_delegate_overrides_succeed(int version)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+            var id = 0;
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            await exp.ExecuteAsync(conn, 45, row => id = row.ReadField().GetValue<int>());
+
+            //then
+            id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_with_map_to_entity_delegate_override_succeed(int version)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var person = await exp.ExecuteAsync((row, person) => person.Id = row.ReadField().GetValue<int>());
+
+            //then
+            person.Should().NotBeNull();
+            person.Id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_with_commandTimeout_and_map_to_entity_delegate_overrides_succeed(int version)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var person = await exp.ExecuteAsync(45, (row, person) => person.Id = row.ReadField().GetValue<int>());
+
+            //then
+            person.Should().NotBeNull();
+            person.Id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_with_connection_and_map_to_entity_delegate_overrides_succeed(int version)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var person = await exp.ExecuteAsync(conn, (row, person) => person.Id = row.ReadField().GetValue<int>());
+
+            //then
+            person.Should().NotBeNull();
+            person.Id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_with_connection_and_commandTimeout_and_map_to_entity_delegate_overrides_succeed(int version)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var person = await exp.ExecuteAsync(conn, 45, (row, person) => person.Id = row.ReadField().GetValue<int>());
+
+            //then
+            person.Should().NotBeNull();
+            person.Id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_with_async_map_to_entity_delegate_override_succeed(int version)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var person = await exp.ExecuteAsync(row =>
+                {
+                    var person = new Person();
+                    person.Id = row.ReadField().GetValue<int>();
+                    return person;
+                }
+            );
+
+            //then
+            person.Should().NotBeNull();
+            person.Id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_with_commandTimeout_and_async_map_to_entity_delegate_overrides_succeed(int version)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var person = await exp.ExecuteAsync(45, row =>
+                {
+                    var person = new Person();
+                    person.Id = row.ReadField().GetValue<int>();
+                    return person;
+                }
+            );
+
+            //then
+            person.Should().NotBeNull();
+            person.Id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_with_connection_and_async_map_to_entity_delegate_overrides_succeed(int version)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var person = await exp.ExecuteAsync(conn, row =>
+                {
+                    var person = new Person();
+                    person.Id = row.ReadField().GetValue<int>();
+                    return person;
+                }
+            );
+
+            //then
+            person.Should().NotBeNull();
+            person.Id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_with_connection_and_commandTimeout_and_async_map_to_entity_delegate_overrides_succeed(int version)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var person = await exp.ExecuteAsync(conn, 45, row =>
+                {
+                    var person = new Person();
+                    person.Id = row.ReadField().GetValue<int>();
+                    return person;
+                }
+            );
+
+            //then
+            person.Should().NotBeNull();
+            person.Id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_void_with_async_map_to_entity_delegate_override_succeed(int version)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            Person person = default;
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            await exp.ExecuteAsync(async row =>
+                {
+                    person = new Person();
+                    person.Id = row.ReadField().GetValue<int>();
+                    await Task.Delay(TimeSpan.Zero);
+                }
+            );
+
+            //then
+            person.Should().NotBeNull();
+            person.Id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_void_with_commandTimeout_and_async_map_to_entity_delegate_overrides_succeed(int version)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            Person person = default;
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            await exp.ExecuteAsync(45, async row =>
+                {
+                    person = new Person();
+                    person.Id = row.ReadField().GetValue<int>();
+                    await Task.Delay(TimeSpan.Zero);
+                }
+            );
+
+            //then
+            person.Should().NotBeNull();
+            person.Id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_void_with_connection_and_async_map_to_entity_delegate_overrides_succeed(int version)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+            Person person = default;
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            await exp.ExecuteAsync(conn, async row =>
+                {
+                    person = new Person();
+                    person.Id = row.ReadField().GetValue<int>();
+                    await Task.Delay(TimeSpan.Zero);
+                }
+            );
+
+            //then
+            person.Should().NotBeNull();
+            person.Id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_void_with_connection_and_commandTimeout_and_async_map_to_entity_delegate_overrides_succeed(int version)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+            Person person = default;
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            await exp.ExecuteAsync(conn, 45, async row =>
+                {
+                    person = new Person();
+                    person.Id = row.ReadField().GetValue<int>();
+                    await Task.Delay(TimeSpan.Zero);
+                }
+            );
+
+            //then
+            person.Should().NotBeNull();
+            person.Id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_with_async_map_to_factory_created_entity_delegate_override_succeed(int version)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var person = await exp.ExecuteAsync(async (row, person) =>
+                {
+                    person.Id = row.ReadField().GetValue<int>();
+                    await Task.Delay(TimeSpan.Zero);
+                }
+            );
+
+            //then
+            person.Should().NotBeNull();
+            person.Id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_with_commandTimeout_and_async_map_to_factory_created_entity_delegate_overrides_succeed(int version)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var person = await exp.ExecuteAsync(45, async (row, person) =>
+                {
+                    person.Id = row.ReadField().GetValue<int>();
+                    await Task.Delay(TimeSpan.Zero);
+                }
+            );
+
+            //then
+            person.Should().NotBeNull();
+            person.Id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_with_connection_and_async_map_to_factory_created_entity_delegate_overrides_succeed(int version)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var person = await exp.ExecuteAsync(conn, async (row, person) =>
+                {
+                    person.Id = row.ReadField().GetValue<int>();
+                    await Task.Delay(TimeSpan.Zero);
+                }
+            );
+
+            //then
+            person.Should().NotBeNull();
+            person.Id.Should().NotBe(0);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Does_execute_async_type_with_connection_and_commandTimeout_and_async_map_to_factory_created_entity_delegate_overrides_succeed(int version)
+        {
+            //given
+            var config = ConfigureForMsSqlVersion(version);
+            var conn = new SqlConnector(config.ConnectionFactory);
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var person = await exp.ExecuteAsync(conn, 45, async (row, person) =>
+                {
+                    person.Id = row.ReadField().GetValue<int>();
+                    await Task.Delay(TimeSpan.Zero);
+                }
+            );
+
+            //then
+            person.Should().NotBeNull();
+            person.Id.Should().NotBe(0);
         }
         #endregion
 

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_SelectOne/SelectOne.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_SelectOne/SelectOne.cs
@@ -2,6 +2,7 @@
 using DbEx.DataService;
 using DbEx.dboData;
 using DbEx.dboDataService;
+using DbEx.secDataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
 using HatTrick.DbEx.Sql;
@@ -70,6 +71,39 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
 
             //then
             count.Should().Be(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Can_an_overriden_property_name_return_the_overridden_property_name_when_retrieved_as_a_dynamic(int version)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var person = await db.SelectOne(
+                    sec.Person.Id, 
+                    sec.Person.SocialSecurityNumber
+                )
+                .From(sec.Person).ExecuteAsync();
+
+            //then
+            ((string)person.SocialSecurityNumber).Should().NotBeNull();
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task xCan_an_overriden_property_name_aliased_return_the_correct_data_type_when_selecting_value(int version)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var person = await db.SelectOne(
+                    sec.Person.SocialSecurityNumber.As("foo")
+                )
+                .From(sec.Person).ExecuteAsync();
+
+            //then
+            person.Should().NotBeNull();
         }
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Update/Update.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Update/Update.cs
@@ -253,5 +253,25 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
             execute.Should().Throw<SqlException>().And.Message.Should().StartWith("Incorrect syntax near");
 
         }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "WHERE")]
+        public async Task Can_update_persons_firstname_async(int version, int id = 1, string expectedFirstName = "Foo")
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.Update(dbo.Person.FirstName.Set(expectedFirstName))
+               .From(dbo.Person)
+               .Where(dbo.Person.Id == id);
+
+            //when               
+            await exp.ExecuteAsync();
+
+            //then
+            var firstName = db.SelectOne(dbo.Person.FirstName).From(dbo.Person).Where(dbo.Person.Id == id).Execute();
+            firstName.Should().Be(expectedFirstName);
+        }
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/dbex_Alias.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/dbex_Alias.cs
@@ -14,7 +14,7 @@ using System;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor
 {
-    public class Aliasing : ExecutorTestBase
+    public class dbex_Alias : ExecutorTestBase
     {
         [Theory]
         [Trait("Operation", "SUBQUERY")]

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/dbex_Coerce.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/dbex_Coerce.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace HatTrick.DbEx.MsSql.Test.Database.Executor
 {
-    public class Coerce : ExecutorTestBase
+    public class dbex_Coerce : ExecutorTestBase
     {
         [Theory]
         [Trait("Pattern", "LEFT JOIN NULL PATTERN")]

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/dbex_GetDefaultMapping.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/dbex_GetDefaultMapping.cs
@@ -1,0 +1,123 @@
+﻿using DbEx.DataService;
+using DbEx.dboData;
+using DbEx.dboDataService;
+using FluentAssertions;
+using HatTrick.DbEx.MsSql.Test.Executor;
+using HatTrick.DbEx.Sql;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HatTrick.DbEx.MsSql.Test.Database.Executor
+{
+    public partial class dbex_GetDefaultMapping : ExecutorTestBase
+    {
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Can_select_person_entity_and_map_using_default_mapping_execute_successfully(int version, int expected = 50)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany<Person>()
+                .From(dbo.Person);
+
+            //when               
+            var persons = await exp.ExecuteAsync(dbex.GetDefaultMappingFor(dbo.Person));
+
+            //then
+            persons.Should().HaveCount(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Can_use_select_all_for_person_entity_and_map_using_default_mapping_execute_successfully(int version, int expected = 50)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+            var persons = new List<Person>();
+            var map = dbex.GetDefaultMappingFor(dbo.Person);
+
+            var exp = db.SelectMany(
+                    dbex.SelectAllFor(dbo.Person)
+                )
+                .From(dbo.Person);
+
+            //when               
+            await exp.ExecuteAsync(row =>
+                {
+                    var person = new Person();
+                    map(row, person);
+                    persons.Add(person);
+                } 
+            );
+
+            //then
+            persons.Should().HaveCount(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Can_use_select_all_for_person_entity_and_additional_field_and_map_using_default_mapping_execute_successfully(int version, int expected = 52)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+            var persons = new List<(Person, int)>();
+            var map = dbex.GetDefaultMappingFor(dbo.Person);
+
+            var exp = db.SelectMany(
+                    dbex.SelectAllFor(dbo.Person),
+                    dbo.PersonAddress.AddressId
+                )
+                .From(dbo.Person)
+                .InnerJoin(dbo.PersonAddress).On(dbo.Person.Id == dbo.PersonAddress.PersonId);
+
+            //when               
+            await exp.ExecuteAsync(row =>
+                {
+                    var person = new Person();
+                    map(row, person);
+                    var addressId = row.ReadField().GetValue<int>();
+                    persons.Add((person, addressId));
+                }
+            );
+
+            //then
+            persons.Should().HaveCount(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Can_use_select_all_for_person_and_address_entity_and_map_using_default_mappings_execute_successfully(int version, int expected = 52)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+            var persons = new List<(Person, Address)>();
+            var personMap = dbex.GetDefaultMappingFor(dbo.Person);
+            var addressMap = dbex.GetDefaultMappingFor(dbo.Address);
+
+            var exp = db.SelectMany(
+                    dbex.SelectAllFor(dbo.Person)
+                    .Concat(dbex.SelectAllFor(dbo.Address))
+                )
+                .From(dbo.Person)
+                .InnerJoin(dbo.PersonAddress).On(dbo.Person.Id == dbo.PersonAddress.PersonId)
+                .InnerJoin(dbo.Address).On(dbo.PersonAddress.AddressId == dbo.Address.Id);
+
+            //when               
+            await exp.ExecuteAsync(row =>
+                {
+                    var person = new Person();
+                    personMap(row, person);
+                    var address = new Address();
+                    addressMap(row, address);
+                    persons.Add((person, address));
+                }
+            );
+
+            //then
+            persons.Should().HaveCount(expected);
+        }
+    }
+}

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/dbex_SelectAll.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/dbex_SelectAll.cs
@@ -1,0 +1,173 @@
+﻿using DbEx.DataService;
+using DbEx.dboData;
+using DbEx.dboDataService;
+using FluentAssertions;
+using HatTrick.DbEx.MsSql.Test.Executor;
+using HatTrick.DbEx.Sql;
+using HatTrick.DbEx.Sql.Expression;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HatTrick.DbEx.MsSql.Test.Database.Executor
+{
+    public partial class dbex_SelectAll : ExecutorTestBase
+    {
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Can_use_select_all_for_person_entity_successfully(int version, int expected = 50)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany(
+                    dbex.SelectAllFor(dbo.Person)
+                )
+                .From(dbo.Person);
+
+            //when               
+            var persons = await exp.ExecuteAsync();
+
+            //then
+            persons.Should().HaveCount(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Can_use_select_all_for_multiple_entities_successfully(int version, int expected = 52)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+            var expectedFieldCount = 0;
+            var rowCount = 0;
+            var fieldCount = 0;
+
+            expectedFieldCount += (dbo.Person as IExpressionListProvider<FieldExpression>).Expressions.Count();
+            expectedFieldCount += (dbo.Address as IExpressionListProvider<FieldExpression>).Expressions.Count();
+            expectedFieldCount += (dbo.PersonAddress as IExpressionListProvider<FieldExpression>).Expressions.Count();
+
+            var exp = db.SelectMany(
+                    dbex.SelectAllFor(dbo.Person)
+                    .Concat(dbex.SelectAllFor(dbo.Address))
+                    .Concat(dbex.SelectAllFor(dbo.PersonAddress))
+                )
+                .From(dbo.Person)
+                .InnerJoin(dbo.PersonAddress).On(dbo.Person.Id == dbo.PersonAddress.PersonId)
+                .InnerJoin(dbo.Address).On(dbo.PersonAddress.AddressId == dbo.Address.Id);
+
+            //when               
+            await exp.ExecuteAsync(reader =>
+            {
+                if (rowCount == 0)
+                    fieldCount = reader.FieldCount;
+                rowCount++;
+            });
+
+            //then
+            rowCount.Should().Be(expected);
+            fieldCount.Should().Be(expectedFieldCount);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Can_use_select_all_for_multiple_entities_and_additional_field_successfully(int version, int expected = 52)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+            var expectedFieldCount = 1;
+            var rowCount = 0;
+            var fieldCount = 0;
+
+            expectedFieldCount += (dbo.Person as IExpressionListProvider<FieldExpression>).Expressions.Count();
+            expectedFieldCount += (dbo.Address as IExpressionListProvider<FieldExpression>).Expressions.Count();
+            expectedFieldCount += (dbo.PersonAddress as IExpressionListProvider<FieldExpression>).Expressions.Count();
+
+            var exp = db.SelectMany(
+                    dbex.SelectAllFor(dbo.Person)
+                    .Concat(dbex.SelectAllFor(dbo.Address))
+                    .Concat(dbex.SelectAllFor(dbo.PersonAddress)),
+                    dbo.PersonAddress.AddressId.As("foo")
+                )
+                .From(dbo.Person)
+                .InnerJoin(dbo.PersonAddress).On(dbo.Person.Id == dbo.PersonAddress.PersonId)
+                .InnerJoin(dbo.Address).On(dbo.PersonAddress.AddressId == dbo.Address.Id);
+
+            //when               
+            await exp.ExecuteAsync(reader =>
+                {
+                    if (rowCount == 0)
+                        fieldCount = reader.FieldCount;
+                    rowCount++;
+                });
+
+            //then
+            rowCount.Should().Be(expected);
+            fieldCount.Should().Be(expectedFieldCount);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Can_use_select_all_for_multiple_entities_and_alias_each_with_static_prefix_execute_successfully(int version, int expected = 52)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany(
+                    dbex.SelectAllFor(dbo.Person, "Person_")
+                    .Concat(dbex.SelectAllFor(dbo.Address, "Address_"))
+                    .Concat(dbex.SelectAllFor(dbo.PersonAddress, "PersonAddress_"))
+                )
+                .From(dbo.Person)
+                .InnerJoin(dbo.PersonAddress).On(dbo.Person.Id == dbo.PersonAddress.PersonId)
+                .InnerJoin(dbo.Address).On(dbo.PersonAddress.AddressId == dbo.Address.Id);
+
+            //when               
+            var persons = await exp.ExecuteAsync();
+
+            //then
+            persons.Should().HaveCount(expected);
+            ((int)persons.First().Person_Id).Should().BeGreaterThan(0);
+            ((int)persons.First().Address_Id).Should().BeGreaterThan(0);
+            ((int)persons.First().PersonAddress_Id).Should().BeGreaterThan(0);
+            ((string)persons.First().Person_FirstName).Should().NotBeNull();
+            ((int)persons.First().PersonAddress_PersonId).Should().BeGreaterThan(0);
+            ((string)persons.First().Address_Line1).Should().NotBeNull();
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public async Task Can_use_select_all_for_multiple_entities_and_alias_only_id_fields_with_prefix_execute_successfully(int version, int expected = 52)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            static string aliasPerson(string name) => new List<string> { nameof(dbo.Person.Id), nameof(dbo.Person.DateCreated), nameof(dbo.Person.DateUpdated) }.Contains(name) ? $"{nameof(dbo.Person)}_{name}" : name;
+            static string aliasAddress(string name) => new List<string> { nameof(dbo.Address.Id), nameof(dbo.Address.DateCreated), nameof(dbo.Address.DateUpdated) }.Contains(name) ? $"{nameof(dbo.Address)}_{name}" : name;
+            static string aliasPersonAddress(string name) => new List<string> { nameof(dbo.PersonAddress.Id), nameof(dbo.PersonAddress.DateCreated) }.Contains(name) ? $"{nameof(dbo.PersonAddress)}_{name}" : name;
+
+            var exp = db.SelectMany(
+                    dbex.SelectAllFor(dbo.Person, aliasPerson)
+                    .Concat(dbex.SelectAllFor(dbo.Address, aliasAddress)
+                    .Concat(dbex.SelectAllFor(dbo.PersonAddress, aliasPersonAddress)))
+                )
+                .From(dbo.Person)
+                .InnerJoin(dbo.PersonAddress).On(dbo.Person.Id == dbo.PersonAddress.PersonId)
+                .InnerJoin(dbo.Address).On(dbo.PersonAddress.AddressId == dbo.Address.Id);
+
+            //when               
+            var persons = await exp.ExecuteAsync();
+
+            //then
+            persons.Should().HaveCount(expected);
+            ((int)persons.First().Person_Id).Should().BeGreaterThan(0);
+            ((int)persons.First().Address_Id).Should().BeGreaterThan(0);
+            ((int)persons.First().PersonAddress_Id).Should().BeGreaterThan(0);
+            ((string)persons.First().FirstName).Should().NotBeNull();
+            ((int)persons.First().PersonId).Should().BeGreaterThan(0);
+            ((string)persons.First().Line1).Should().NotBeNull();
+        }
+    }
+}

--- a/test/HatTrick.DbEx.MsSql.Test/Generated/DbExDataPackage.generated.cs
+++ b/test/HatTrick.DbEx.MsSql.Test/Generated/DbExDataPackage.generated.cs
@@ -174,7 +174,7 @@ namespace DbEx.secData
     {
         #region interface
         public virtual int Id { get; set; }
-        public virtual string SSN { get; set; }
+        public virtual string SocialSecurityNumber { get; set; }
         public virtual DateTime DateCreated { get; set; }
         public virtual DateTime DateUpdated { get; set; }
         #endregion

--- a/test/HatTrick.DbEx.MsSql.Test/Generated/DbExDataService.generated.cs
+++ b/test/HatTrick.DbEx.MsSql.Test/Generated/DbExDataService.generated.cs
@@ -7,6 +7,7 @@ using HatTrick.DbEx.Sql.Expression;
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.Linq;
 
 #pragma warning disable IDE1006 // Naming Styles
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
@@ -466,7 +467,7 @@ namespace DbEx.DataService
         /// <param name="element1">Any expression</param>
         /// <param name="element2">Any expression</param>
         /// <param name="elements">Any expression</param>
-        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{ExpandoObject}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<ExpandoObject> SelectOne(AnyElement element1, AnyElement element2, params AnyElement[] elements)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element1, element2, elements);
 
@@ -478,9 +479,21 @@ namespace DbEx.DataService
         /// </summary>
         /// <param name="element1">Any expression</param>
         /// <param name="elements">A list of any expression</param>
-        /// <returns><see cref="SelectValue{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{ExpandoObject}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<ExpandoObject> SelectOne(IEnumerable<AnyElement> elements)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, elements);
+
+        /// <summary>
+        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="AnyElement" /> method parameters.
+        /// <para>
+        /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
+        /// </para>
+        /// </summary>
+        /// <param name="elements">A list of any expression that is valid for a SELECT query expression.</param>
+        /// <param name="additionalElements">Any additional fields to select as part of the SELECT query expression.</param>
+        /// <returns><see cref="SelectValues{ExpandoObject}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        public static SelectValue<ExpandoObject> SelectOne(IEnumerable<AnyElement> elements, params AnyElement[] additionalElements)
+            => expressionBuilderFactory.CreateSelectValueBuilder(config, (elements ?? throw new ArgumentNullException($"{nameof(elements)} is required.")).Concat(additionalElements));
         #endregion
 
         #region select many
@@ -899,7 +912,7 @@ namespace DbEx.DataService
         /// <param name="element1">Any expression</param>
         /// <param name="element2">Any expression</param>
         /// <param name="elements">Any expression</param>
-        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{ExpandoObject}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<ExpandoObject> SelectMany(AnyElement element1, AnyElement element2, params AnyElement[] elements)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element1, element2, elements);
 
@@ -910,9 +923,21 @@ namespace DbEx.DataService
         /// </para>
         /// </summary>
         /// <param name="elements">A list of any expression</param>
-        /// <returns><see cref="SelectValues{TValue}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{ExpandoObject}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<ExpandoObject> SelectMany(IEnumerable<AnyElement> elements)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, elements);
+
+            /// <summary>
+        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="AnyElement" /> method parameters.
+        /// <para>
+        /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
+        /// </para>
+        /// </summary>
+        /// <param name="elements">A list of any expression that is valid for a SELECT query expression.</param>
+        /// <param name="additionalElements">Any additional fields to select as part of the SELECT query expression.</param>
+        /// <returns><see cref="SelectValues{ExpandoObject}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        public static SelectValues<ExpandoObject> SelectMany(IEnumerable<AnyElement> elements, params AnyElement[] additionalElements)
+            => expressionBuilderFactory.CreateSelectValuesBuilder(config, (elements ?? throw new ArgumentNullException($"{nameof(elements)} is required.")).Concat(additionalElements));
         #endregion
 
         #region update
@@ -1060,13 +1085,13 @@ namespace DbEx.dboDataService
         #region constructors
         public dboSchemaExpression(string identifier) : base(identifier, null)
         {
-            Entities.Add($"{identifier}.Address", Address = new AddressEntity($"{identifier}.Address", this));
-            Entities.Add($"{identifier}.Person", Person = new PersonEntity($"{identifier}.Person", this));
-            Entities.Add($"{identifier}.Person_Address", PersonAddress = new PersonAddressEntity($"{identifier}.Person_Address", this));
-            Entities.Add($"{identifier}.Product", Product = new ProductEntity($"{identifier}.Product", this));
-            Entities.Add($"{identifier}.Purchase", Purchase = new PurchaseEntity($"{identifier}.Purchase", this));
-            Entities.Add($"{identifier}.PurchaseLine", PurchaseLine = new PurchaseLineEntity($"{identifier}.PurchaseLine", this));
-            Entities.Add($"{identifier}.PersonTotalPurchasesView", PersonTotalPurchasesView = new PersonTotalPurchasesViewEntity($"{identifier}.PersonTotalPurchasesView", this));
+            Entities.Add($"{identifier}.Address", Address = new AddressEntity($"{identifier}.Address", "Address", this));
+            Entities.Add($"{identifier}.Person", Person = new PersonEntity($"{identifier}.Person", "Person", this));
+            Entities.Add($"{identifier}.Person_Address", PersonAddress = new PersonAddressEntity($"{identifier}.Person_Address", "Person_Address", this));
+            Entities.Add($"{identifier}.Product", Product = new ProductEntity($"{identifier}.Product", "Product", this));
+            Entities.Add($"{identifier}.Purchase", Purchase = new PurchaseEntity($"{identifier}.Purchase", "Purchase", this));
+            Entities.Add($"{identifier}.PurchaseLine", PurchaseLine = new PurchaseLineEntity($"{identifier}.PurchaseLine", "PurchaseLine", this));
+            Entities.Add($"{identifier}.PersonTotalPurchasesView", PersonTotalPurchasesView = new PersonTotalPurchasesViewEntity($"{identifier}.PersonTotalPurchasesView", "PersonTotalPurchasesView", this));
         }
         #endregion
     }
@@ -1263,31 +1288,31 @@ namespace DbEx.dboDataService
         #endregion
 
         #region constructors
-        private AddressEntity() : base(null, null, null)
+        private AddressEntity() : base(null, null, null, null)
         {
         }
 
-		public AddressEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public AddressEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private AddressEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private AddressEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.AddressType", AddressType = new AddressTypeField($"{identifier}.AddressType", this));
-            Fields.Add($"{identifier}.Line1", Line1 = new Line1Field($"{identifier}.Line1", this));
-            Fields.Add($"{identifier}.Line2", Line2 = new Line2Field($"{identifier}.Line2", this));
-            Fields.Add($"{identifier}.City", City = new CityField($"{identifier}.City", this));
-            Fields.Add($"{identifier}.State", State = new StateField($"{identifier}.State", this));
-            Fields.Add($"{identifier}.Zip", Zip = new ZipField($"{identifier}.Zip", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.AddressType", AddressType = new AddressTypeField($"{identifier}.AddressType", "AddressType", this));
+            Fields.Add($"{identifier}.Line1", Line1 = new Line1Field($"{identifier}.Line1", "Line1", this));
+            Fields.Add($"{identifier}.Line2", Line2 = new Line2Field($"{identifier}.Line2", "Line2", this));
+            Fields.Add($"{identifier}.City", City = new CityField($"{identifier}.City", "City", this));
+            Fields.Add($"{identifier}.State", State = new StateField($"{identifier}.State", "State", this));
+            Fields.Add($"{identifier}.Zip", Zip = new ZipField($"{identifier}.Zip", "Zip", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", "DateUpdated", this));
         }
         #endregion
 
         #region methods
         public AddressEntity As(string name)
-            => new AddressEntity(this.identifier, this.schema, name);
+            => new AddressEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -1302,6 +1327,44 @@ namespace DbEx.dboDataService
                 ,new DateTimeSelectExpression(DateCreated)
                 ,new DateTimeSelectExpression(DateUpdated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(AddressType));
+            set &= aliased != nameof(AddressType) ? new NullableEnumSelectExpression<DbEx.Data.AddressType>(AddressType).As(aliased) as NullableEnumSelectExpression<DbEx.Data.AddressType> : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(AddressType));
+
+            aliased = alias(nameof(Line1));
+            set &= aliased != nameof(Line1) ? new StringSelectExpression(Line1).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Line1));
+
+            aliased = alias(nameof(Line2));
+            set &= aliased != nameof(Line2) ? new NullableStringSelectExpression(Line2).As(aliased) as NullableStringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Line2));
+
+            aliased = alias(nameof(City));
+            set &= aliased != nameof(City) ? new StringSelectExpression(City).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(City));
+
+            aliased = alias(nameof(State));
+            set &= aliased != nameof(State) ? new StringSelectExpression(State).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(State));
+
+            aliased = alias(nameof(Zip));
+            set &= aliased != nameof(Zip) ? new StringSelectExpression(Zip).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Zip));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            aliased = alias(nameof(DateUpdated));
+            set &= aliased != nameof(DateUpdated) ? new DateTimeSelectExpression(DateUpdated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateUpdated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<Address> GetInclusiveInsertExpression(Address address)
@@ -1329,7 +1392,7 @@ namespace DbEx.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(Address address, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, Address address)
         {
 			address.Id = reader.ReadField().GetValue<int>();
 			address.AddressType = reader.ReadField().GetValue<DbEx.Data.AddressType?>();
@@ -1348,12 +1411,7 @@ namespace DbEx.dboDataService
         public partial class IdField : Int32FieldExpression<Address>
         {
             #region constructors
-            public IdField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1375,12 +1433,7 @@ namespace DbEx.dboDataService
         public partial class AddressTypeField : NullableEnumFieldExpression<Address, DbEx.Data.AddressType>
         {
             #region constructors
-            public AddressTypeField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private AddressTypeField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public AddressTypeField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1407,12 +1460,7 @@ namespace DbEx.dboDataService
         public partial class Line1Field : StringFieldExpression<Address>
         {
             #region constructors
-            public Line1Field(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private Line1Field(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public Line1Field(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1436,12 +1484,7 @@ namespace DbEx.dboDataService
         public partial class Line2Field : NullableStringFieldExpression<Address>
         {
             #region constructors
-            public Line2Field(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private Line2Field(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public Line2Field(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1467,12 +1510,7 @@ namespace DbEx.dboDataService
         public partial class CityField : StringFieldExpression<Address>
         {
             #region constructors
-            public CityField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private CityField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public CityField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1496,12 +1534,7 @@ namespace DbEx.dboDataService
         public partial class StateField : StringFieldExpression<Address>
         {
             #region constructors
-            public StateField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private StateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public StateField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1525,12 +1558,7 @@ namespace DbEx.dboDataService
         public partial class ZipField : StringFieldExpression<Address>
         {
             #region constructors
-            public ZipField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ZipField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ZipField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1554,12 +1582,7 @@ namespace DbEx.dboDataService
         public partial class DateCreatedField : DateTimeFieldExpression<Address>
         {
             #region constructors
-            public DateCreatedField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1581,12 +1604,7 @@ namespace DbEx.dboDataService
         public partial class DateUpdatedField : DateTimeFieldExpression<Address>
         {
             #region constructors
-            public DateUpdatedField(string identifier, AddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateUpdatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateUpdatedField(string identifier, string name, AddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1840,33 +1858,33 @@ namespace DbEx.dboDataService
         #endregion
 
         #region constructors
-        private PersonEntity() : base(null, null, null)
+        private PersonEntity() : base(null, null, null, null)
         {
         }
 
-		public PersonEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public PersonEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private PersonEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private PersonEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.FirstName", FirstName = new FirstNameField($"{identifier}.FirstName", this));
-            Fields.Add($"{identifier}.LastName", LastName = new LastNameField($"{identifier}.LastName", this));
-            Fields.Add($"{identifier}.BirthDate", BirthDate = new BirthDateField($"{identifier}.BirthDate", this));
-            Fields.Add($"{identifier}.GenderType", GenderType = new GenderTypeField($"{identifier}.GenderType", this));
-            Fields.Add($"{identifier}.CreditLimit", CreditLimit = new CreditLimitField($"{identifier}.CreditLimit", this));
-            Fields.Add($"{identifier}.YearOfLastCreditLimitReview", YearOfLastCreditLimitReview = new YearOfLastCreditLimitReviewField($"{identifier}.YearOfLastCreditLimitReview", this));
-            Fields.Add($"{identifier}.RegistrationDate", RegistrationDate = new RegistrationDateField($"{identifier}.RegistrationDate", this));
-            Fields.Add($"{identifier}.LastLoginDate", LastLoginDate = new LastLoginDateField($"{identifier}.LastLoginDate", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.FirstName", FirstName = new FirstNameField($"{identifier}.FirstName", "FirstName", this));
+            Fields.Add($"{identifier}.LastName", LastName = new LastNameField($"{identifier}.LastName", "LastName", this));
+            Fields.Add($"{identifier}.BirthDate", BirthDate = new BirthDateField($"{identifier}.BirthDate", "BirthDate", this));
+            Fields.Add($"{identifier}.GenderType", GenderType = new GenderTypeField($"{identifier}.GenderType", "GenderType", this));
+            Fields.Add($"{identifier}.CreditLimit", CreditLimit = new CreditLimitField($"{identifier}.CreditLimit", "CreditLimit", this));
+            Fields.Add($"{identifier}.YearOfLastCreditLimitReview", YearOfLastCreditLimitReview = new YearOfLastCreditLimitReviewField($"{identifier}.YearOfLastCreditLimitReview", "YearOfLastCreditLimitReview", this));
+            Fields.Add($"{identifier}.RegistrationDate", RegistrationDate = new RegistrationDateField($"{identifier}.RegistrationDate", "RegistrationDate", this));
+            Fields.Add($"{identifier}.LastLoginDate", LastLoginDate = new LastLoginDateField($"{identifier}.LastLoginDate", "LastLoginDate", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", "DateUpdated", this));
         }
         #endregion
 
         #region methods
         public PersonEntity As(string name)
-            => new PersonEntity(this.identifier, this.schema, name);
+            => new PersonEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -1883,6 +1901,50 @@ namespace DbEx.dboDataService
                 ,new DateTimeSelectExpression(DateCreated)
                 ,new DateTimeSelectExpression(DateUpdated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(FirstName));
+            set &= aliased != nameof(FirstName) ? new StringSelectExpression(FirstName).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(FirstName));
+
+            aliased = alias(nameof(LastName));
+            set &= aliased != nameof(LastName) ? new StringSelectExpression(LastName).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(LastName));
+
+            aliased = alias(nameof(BirthDate));
+            set &= aliased != nameof(BirthDate) ? new NullableDateTimeSelectExpression(BirthDate).As(aliased) as NullableDateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(BirthDate));
+
+            aliased = alias(nameof(GenderType));
+            set &= aliased != nameof(GenderType) ? new EnumSelectExpression<DbEx.Data.GenderType>(GenderType).As(aliased) as EnumSelectExpression<DbEx.Data.GenderType> : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(GenderType));
+
+            aliased = alias(nameof(CreditLimit));
+            set &= aliased != nameof(CreditLimit) ? new NullableInt32SelectExpression(CreditLimit).As(aliased) as NullableInt32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(CreditLimit));
+
+            aliased = alias(nameof(YearOfLastCreditLimitReview));
+            set &= aliased != nameof(YearOfLastCreditLimitReview) ? new NullableInt32SelectExpression(YearOfLastCreditLimitReview).As(aliased) as NullableInt32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(YearOfLastCreditLimitReview));
+
+            aliased = alias(nameof(RegistrationDate));
+            set &= aliased != nameof(RegistrationDate) ? new DateTimeOffsetSelectExpression(RegistrationDate).As(aliased) as DateTimeOffsetSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(RegistrationDate));
+
+            aliased = alias(nameof(LastLoginDate));
+            set &= aliased != nameof(LastLoginDate) ? new NullableDateTimeOffsetSelectExpression(LastLoginDate).As(aliased) as NullableDateTimeOffsetSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(LastLoginDate));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            aliased = alias(nameof(DateUpdated));
+            set &= aliased != nameof(DateUpdated) ? new DateTimeSelectExpression(DateUpdated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateUpdated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<Person> GetInclusiveInsertExpression(Person person)
@@ -1914,7 +1976,7 @@ namespace DbEx.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(Person person, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, Person person)
         {
 			person.Id = reader.ReadField().GetValue<int>();
 			person.FirstName = reader.ReadField().GetValue<string>();
@@ -1935,12 +1997,7 @@ namespace DbEx.dboDataService
         public partial class IdField : Int32FieldExpression<Person>
         {
             #region constructors
-            public IdField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1962,12 +2019,7 @@ namespace DbEx.dboDataService
         public partial class FirstNameField : StringFieldExpression<Person>
         {
             #region constructors
-            public FirstNameField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private FirstNameField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public FirstNameField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -1991,12 +2043,7 @@ namespace DbEx.dboDataService
         public partial class LastNameField : StringFieldExpression<Person>
         {
             #region constructors
-            public LastNameField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private LastNameField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public LastNameField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2020,12 +2067,7 @@ namespace DbEx.dboDataService
         public partial class BirthDateField : NullableDateTimeFieldExpression<Person>
         {
             #region constructors
-            public BirthDateField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private BirthDateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public BirthDateField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2052,12 +2094,7 @@ namespace DbEx.dboDataService
         public partial class GenderTypeField : EnumFieldExpression<Person, DbEx.Data.GenderType>
         {
             #region constructors
-            public GenderTypeField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private GenderTypeField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public GenderTypeField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2081,12 +2118,7 @@ namespace DbEx.dboDataService
         public partial class CreditLimitField : NullableInt32FieldExpression<Person>
         {
             #region constructors
-            public CreditLimitField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private CreditLimitField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public CreditLimitField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2113,12 +2145,7 @@ namespace DbEx.dboDataService
         public partial class YearOfLastCreditLimitReviewField : NullableInt32FieldExpression<Person>
         {
             #region constructors
-            public YearOfLastCreditLimitReviewField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private YearOfLastCreditLimitReviewField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public YearOfLastCreditLimitReviewField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2145,12 +2172,7 @@ namespace DbEx.dboDataService
         public partial class RegistrationDateField : DateTimeOffsetFieldExpression<Person>
         {
             #region constructors
-            public RegistrationDateField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private RegistrationDateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public RegistrationDateField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2174,12 +2196,7 @@ namespace DbEx.dboDataService
         public partial class LastLoginDateField : NullableDateTimeOffsetFieldExpression<Person>
         {
             #region constructors
-            public LastLoginDateField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private LastLoginDateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public LastLoginDateField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2206,12 +2223,7 @@ namespace DbEx.dboDataService
         public partial class DateCreatedField : DateTimeFieldExpression<Person>
         {
             #region constructors
-            public DateCreatedField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2233,12 +2245,7 @@ namespace DbEx.dboDataService
         public partial class DateUpdatedField : DateTimeFieldExpression<Person>
         {
             #region constructors
-            public DateUpdatedField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateUpdatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateUpdatedField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2353,26 +2360,26 @@ namespace DbEx.dboDataService
         #endregion
 
         #region constructors
-        private PersonAddressEntity() : base(null, null, null)
+        private PersonAddressEntity() : base(null, null, null, null)
         {
         }
 
-		public PersonAddressEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public PersonAddressEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private PersonAddressEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private PersonAddressEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.PersonId", PersonId = new PersonIdField($"{identifier}.PersonId", this));
-            Fields.Add($"{identifier}.AddressId", AddressId = new AddressIdField($"{identifier}.AddressId", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.PersonId", PersonId = new PersonIdField($"{identifier}.PersonId", "PersonId", this));
+            Fields.Add($"{identifier}.AddressId", AddressId = new AddressIdField($"{identifier}.AddressId", "AddressId", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
         }
         #endregion
 
         #region methods
         public PersonAddressEntity As(string name)
-            => new PersonAddressEntity(this.identifier, this.schema, name);
+            => new PersonAddressEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -2382,6 +2389,29 @@ namespace DbEx.dboDataService
                 ,new Int32SelectExpression(AddressId)
                 ,new DateTimeSelectExpression(DateCreated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(PersonId));
+            set &= aliased != nameof(PersonId) ? new Int32SelectExpression(PersonId).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(PersonId));
+
+            aliased = alias(nameof(AddressId));
+            set &= aliased != nameof(AddressId) ? new Int32SelectExpression(AddressId).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(AddressId));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<PersonAddress> GetInclusiveInsertExpression(PersonAddress personAddress)
@@ -2401,7 +2431,7 @@ namespace DbEx.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(PersonAddress personAddress, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, PersonAddress personAddress)
         {
 			personAddress.Id = reader.ReadField().GetValue<int>();
 			personAddress.PersonId = reader.ReadField().GetValue<int>();
@@ -2415,12 +2445,7 @@ namespace DbEx.dboDataService
         public partial class IdField : Int32FieldExpression<PersonAddress>
         {
             #region constructors
-            public IdField(string identifier, PersonAddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, PersonAddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2442,12 +2467,7 @@ namespace DbEx.dboDataService
         public partial class PersonIdField : Int32FieldExpression<PersonAddress>
         {
             #region constructors
-            public PersonIdField(string identifier, PersonAddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PersonIdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PersonIdField(string identifier, string name, PersonAddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2471,12 +2491,7 @@ namespace DbEx.dboDataService
         public partial class AddressIdField : Int32FieldExpression<PersonAddress>
         {
             #region constructors
-            public AddressIdField(string identifier, PersonAddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private AddressIdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public AddressIdField(string identifier, string name, PersonAddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2500,12 +2515,7 @@ namespace DbEx.dboDataService
         public partial class DateCreatedField : DateTimeFieldExpression<PersonAddress>
         {
             #region constructors
-            public DateCreatedField(string identifier, PersonAddressEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, PersonAddressEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -2870,39 +2880,39 @@ namespace DbEx.dboDataService
         #endregion
 
         #region constructors
-        private ProductEntity() : base(null, null, null)
+        private ProductEntity() : base(null, null, null, null)
         {
         }
 
-		public ProductEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public ProductEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private ProductEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private ProductEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.ProductCategoryType", ProductCategoryType = new ProductCategoryTypeField($"{identifier}.ProductCategoryType", this));
-            Fields.Add($"{identifier}.Name", Name = new NameField($"{identifier}.Name", this));
-            Fields.Add($"{identifier}.Description", Description = new DescriptionField($"{identifier}.Description", this));
-            Fields.Add($"{identifier}.ListPrice", ListPrice = new ListPriceField($"{identifier}.ListPrice", this));
-            Fields.Add($"{identifier}.Price", Price = new PriceField($"{identifier}.Price", this));
-            Fields.Add($"{identifier}.Quantity", Quantity = new QuantityField($"{identifier}.Quantity", this));
-            Fields.Add($"{identifier}.Image", Image = new ImageField($"{identifier}.Image", this));
-            Fields.Add($"{identifier}.Height", Height = new HeightField($"{identifier}.Height", this));
-            Fields.Add($"{identifier}.Width", Width = new WidthField($"{identifier}.Width", this));
-            Fields.Add($"{identifier}.Depth", Depth = new DepthField($"{identifier}.Depth", this));
-            Fields.Add($"{identifier}.Weight", Weight = new WeightField($"{identifier}.Weight", this));
-            Fields.Add($"{identifier}.ShippingWeight", ShippingWeight = new ShippingWeightField($"{identifier}.ShippingWeight", this));
-            Fields.Add($"{identifier}.ValidStartTimeOfDayForPurchase", ValidStartTimeOfDayForPurchase = new ValidStartTimeOfDayForPurchaseField($"{identifier}.ValidStartTimeOfDayForPurchase", this));
-            Fields.Add($"{identifier}.ValidEndTimeOfDayForPurchase", ValidEndTimeOfDayForPurchase = new ValidEndTimeOfDayForPurchaseField($"{identifier}.ValidEndTimeOfDayForPurchase", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.ProductCategoryType", ProductCategoryType = new ProductCategoryTypeField($"{identifier}.ProductCategoryType", "ProductCategoryType", this));
+            Fields.Add($"{identifier}.Name", Name = new NameField($"{identifier}.Name", "Name", this));
+            Fields.Add($"{identifier}.Description", Description = new DescriptionField($"{identifier}.Description", "Description", this));
+            Fields.Add($"{identifier}.ListPrice", ListPrice = new ListPriceField($"{identifier}.ListPrice", "ListPrice", this));
+            Fields.Add($"{identifier}.Price", Price = new PriceField($"{identifier}.Price", "Price", this));
+            Fields.Add($"{identifier}.Quantity", Quantity = new QuantityField($"{identifier}.Quantity", "Quantity", this));
+            Fields.Add($"{identifier}.Image", Image = new ImageField($"{identifier}.Image", "Image", this));
+            Fields.Add($"{identifier}.Height", Height = new HeightField($"{identifier}.Height", "Height", this));
+            Fields.Add($"{identifier}.Width", Width = new WidthField($"{identifier}.Width", "Width", this));
+            Fields.Add($"{identifier}.Depth", Depth = new DepthField($"{identifier}.Depth", "Depth", this));
+            Fields.Add($"{identifier}.Weight", Weight = new WeightField($"{identifier}.Weight", "Weight", this));
+            Fields.Add($"{identifier}.ShippingWeight", ShippingWeight = new ShippingWeightField($"{identifier}.ShippingWeight", "ShippingWeight", this));
+            Fields.Add($"{identifier}.ValidStartTimeOfDayForPurchase", ValidStartTimeOfDayForPurchase = new ValidStartTimeOfDayForPurchaseField($"{identifier}.ValidStartTimeOfDayForPurchase", "ValidStartTimeOfDayForPurchase", this));
+            Fields.Add($"{identifier}.ValidEndTimeOfDayForPurchase", ValidEndTimeOfDayForPurchase = new ValidEndTimeOfDayForPurchaseField($"{identifier}.ValidEndTimeOfDayForPurchase", "ValidEndTimeOfDayForPurchase", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", "DateUpdated", this));
         }
         #endregion
 
         #region methods
         public ProductEntity As(string name)
-            => new ProductEntity(this.identifier, this.schema, name);
+            => new ProductEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -2925,6 +2935,68 @@ namespace DbEx.dboDataService
                 ,new DateTimeSelectExpression(DateCreated)
                 ,new DateTimeSelectExpression(DateUpdated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(ProductCategoryType));
+            set &= aliased != nameof(ProductCategoryType) ? new NullableEnumSelectExpression<DbEx.Data.ProductCategoryType>(ProductCategoryType).As(aliased) as NullableEnumSelectExpression<DbEx.Data.ProductCategoryType> : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ProductCategoryType));
+
+            aliased = alias(nameof(Name));
+            set &= aliased != nameof(Name) ? new StringSelectExpression(Name).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Name));
+
+            aliased = alias(nameof(Description));
+            set &= aliased != nameof(Description) ? new NullableStringSelectExpression(Description).As(aliased) as NullableStringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Description));
+
+            aliased = alias(nameof(ListPrice));
+            set &= aliased != nameof(ListPrice) ? new DoubleSelectExpression(ListPrice).As(aliased) as DoubleSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ListPrice));
+
+            aliased = alias(nameof(Price));
+            set &= aliased != nameof(Price) ? new DoubleSelectExpression(Price).As(aliased) as DoubleSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Price));
+
+            aliased = alias(nameof(Quantity));
+            set &= aliased != nameof(Quantity) ? new Int32SelectExpression(Quantity).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Quantity));
+
+            aliased = alias(nameof(Image));
+            set &= aliased != nameof(Image) ? new NullableByteArraySelectExpression(Image).As(aliased) as NullableByteArraySelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Image));
+
+            aliased = alias(nameof(Height));
+            set &= aliased != nameof(Height) ? new NullableDecimalSelectExpression(Height).As(aliased) as NullableDecimalSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Height));
+
+            aliased = alias(nameof(Width));
+            set &= aliased != nameof(Width) ? new NullableDecimalSelectExpression(Width).As(aliased) as NullableDecimalSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Width));
+
+            aliased = alias(nameof(Depth));
+            set &= aliased != nameof(Depth) ? new NullableDecimalSelectExpression(Depth).As(aliased) as NullableDecimalSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Depth));
+
+            aliased = alias(nameof(Weight));
+            set &= aliased != nameof(Weight) ? new NullableDecimalSelectExpression(Weight).As(aliased) as NullableDecimalSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Weight));
+
+            aliased = alias(nameof(ShippingWeight));
+            set &= aliased != nameof(ShippingWeight) ? new DecimalSelectExpression(ShippingWeight).As(aliased) as DecimalSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ShippingWeight));
+
+            aliased = alias(nameof(ValidStartTimeOfDayForPurchase));
+            set &= aliased != nameof(ValidStartTimeOfDayForPurchase) ? new NullableTimeSpanSelectExpression(ValidStartTimeOfDayForPurchase).As(aliased) as NullableTimeSpanSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ValidStartTimeOfDayForPurchase));
+
+            aliased = alias(nameof(ValidEndTimeOfDayForPurchase));
+            set &= aliased != nameof(ValidEndTimeOfDayForPurchase) ? new NullableTimeSpanSelectExpression(ValidEndTimeOfDayForPurchase).As(aliased) as NullableTimeSpanSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ValidEndTimeOfDayForPurchase));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            aliased = alias(nameof(DateUpdated));
+            set &= aliased != nameof(DateUpdated) ? new DateTimeSelectExpression(DateUpdated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateUpdated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<Product> GetInclusiveInsertExpression(Product product)
@@ -2968,7 +3040,7 @@ namespace DbEx.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(Product product, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, Product product)
         {
 			product.Id = reader.ReadField().GetValue<int>();
 			product.ProductCategoryType = reader.ReadField().GetValue<DbEx.Data.ProductCategoryType?>();
@@ -2995,12 +3067,7 @@ namespace DbEx.dboDataService
         public partial class IdField : Int32FieldExpression<Product>
         {
             #region constructors
-            public IdField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3022,12 +3089,7 @@ namespace DbEx.dboDataService
         public partial class ProductCategoryTypeField : NullableEnumFieldExpression<Product, DbEx.Data.ProductCategoryType>
         {
             #region constructors
-            public ProductCategoryTypeField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ProductCategoryTypeField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ProductCategoryTypeField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3054,12 +3116,7 @@ namespace DbEx.dboDataService
         public partial class NameField : StringFieldExpression<Product>
         {
             #region constructors
-            public NameField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private NameField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public NameField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3083,12 +3140,7 @@ namespace DbEx.dboDataService
         public partial class DescriptionField : NullableStringFieldExpression<Product>
         {
             #region constructors
-            public DescriptionField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DescriptionField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DescriptionField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3114,12 +3166,7 @@ namespace DbEx.dboDataService
         public partial class ListPriceField : DoubleFieldExpression<Product>
         {
             #region constructors
-            public ListPriceField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ListPriceField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ListPriceField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3143,12 +3190,7 @@ namespace DbEx.dboDataService
         public partial class PriceField : DoubleFieldExpression<Product>
         {
             #region constructors
-            public PriceField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PriceField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PriceField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3172,12 +3214,7 @@ namespace DbEx.dboDataService
         public partial class QuantityField : Int32FieldExpression<Product>
         {
             #region constructors
-            public QuantityField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private QuantityField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public QuantityField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3201,12 +3238,7 @@ namespace DbEx.dboDataService
         public partial class ImageField : NullableByteArrayFieldExpression<Product>
         {
             #region constructors
-            public ImageField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ImageField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ImageField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3232,12 +3264,7 @@ namespace DbEx.dboDataService
         public partial class HeightField : NullableDecimalFieldExpression<Product>
         {
             #region constructors
-            public HeightField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private HeightField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public HeightField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3264,12 +3291,7 @@ namespace DbEx.dboDataService
         public partial class WidthField : NullableDecimalFieldExpression<Product>
         {
             #region constructors
-            public WidthField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private WidthField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public WidthField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3296,12 +3318,7 @@ namespace DbEx.dboDataService
         public partial class DepthField : NullableDecimalFieldExpression<Product>
         {
             #region constructors
-            public DepthField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DepthField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DepthField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3328,12 +3345,7 @@ namespace DbEx.dboDataService
         public partial class WeightField : NullableDecimalFieldExpression<Product>
         {
             #region constructors
-            public WeightField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private WeightField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public WeightField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3360,12 +3372,7 @@ namespace DbEx.dboDataService
         public partial class ShippingWeightField : DecimalFieldExpression<Product>
         {
             #region constructors
-            public ShippingWeightField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ShippingWeightField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ShippingWeightField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3389,12 +3396,7 @@ namespace DbEx.dboDataService
         public partial class ValidStartTimeOfDayForPurchaseField : NullableTimeSpanFieldExpression<Product>
         {
             #region constructors
-            public ValidStartTimeOfDayForPurchaseField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ValidStartTimeOfDayForPurchaseField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ValidStartTimeOfDayForPurchaseField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3421,12 +3423,7 @@ namespace DbEx.dboDataService
         public partial class ValidEndTimeOfDayForPurchaseField : NullableTimeSpanFieldExpression<Product>
         {
             #region constructors
-            public ValidEndTimeOfDayForPurchaseField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ValidEndTimeOfDayForPurchaseField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ValidEndTimeOfDayForPurchaseField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3453,12 +3450,7 @@ namespace DbEx.dboDataService
         public partial class DateCreatedField : DateTimeFieldExpression<Product>
         {
             #region constructors
-            public DateCreatedField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3480,12 +3472,7 @@ namespace DbEx.dboDataService
         public partial class DateUpdatedField : DateTimeFieldExpression<Product>
         {
             #region constructors
-            public DateUpdatedField(string identifier, ProductEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateUpdatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateUpdatedField(string identifier, string name, ProductEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3774,35 +3761,35 @@ namespace DbEx.dboDataService
         #endregion
 
         #region constructors
-        private PurchaseEntity() : base(null, null, null)
+        private PurchaseEntity() : base(null, null, null, null)
         {
         }
 
-		public PurchaseEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public PurchaseEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private PurchaseEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private PurchaseEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.PersonId", PersonId = new PersonIdField($"{identifier}.PersonId", this));
-            Fields.Add($"{identifier}.OrderNumber", OrderNumber = new OrderNumberField($"{identifier}.OrderNumber", this));
-            Fields.Add($"{identifier}.TotalPurchaseQuantity", TotalPurchaseQuantity = new TotalPurchaseQuantityField($"{identifier}.TotalPurchaseQuantity", this));
-            Fields.Add($"{identifier}.TotalPurchaseAmount", TotalPurchaseAmount = new TotalPurchaseAmountField($"{identifier}.TotalPurchaseAmount", this));
-            Fields.Add($"{identifier}.PurchaseDate", PurchaseDate = new PurchaseDateField($"{identifier}.PurchaseDate", this));
-            Fields.Add($"{identifier}.ShipDate", ShipDate = new ShipDateField($"{identifier}.ShipDate", this));
-            Fields.Add($"{identifier}.ExpectedDeliveryDate", ExpectedDeliveryDate = new ExpectedDeliveryDateField($"{identifier}.ExpectedDeliveryDate", this));
-            Fields.Add($"{identifier}.TrackingIdentifier", TrackingIdentifier = new TrackingIdentifierField($"{identifier}.TrackingIdentifier", this));
-            Fields.Add($"{identifier}.PaymentMethodType", PaymentMethodType = new PaymentMethodTypeField($"{identifier}.PaymentMethodType", this));
-            Fields.Add($"{identifier}.PaymentSourceType", PaymentSourceType = new PaymentSourceTypeField($"{identifier}.PaymentSourceType", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.PersonId", PersonId = new PersonIdField($"{identifier}.PersonId", "PersonId", this));
+            Fields.Add($"{identifier}.OrderNumber", OrderNumber = new OrderNumberField($"{identifier}.OrderNumber", "OrderNumber", this));
+            Fields.Add($"{identifier}.TotalPurchaseQuantity", TotalPurchaseQuantity = new TotalPurchaseQuantityField($"{identifier}.TotalPurchaseQuantity", "TotalPurchaseQuantity", this));
+            Fields.Add($"{identifier}.TotalPurchaseAmount", TotalPurchaseAmount = new TotalPurchaseAmountField($"{identifier}.TotalPurchaseAmount", "TotalPurchaseAmount", this));
+            Fields.Add($"{identifier}.PurchaseDate", PurchaseDate = new PurchaseDateField($"{identifier}.PurchaseDate", "PurchaseDate", this));
+            Fields.Add($"{identifier}.ShipDate", ShipDate = new ShipDateField($"{identifier}.ShipDate", "ShipDate", this));
+            Fields.Add($"{identifier}.ExpectedDeliveryDate", ExpectedDeliveryDate = new ExpectedDeliveryDateField($"{identifier}.ExpectedDeliveryDate", "ExpectedDeliveryDate", this));
+            Fields.Add($"{identifier}.TrackingIdentifier", TrackingIdentifier = new TrackingIdentifierField($"{identifier}.TrackingIdentifier", "TrackingIdentifier", this));
+            Fields.Add($"{identifier}.PaymentMethodType", PaymentMethodType = new PaymentMethodTypeField($"{identifier}.PaymentMethodType", "PaymentMethodType", this));
+            Fields.Add($"{identifier}.PaymentSourceType", PaymentSourceType = new PaymentSourceTypeField($"{identifier}.PaymentSourceType", "PaymentSourceType", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", "DateUpdated", this));
         }
         #endregion
 
         #region methods
         public PurchaseEntity As(string name)
-            => new PurchaseEntity(this.identifier, this.schema, name);
+            => new PurchaseEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -3821,6 +3808,56 @@ namespace DbEx.dboDataService
                 ,new DateTimeSelectExpression(DateCreated)
                 ,new DateTimeSelectExpression(DateUpdated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(PersonId));
+            set &= aliased != nameof(PersonId) ? new Int32SelectExpression(PersonId).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(PersonId));
+
+            aliased = alias(nameof(OrderNumber));
+            set &= aliased != nameof(OrderNumber) ? new StringSelectExpression(OrderNumber).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(OrderNumber));
+
+            aliased = alias(nameof(TotalPurchaseQuantity));
+            set &= aliased != nameof(TotalPurchaseQuantity) ? new StringSelectExpression(TotalPurchaseQuantity).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(TotalPurchaseQuantity));
+
+            aliased = alias(nameof(TotalPurchaseAmount));
+            set &= aliased != nameof(TotalPurchaseAmount) ? new DoubleSelectExpression(TotalPurchaseAmount).As(aliased) as DoubleSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(TotalPurchaseAmount));
+
+            aliased = alias(nameof(PurchaseDate));
+            set &= aliased != nameof(PurchaseDate) ? new DateTimeSelectExpression(PurchaseDate).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(PurchaseDate));
+
+            aliased = alias(nameof(ShipDate));
+            set &= aliased != nameof(ShipDate) ? new NullableDateTimeSelectExpression(ShipDate).As(aliased) as NullableDateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ShipDate));
+
+            aliased = alias(nameof(ExpectedDeliveryDate));
+            set &= aliased != nameof(ExpectedDeliveryDate) ? new NullableDateTimeSelectExpression(ExpectedDeliveryDate).As(aliased) as NullableDateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ExpectedDeliveryDate));
+
+            aliased = alias(nameof(TrackingIdentifier));
+            set &= aliased != nameof(TrackingIdentifier) ? new NullableGuidSelectExpression(TrackingIdentifier).As(aliased) as NullableGuidSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(TrackingIdentifier));
+
+            aliased = alias(nameof(PaymentMethodType));
+            set &= aliased != nameof(PaymentMethodType) ? new EnumSelectExpression<DbEx.Data.PaymentMethodType>(PaymentMethodType).As(aliased) as EnumSelectExpression<DbEx.Data.PaymentMethodType> : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(PaymentMethodType));
+
+            aliased = alias(nameof(PaymentSourceType));
+            set &= aliased != nameof(PaymentSourceType) ? new NullableEnumSelectExpression<DbEx.Data.PaymentSourceType>(PaymentSourceType).As(aliased) as NullableEnumSelectExpression<DbEx.Data.PaymentSourceType> : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(PaymentSourceType));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            aliased = alias(nameof(DateUpdated));
+            set &= aliased != nameof(DateUpdated) ? new DateTimeSelectExpression(DateUpdated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateUpdated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<Purchase> GetInclusiveInsertExpression(Purchase purchase)
@@ -3856,7 +3893,7 @@ namespace DbEx.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(Purchase purchase, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, Purchase purchase)
         {
 			purchase.Id = reader.ReadField().GetValue<int>();
 			purchase.PersonId = reader.ReadField().GetValue<int>();
@@ -3879,12 +3916,7 @@ namespace DbEx.dboDataService
         public partial class IdField : Int32FieldExpression<Purchase>
         {
             #region constructors
-            public IdField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3906,12 +3938,7 @@ namespace DbEx.dboDataService
         public partial class PersonIdField : Int32FieldExpression<Purchase>
         {
             #region constructors
-            public PersonIdField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PersonIdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PersonIdField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3935,12 +3962,7 @@ namespace DbEx.dboDataService
         public partial class OrderNumberField : StringFieldExpression<Purchase>
         {
             #region constructors
-            public OrderNumberField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private OrderNumberField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public OrderNumberField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3964,12 +3986,7 @@ namespace DbEx.dboDataService
         public partial class TotalPurchaseQuantityField : StringFieldExpression<Purchase>
         {
             #region constructors
-            public TotalPurchaseQuantityField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private TotalPurchaseQuantityField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public TotalPurchaseQuantityField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -3993,12 +4010,7 @@ namespace DbEx.dboDataService
         public partial class TotalPurchaseAmountField : DoubleFieldExpression<Purchase>
         {
             #region constructors
-            public TotalPurchaseAmountField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private TotalPurchaseAmountField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public TotalPurchaseAmountField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4022,12 +4034,7 @@ namespace DbEx.dboDataService
         public partial class PurchaseDateField : DateTimeFieldExpression<Purchase>
         {
             #region constructors
-            public PurchaseDateField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PurchaseDateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PurchaseDateField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4051,12 +4058,7 @@ namespace DbEx.dboDataService
         public partial class ShipDateField : NullableDateTimeFieldExpression<Purchase>
         {
             #region constructors
-            public ShipDateField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ShipDateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ShipDateField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4083,12 +4085,7 @@ namespace DbEx.dboDataService
         public partial class ExpectedDeliveryDateField : NullableDateTimeFieldExpression<Purchase>
         {
             #region constructors
-            public ExpectedDeliveryDateField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ExpectedDeliveryDateField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ExpectedDeliveryDateField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4115,12 +4112,7 @@ namespace DbEx.dboDataService
         public partial class TrackingIdentifierField : NullableGuidFieldExpression<Purchase>
         {
             #region constructors
-            public TrackingIdentifierField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private TrackingIdentifierField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public TrackingIdentifierField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4147,12 +4139,7 @@ namespace DbEx.dboDataService
         public partial class PaymentMethodTypeField : EnumFieldExpression<Purchase, DbEx.Data.PaymentMethodType>
         {
             #region constructors
-            public PaymentMethodTypeField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PaymentMethodTypeField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PaymentMethodTypeField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4176,12 +4163,7 @@ namespace DbEx.dboDataService
         public partial class PaymentSourceTypeField : NullableEnumFieldExpression<Purchase, DbEx.Data.PaymentSourceType>
         {
             #region constructors
-            public PaymentSourceTypeField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PaymentSourceTypeField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PaymentSourceTypeField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4208,12 +4190,7 @@ namespace DbEx.dboDataService
         public partial class DateCreatedField : DateTimeFieldExpression<Purchase>
         {
             #region constructors
-            public DateCreatedField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4235,12 +4212,7 @@ namespace DbEx.dboDataService
         public partial class DateUpdatedField : DateTimeFieldExpression<Purchase>
         {
             #region constructors
-            public DateUpdatedField(string identifier, PurchaseEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateUpdatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateUpdatedField(string identifier, string name, PurchaseEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4415,29 +4387,29 @@ namespace DbEx.dboDataService
         #endregion
 
         #region constructors
-        private PurchaseLineEntity() : base(null, null, null)
+        private PurchaseLineEntity() : base(null, null, null, null)
         {
         }
 
-		public PurchaseLineEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public PurchaseLineEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private PurchaseLineEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private PurchaseLineEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.PurchaseId", PurchaseId = new PurchaseIdField($"{identifier}.PurchaseId", this));
-            Fields.Add($"{identifier}.ProductId", ProductId = new ProductIdField($"{identifier}.ProductId", this));
-            Fields.Add($"{identifier}.PurchasePrice", PurchasePrice = new PurchasePriceField($"{identifier}.PurchasePrice", this));
-            Fields.Add($"{identifier}.Quantity", Quantity = new QuantityField($"{identifier}.Quantity", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.PurchaseId", PurchaseId = new PurchaseIdField($"{identifier}.PurchaseId", "PurchaseId", this));
+            Fields.Add($"{identifier}.ProductId", ProductId = new ProductIdField($"{identifier}.ProductId", "ProductId", this));
+            Fields.Add($"{identifier}.PurchasePrice", PurchasePrice = new PurchasePriceField($"{identifier}.PurchasePrice", "PurchasePrice", this));
+            Fields.Add($"{identifier}.Quantity", Quantity = new QuantityField($"{identifier}.Quantity", "Quantity", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", "DateUpdated", this));
         }
         #endregion
 
         #region methods
         public PurchaseLineEntity As(string name)
-            => new PurchaseLineEntity(this.identifier, this.schema, name);
+            => new PurchaseLineEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -4450,6 +4422,38 @@ namespace DbEx.dboDataService
                 ,new DateTimeSelectExpression(DateCreated)
                 ,new DateTimeSelectExpression(DateUpdated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(PurchaseId));
+            set &= aliased != nameof(PurchaseId) ? new Int32SelectExpression(PurchaseId).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(PurchaseId));
+
+            aliased = alias(nameof(ProductId));
+            set &= aliased != nameof(ProductId) ? new Int32SelectExpression(ProductId).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(ProductId));
+
+            aliased = alias(nameof(PurchasePrice));
+            set &= aliased != nameof(PurchasePrice) ? new DecimalSelectExpression(PurchasePrice).As(aliased) as DecimalSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(PurchasePrice));
+
+            aliased = alias(nameof(Quantity));
+            set &= aliased != nameof(Quantity) ? new Int32SelectExpression(Quantity).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Quantity));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            aliased = alias(nameof(DateUpdated));
+            set &= aliased != nameof(DateUpdated) ? new DateTimeSelectExpression(DateUpdated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateUpdated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<PurchaseLine> GetInclusiveInsertExpression(PurchaseLine purchaseLine)
@@ -4473,7 +4477,7 @@ namespace DbEx.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(PurchaseLine purchaseLine, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, PurchaseLine purchaseLine)
         {
 			purchaseLine.Id = reader.ReadField().GetValue<int>();
 			purchaseLine.PurchaseId = reader.ReadField().GetValue<int>();
@@ -4490,12 +4494,7 @@ namespace DbEx.dboDataService
         public partial class IdField : Int32FieldExpression<PurchaseLine>
         {
             #region constructors
-            public IdField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4517,12 +4516,7 @@ namespace DbEx.dboDataService
         public partial class PurchaseIdField : Int32FieldExpression<PurchaseLine>
         {
             #region constructors
-            public PurchaseIdField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PurchaseIdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PurchaseIdField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4546,12 +4540,7 @@ namespace DbEx.dboDataService
         public partial class ProductIdField : Int32FieldExpression<PurchaseLine>
         {
             #region constructors
-            public ProductIdField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private ProductIdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public ProductIdField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4575,12 +4564,7 @@ namespace DbEx.dboDataService
         public partial class PurchasePriceField : DecimalFieldExpression<PurchaseLine>
         {
             #region constructors
-            public PurchasePriceField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private PurchasePriceField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public PurchasePriceField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4604,12 +4588,7 @@ namespace DbEx.dboDataService
         public partial class QuantityField : Int32FieldExpression<PurchaseLine>
         {
             #region constructors
-            public QuantityField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private QuantityField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public QuantityField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4633,12 +4612,7 @@ namespace DbEx.dboDataService
         public partial class DateCreatedField : DateTimeFieldExpression<PurchaseLine>
         {
             #region constructors
-            public DateCreatedField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4660,12 +4634,7 @@ namespace DbEx.dboDataService
         public partial class DateUpdatedField : DateTimeFieldExpression<PurchaseLine>
         {
             #region constructors
-            public DateUpdatedField(string identifier, PurchaseLineEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateUpdatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateUpdatedField(string identifier, string name, PurchaseLineEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4755,25 +4724,25 @@ namespace DbEx.dboDataService
         #endregion
 
         #region constructors
-        private PersonTotalPurchasesViewEntity() : base(null, null, null)
+        private PersonTotalPurchasesViewEntity() : base(null, null, null, null)
         {
         }
 
-		public PersonTotalPurchasesViewEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public PersonTotalPurchasesViewEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private PersonTotalPurchasesViewEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private PersonTotalPurchasesViewEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.TotalAmount", TotalAmount = new TotalAmountField($"{identifier}.TotalAmount", this));
-            Fields.Add($"{identifier}.TotalCount", TotalCount = new TotalCountField($"{identifier}.TotalCount", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.TotalAmount", TotalAmount = new TotalAmountField($"{identifier}.TotalAmount", "TotalAmount", this));
+            Fields.Add($"{identifier}.TotalCount", TotalCount = new TotalCountField($"{identifier}.TotalCount", "TotalCount", this));
         }
         #endregion
 
         #region methods
         public PersonTotalPurchasesViewEntity As(string name)
-            => new PersonTotalPurchasesViewEntity(this.identifier, this.schema, name);
+            => new PersonTotalPurchasesViewEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
@@ -4782,6 +4751,26 @@ namespace DbEx.dboDataService
                 ,new NullableDoubleSelectExpression(TotalAmount)
                 ,new NullableInt32SelectExpression(TotalCount)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(TotalAmount));
+            set &= aliased != nameof(TotalAmount) ? new NullableDoubleSelectExpression(TotalAmount).As(aliased) as NullableDoubleSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(TotalAmount));
+
+            aliased = alias(nameof(TotalCount));
+            set &= aliased != nameof(TotalCount) ? new NullableInt32SelectExpression(TotalCount).As(aliased) as NullableInt32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(TotalCount));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<PersonTotalPurchasesView> GetInclusiveInsertExpression(PersonTotalPurchasesView personTotalPurchasesView)
@@ -4797,7 +4786,7 @@ namespace DbEx.dboDataService
             return expr;
         }
 
-        protected override void HydrateEntity(PersonTotalPurchasesView personTotalPurchasesView, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, PersonTotalPurchasesView personTotalPurchasesView)
         {
 			personTotalPurchasesView.Id = reader.ReadField().GetValue<int>();
 			personTotalPurchasesView.TotalAmount = reader.ReadField().GetValue<double?>();
@@ -4810,12 +4799,7 @@ namespace DbEx.dboDataService
         public partial class IdField : Int32FieldExpression<PersonTotalPurchasesView>
         {
             #region constructors
-            public IdField(string identifier, PersonTotalPurchasesViewEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, PersonTotalPurchasesViewEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4837,12 +4821,7 @@ namespace DbEx.dboDataService
         public partial class TotalAmountField : NullableDoubleFieldExpression<PersonTotalPurchasesView>
         {
             #region constructors
-            public TotalAmountField(string identifier, PersonTotalPurchasesViewEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private TotalAmountField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public TotalAmountField(string identifier, string name, PersonTotalPurchasesViewEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -4864,12 +4843,7 @@ namespace DbEx.dboDataService
         public partial class TotalCountField : NullableInt32FieldExpression<PersonTotalPurchasesView>
         {
             #region constructors
-            public TotalCountField(string identifier, PersonTotalPurchasesViewEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private TotalCountField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public TotalCountField(string identifier, string name, PersonTotalPurchasesViewEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -5088,7 +5062,7 @@ namespace DbEx.secDataService
         #region constructors
         public secSchemaExpression(string identifier) : base(identifier, null)
         {
-            Entities.Add($"{identifier}.Person", Person = new PersonEntity($"{identifier}.Person", this));
+            Entities.Add($"{identifier}.Person", Person = new PersonEntity($"{identifier}.Person", "Person", this));
         }
         #endregion
     }
@@ -5121,8 +5095,8 @@ namespace DbEx.secDataService
         /// </summary>
         public readonly IdField Id;
 
-        /// <summary>A <see cref="DbEx.secDataService.PersonEntity.SSNField"/> representing the "sec.Person.SSN" column in the database, 
-        /// with a .NET type of <see cref="string"/>.  The <see cref="DbEx.secDataService.PersonEntity.SSNField"/> can be 
+        /// <summary>A <see cref="DbEx.secDataService.PersonEntity.SocialSecurityNumberField"/> representing the "sec.Person.SSN" column in the database, 
+        /// with a .NET type of <see cref="string"/>.  The <see cref="DbEx.secDataService.PersonEntity.SocialSecurityNumberField"/> can be 
         /// used with any operation accepting a <see cref="HatTrick.DbEx.Sql.AnyStringElement"/> or <see cref="HatTrick.DbEx.Sql.StringElement"/>.
         /// <para>Database Properties:
         /// <list type="table">
@@ -5138,7 +5112,7 @@ namespace DbEx.secDataService
         /// </list>
         /// </para>
         /// </summary>
-        public readonly SSNField SSN;
+        public readonly SocialSecurityNumberField SocialSecurityNumber;
 
         /// <summary>A <see cref="DbEx.secDataService.PersonEntity.DateCreatedField"/> representing the "sec.Person.DateCreated" column in the database, 
         /// with a .NET type of <see cref="DateTime"/>.  The <see cref="DbEx.secDataService.PersonEntity.DateCreatedField"/> can be 
@@ -5187,42 +5161,65 @@ namespace DbEx.secDataService
         #endregion
 
         #region constructors
-        private PersonEntity() : base(null, null, null)
+        private PersonEntity() : base(null, null, null, null)
         {
         }
 
-		public PersonEntity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public PersonEntity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {
         }
 
-        private PersonEntity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private PersonEntity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {
-            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", this));
-            Fields.Add($"{identifier}.SSN", SSN = new SSNField($"{identifier}.SSN", this));
-            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", this));
-            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", this));
+            Fields.Add($"{identifier}.Id", Id = new IdField($"{identifier}.Id", "Id", this));
+            Fields.Add($"{identifier}.SSN", SocialSecurityNumber = new SocialSecurityNumberField($"{identifier}.SSN", "SocialSecurityNumber", this));
+            Fields.Add($"{identifier}.DateCreated", DateCreated = new DateCreatedField($"{identifier}.DateCreated", "DateCreated", this));
+            Fields.Add($"{identifier}.DateUpdated", DateUpdated = new DateUpdatedField($"{identifier}.DateUpdated", "DateUpdated", this));
         }
         #endregion
 
         #region methods
         public PersonEntity As(string name)
-            => new PersonEntity(this.identifier, this.schema, name);
+            => new PersonEntity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {
             return _inclusiveSelectExpressionSet ?? (_inclusiveSelectExpressionSet = new SelectExpressionSet(
                 new Int32SelectExpression(Id)
-                ,new StringSelectExpression(SSN)
+                ,new StringSelectExpression(SocialSecurityNumber)
                 ,new DateTimeSelectExpression(DateCreated)
                 ,new DateTimeSelectExpression(DateUpdated)
             ));
+        }
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {
+            if (alias is null)
+                throw new ArgumentNullException($"{nameof(alias)} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            aliased = alias(nameof(Id));
+            set &= aliased != nameof(Id) ? new Int32SelectExpression(Id).As(aliased) as Int32SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(Id));
+
+            aliased = alias(nameof(SocialSecurityNumber));
+            set &= aliased != nameof(SocialSecurityNumber) ? new StringSelectExpression(SocialSecurityNumber).As(aliased) as StringSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(SocialSecurityNumber));
+
+            aliased = alias(nameof(DateCreated));
+            set &= aliased != nameof(DateCreated) ? new DateTimeSelectExpression(DateCreated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateCreated));
+
+            aliased = alias(nameof(DateUpdated));
+            set &= aliased != nameof(DateUpdated) ? new DateTimeSelectExpression(DateUpdated).As(aliased) as DateTimeSelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof(DateUpdated));
+
+            return set;
         }
 		
         protected override InsertExpressionSet<Person> GetInclusiveInsertExpression(Person person)
         {
             return new InsertExpressionSet<Person>(person 
                 ,new InsertExpression<int>(Id, person.Id)
-                ,new InsertExpression<string>(SSN, person.SSN)
+                ,new InsertExpression<string>(SocialSecurityNumber, person.SocialSecurityNumber)
             );
         }
 
@@ -5231,14 +5228,14 @@ namespace DbEx.secDataService
             AssignmentExpressionSet expr = new AssignmentExpressionSet();
 
             if (target.Id != source.Id) { expr &= Id.Set(source.Id); }
-            if (target.SSN != source.SSN) { expr &= SSN.Set(source.SSN); }
+            if (target.SocialSecurityNumber != source.SocialSecurityNumber) { expr &= SocialSecurityNumber.Set(source.SocialSecurityNumber); }
             return expr;
         }
 
-        protected override void HydrateEntity(Person person, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, Person person)
         {
 			person.Id = reader.ReadField().GetValue<int>();
-			person.SSN = reader.ReadField().GetValue<string>();
+			person.SocialSecurityNumber = reader.ReadField().GetValue<string>();
 			person.DateCreated = reader.ReadField().GetValue<DateTime>();
 			person.DateUpdated = reader.ReadField().GetValue<DateTime>();
         }
@@ -5249,12 +5246,7 @@ namespace DbEx.secDataService
         public partial class IdField : Int32FieldExpression<Person>
         {
             #region constructors
-            public IdField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private IdField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public IdField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -5274,16 +5266,11 @@ namespace DbEx.secDataService
         }
         #endregion
 
-        #region s s n field expression
-        public partial class SSNField : StringFieldExpression<Person>
+        #region social security number field expression
+        public partial class SocialSecurityNumberField : StringFieldExpression<Person>
         {
             #region constructors
-            public SSNField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private SSNField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public SocialSecurityNumberField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -5307,12 +5294,7 @@ namespace DbEx.secDataService
         public partial class DateCreatedField : DateTimeFieldExpression<Person>
         {
             #region constructors
-            public DateCreatedField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateCreatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateCreatedField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }
@@ -5334,12 +5316,7 @@ namespace DbEx.secDataService
         public partial class DateUpdatedField : DateTimeFieldExpression<Person>
         {
             #region constructors
-            public DateUpdatedField(string identifier, PersonEntity entity) : base(identifier, entity)
-            {
-
-            }
-
-            private DateUpdatedField(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public DateUpdatedField(string identifier, string name, PersonEntity entity) : base(identifier, name, entity)
             {
 
             }

--- a/test/HatTrick.DbEx.MsSql.Test/dbex.config.json
+++ b/test/HatTrick.DbEx.MsSql.Test/dbex.config.json
@@ -113,6 +113,14 @@
 					"objectType": "tablecolumn"
 				}
 			}
+		},
+		{
+			"apply": {
+				"name": "SocialSecurityNumber",
+				"to": {
+					"path": "sec.Person.SSN"
+				}
+			}
 		}
 	]
 }

--- a/tools/HatTrick.DbEx.Tools/Resources/Templates/DbExDataService._cs.htt
+++ b/tools/HatTrick.DbEx.Tools/Resources/Templates/DbExDataService._cs.htt
@@ -7,6 +7,7 @@ using HatTrick.DbEx.Sql.Expression;
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.Linq;
 
 #pragma warning disable IDE1006 // Naming Styles
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member

--- a/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/EntityExpression.htt
+++ b/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/EntityExpression.htt
@@ -14,25 +14,25 @@
         #endregion
 
         #region constructors
-        private {$.EntityExpression.Name}Entity() : base(null, null, null)
+        private {$.EntityExpression.Name}Entity() : base(null, null, null, null)
         {{
         }}
 
-		public {$.EntityExpression.Name}Entity(string identifier, SchemaExpression schema) : this(identifier, schema, null)
+		public {$.EntityExpression.Name}Entity(string identifier, string name, SchemaExpression schema) : this(identifier, name, schema, null)
         {{
         }}
 
-        private {$.EntityExpression.Name}Entity(string identifier, SchemaExpression schema, string alias) : base(identifier, schema, alias)
+        private {$.EntityExpression.Name}Entity(string identifier, string name, SchemaExpression schema, string alias) : base(identifier, name, schema, alias)
         {{
 			{#each $.Items}
-            Fields.Add($"{{identifier}}.{$.Column.Name}", {$.FieldExpression.Name} = new {$.FieldExpression.Name}Field($"{{identifier}}.{$.Column.Name}", this));
+            Fields.Add($"{{identifier}}.{$.Column.Name}", {$.FieldExpression.Name} = new {$.FieldExpression.Name}Field($"{{identifier}}.{$.Column.Name}", "{$.FieldExpression.Name}", this));
 			{/each}
         }}
         #endregion
 
         #region methods
         public {$.EntityExpression.Name}Entity As(string name)
-            => new {$.EntityExpression.Name}Entity(this.identifier, this.schema, name);
+            => new {$.EntityExpression.Name}Entity(this.identifier, this.name, this.schema, name);
 
         protected override SelectExpressionSet GetInclusiveSelectExpression()
         {{
@@ -48,6 +48,27 @@
                 {? :applyComma = true}
 				{/each}
             ));
+        }}
+
+        protected override SelectExpressionSet GetInclusiveSelectExpression(Func<string, string> alias)
+        {{
+            if (alias is null)
+                throw new ArgumentNullException($"{{nameof(alias)}} is required.");
+
+            SelectExpressionSet set = null;
+            string aliased = null;
+
+            {#each $.Items}
+            aliased = alias(nameof({$.FieldExpression.Name}));
+            {#if !$.FieldExpression.Type.IsEnum}
+            set &= aliased != nameof({$.FieldExpression.Name}) ? new {+#if $.Column.IsNullable}Nullable{/if}{$.FieldExpression.Type.TypeName}SelectExpression({$.FieldExpression.Name}).As(aliased) as {+#if $.Column.IsNullable}Nullable{/if}{$.FieldExpression.Type.TypeName}SelectExpression : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof({$.FieldExpression.Name}));
+			{/if}
+            {#if $.FieldExpression.Type.IsEnum}
+            set &= aliased != nameof({$.FieldExpression.Name}) ? new {+#if $.Column.IsNullable}Nullable{/if}EnumSelectExpression<{$.FieldExpression.Type.TypeName}>({$.FieldExpression.Name}).As(aliased) as {+#if $.Column.IsNullable}Nullable{/if}EnumSelectExpression<{$.FieldExpression.Type.TypeName}> : GetInclusiveSelectExpression().Expressions.Single(x => (x.Expression as IExpressionNameProvider).Name == nameof({$.FieldExpression.Name}));
+            {/if}
+
+            {/each}
+            return set;
         }}
 		
         protected override InsertExpressionSet<{$.EntityExpression.Name}> GetInclusiveInsertExpression({$.EntityExpression.Name} {($.EntityExpression.Name) => ToCamelCase})
@@ -81,7 +102,7 @@
             return expr;
         }}
 
-        protected override void HydrateEntity({$.EntityExpression.Name} {($.EntityExpression.Name) => ToCamelCase}, ISqlFieldReader reader)
+        protected override void HydrateEntity(ISqlFieldReader reader, {$.EntityExpression.Name} {($.EntityExpression.Name) => ToCamelCase})
         {{
 			{#each $.Items}
 			{($.FieldExpression.EntityExpression.Name) => ToCamelCase}.{$.FieldExpression.Name} = reader.ReadField().GetValue<{$.FieldExpression.Type.NullableAlias}>();

--- a/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/FieldExpression.htt
+++ b/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/FieldExpression.htt
@@ -3,12 +3,7 @@
         public partial class {$.FieldExpression.Name}Field : {+#if $.Column.IsNullable}Nullable{/if}{+#if :isEnum}Enum{/if}{+#if !:isEnum}{$.FieldExpression.Type.TypeName}{/if}FieldExpression<{$.FieldExpression.EntityExpression.Name}{#if :isEnum}, {$.FieldExpression.Type.TypeName}{/if}>
         {{
             #region constructors
-            public {$.FieldExpression.Name}Field(string identifier, {$.FieldExpression.EntityExpression.Name}Entity entity) : base(identifier, entity)
-            {{
-
-            }}
-
-            private {$.FieldExpression.Name}Field(string identifier, EntityExpression entity, string alias) : base(identifier, entity, alias)
+            public {$.FieldExpression.Name}Field(string identifier, string name, {$.FieldExpression.EntityExpression.Name}Entity entity) : base(identifier, name, entity)
             {{
 
             }}

--- a/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/RuntimeDb.htt
+++ b/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/RuntimeDb.htt
@@ -553,7 +553,7 @@
         /// <param name="element1">Any expression</param>
         /// <param name="element2">Any expression</param>
         /// <param name="elements">Any expression</param>
-        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{ExpandoObject}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<ExpandoObject> SelectOne(AnyElement element1, AnyElement element2, params AnyElement[] elements)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, element1, element2, elements);
 
@@ -565,9 +565,21 @@
         /// </summary>
         /// <param name="element1">Any expression</param>
         /// <param name="elements">A list of any expression</param>
-        /// <returns><see cref="SelectValue{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValue{{ExpandoObject}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValue<ExpandoObject> SelectOne(IEnumerable<AnyElement> elements)
             => expressionBuilderFactory.CreateSelectValueBuilder(config, elements);
+
+        /// <summary>
+        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="AnyElement" /> method parameters.
+        /// <para>
+        /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
+        /// </para>
+        /// </summary>
+        /// <param name="elements">A list of any expression that is valid for a SELECT query expression.</param>
+        /// <param name="additionalElements">Any additional fields to select as part of the SELECT query expression.</param>
+        /// <returns><see cref="SelectValues{{ExpandoObject}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        public static SelectValue<ExpandoObject> SelectOne(IEnumerable<AnyElement> elements, params AnyElement[] additionalElements)
+            => expressionBuilderFactory.CreateSelectValueBuilder(config, (elements ?? throw new ArgumentNullException($"{{nameof(elements)}} is required.")).Concat(additionalElements));
         #endregion
 
         #region select many
@@ -1096,7 +1108,7 @@
         /// <param name="element1">Any expression</param>
         /// <param name="element2">Any expression</param>
         /// <param name="elements">Any expression</param>
-        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{ExpandoObject}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<ExpandoObject> SelectMany(AnyElement element1, AnyElement element2, params AnyElement[] elements)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, element1, element2, elements);
 
@@ -1107,9 +1119,21 @@
         /// </para>
         /// </summary>
         /// <param name="elements">A list of any expression</param>
-        /// <returns><see cref="SelectValues{{TValue}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        /// <returns><see cref="SelectValues{{ExpandoObject}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
         public static SelectValues<ExpandoObject> SelectMany(IEnumerable<AnyElement> elements)
             => expressionBuilderFactory.CreateSelectValuesBuilder(config, elements);
+
+            /// <summary>
+        /// Start constructing a sql SELECT query expression for a list of <see cref="System.Dynamic.ExpandoObject" /> objects.  The dynamic properties of each object are defined by the <see cref="AnyElement" /> method parameters.
+        /// <para>
+        /// <see href="https://docs.microsoft.com/en-US/sql/t-sql/queries/select-transact-sql">Microsoft docs on SELECT</see>
+        /// </para>
+        /// </summary>
+        /// <param name="elements">A list of any expression that is valid for a SELECT query expression.</param>
+        /// <param name="additionalElements">Any additional fields to select as part of the SELECT query expression.</param>
+        /// <returns><see cref="SelectValues{{ExpandoObject}}"/>, a fluent builder for constructing a sql SELECT query expression.</returns>
+        public static SelectValues<ExpandoObject> SelectMany(IEnumerable<AnyElement> elements, params AnyElement[] additionalElements)
+            => expressionBuilderFactory.CreateSelectValuesBuilder(config, (elements ?? throw new ArgumentNullException($"{{nameof(elements)}} is required.")).Concat(additionalElements));
         #endregion
 
         #region update

--- a/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/SchemaExpression.htt
+++ b/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/SchemaExpression.htt
@@ -11,7 +11,7 @@
         public {$.SchemaExpression.Name}SchemaExpression(string identifier) : base(identifier, null)
         {{
 			{#each $.Items}
-            Entities.Add($"{{identifier}}.{$.Entity.Name}", {$.EntityExpression.Name} = new {$.EntityExpression.Name}Entity($"{{identifier}}.{$.Entity.Name}", this));
+            Entities.Add($"{{identifier}}.{$.Entity.Name}", {$.EntityExpression.Name} = new {$.EntityExpression.Name}Entity($"{{identifier}}.{$.Entity.Name}", "{$.Entity.Name}", this));
 			{/each}
         }}
         #endregion


### PR DESCRIPTION
- Added SelectAllFor methods to dbex to enable a "SELECT *" pattern	
	- Added overload for GetInclusiveSelectExpression in EntityExpression that supports passing a delegate to provide an alias for each field
	- Added overloads for SelectOne and SelectMany accepting IEnumerable<AnyElement>
	- Added name to EntityExpression and FieldExpression that provides the C# name of the item, which enables comparison between a name and alias in SelectAllFor to determine if the alias should even be applied (i.e. [dbo].[Person].[FirstName] instead of [dbo].[Person].[FirstName] AS [FirstName])
- Added GetDefaultMappingFor method to dbex to allow access to the default mapper used for an entity (mapping to an entity via field reader)
- Added additional properties and methods to ISqlFieldReader that enable access to fields and metadata alternate from ReadField methods
- Fixed issue where the property name of a dynamic was being set to the column name from the database when the field name was changed through config/code generation
- Cleanup
	- Finally removed all lingering bits related to aliasing of field expressions
	- Deprecated ISqlRow as it was confusing when to use that as opposed to ISqlFieldReader
- Reworked all Execute and ExecuteAsync paths to include overloads supporting any arrangement of Action and Func for managing rowsets returned from db