### PR TITLE
Repair issues with rendering order and enum/string conversion

### DIFF
--- a/src/HatTrick.DbEx.MsSql.Extensions.DependencyInjection/DbExpressionConfigurationBuilderExtensions.cs
+++ b/src/HatTrick.DbEx.MsSql.Extensions.DependencyInjection/DbExpressionConfigurationBuilderExtensions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var services = builder as ServiceCollectionRuntimeSqlDatabaseConfigurationBuilder ?? throw new DbExpressionConfigurationException($"Expected {nameof(builder)} to be of type {typeof(ServiceCollectionRuntimeSqlDatabaseConfigurationBuilder)}, but actual type is {builder.GetType()}");
             services.Services.TryAddSingleton<HatTrick.DbEx.MsSql.Assembler.v2005.MsSqlStatementBuilderFactory>();
-            services.Services.TryAdd(ServiceDescriptor.Singleton(typeof(ISqlStatementBuilderFactory), sp => sp.GetRequiredService<HatTrick.DbEx.MsSql.Assembler.v2005.MsSqlStatementBuilderFactory>()));
+            services.Services.TryAdd(ServiceDescriptor.Singleton<ISqlStatementBuilderFactory>(sp => sp.GetRequiredService<HatTrick.DbEx.MsSql.Assembler.v2005.MsSqlStatementBuilderFactory>()));
 
             services.AddMsSql<T>(
                 (serviceProvider, configBuilder) =>
@@ -98,7 +98,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var services = builder as ServiceCollectionRuntimeSqlDatabaseConfigurationBuilder ?? throw new DbExpressionConfigurationException($"Expected {nameof(builder)} to be of type {typeof(ServiceCollectionRuntimeSqlDatabaseConfigurationBuilder)}, but actual type is {builder.GetType()}");
             services.Services.TryAddSingleton<HatTrick.DbEx.MsSql.Assembler.v2008.MsSqlStatementBuilderFactory>();
-            services.Services.TryAdd(ServiceDescriptor.Singleton(typeof(ISqlStatementBuilderFactory), sp => sp.GetRequiredService<HatTrick.DbEx.MsSql.Assembler.v2008.MsSqlStatementBuilderFactory>()));
+            services.Services.TryAdd(ServiceDescriptor.Singleton<ISqlStatementBuilderFactory>(sp => sp.GetRequiredService<HatTrick.DbEx.MsSql.Assembler.v2008.MsSqlStatementBuilderFactory>()));
 
             services.AddMsSql<T>(
                 (serviceProvider, configBuilder) =>
@@ -134,7 +134,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var services = builder as ServiceCollectionRuntimeSqlDatabaseConfigurationBuilder ?? throw new DbExpressionConfigurationException($"Expected {nameof(builder)} to be of type {typeof(ServiceCollectionRuntimeSqlDatabaseConfigurationBuilder)}, but actual type is {builder.GetType()}");
             services.Services.TryAddSingleton<HatTrick.DbEx.MsSql.Assembler.v2012.MsSqlStatementBuilderFactory>();
-            services.Services.TryAdd(ServiceDescriptor.Singleton(typeof(ISqlStatementBuilderFactory), sp => sp.GetRequiredService<HatTrick.DbEx.MsSql.Assembler.v2012.MsSqlStatementBuilderFactory>()));
+            services.Services.TryAdd(ServiceDescriptor.Singleton<ISqlStatementBuilderFactory>(sp => sp.GetRequiredService<HatTrick.DbEx.MsSql.Assembler.v2012.MsSqlStatementBuilderFactory>()));
 
             services.AddMsSql<T>(
                 (serviceProvider, configBuilder) =>
@@ -170,7 +170,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var services = builder as ServiceCollectionRuntimeSqlDatabaseConfigurationBuilder ?? throw new DbExpressionConfigurationException($"Expected {nameof(builder)} to be of type {typeof(ServiceCollectionRuntimeSqlDatabaseConfigurationBuilder)}, but actual type is {builder.GetType()}");
             services.Services.TryAddSingleton<HatTrick.DbEx.MsSql.Assembler.v2014.MsSqlStatementBuilderFactory>();
-            services.Services.TryAdd(ServiceDescriptor.Singleton(typeof(ISqlStatementBuilderFactory), sp => sp.GetRequiredService<HatTrick.DbEx.MsSql.Assembler.v2014.MsSqlStatementBuilderFactory>()));
+            services.Services.TryAdd(ServiceDescriptor.Singleton<ISqlStatementBuilderFactory>(sp => sp.GetRequiredService<HatTrick.DbEx.MsSql.Assembler.v2014.MsSqlStatementBuilderFactory>()));
 
             services.AddMsSql<T>(
                 (serviceProvider, configBuilder) =>
@@ -206,7 +206,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var services = builder as ServiceCollectionRuntimeSqlDatabaseConfigurationBuilder ?? throw new DbExpressionConfigurationException($"Expected {nameof(builder)} to be of type {typeof(ServiceCollectionRuntimeSqlDatabaseConfigurationBuilder)}, but actual type is {builder.GetType()}");
             services.Services.TryAddSingleton<HatTrick.DbEx.MsSql.Assembler.v2016.MsSqlStatementBuilderFactory>();
-            services.Services.TryAdd(ServiceDescriptor.Singleton(typeof(ISqlStatementBuilderFactory), sp => sp.GetRequiredService<HatTrick.DbEx.MsSql.Assembler.v2016.MsSqlStatementBuilderFactory>()));
+            services.Services.TryAdd(ServiceDescriptor.Singleton<ISqlStatementBuilderFactory>(sp => sp.GetRequiredService<HatTrick.DbEx.MsSql.Assembler.v2016.MsSqlStatementBuilderFactory>()));
 
             services.AddMsSql<T>(
                 (serviceProvider, configBuilder) =>
@@ -242,7 +242,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var services = builder as ServiceCollectionRuntimeSqlDatabaseConfigurationBuilder ?? throw new DbExpressionConfigurationException($"Expected {nameof(builder)} to be of type {typeof(ServiceCollectionRuntimeSqlDatabaseConfigurationBuilder)}, but actual type is {builder.GetType()}");
             services.Services.TryAddSingleton<HatTrick.DbEx.MsSql.Assembler.v2017.MsSqlStatementBuilderFactory>();
-            services.Services.TryAdd(ServiceDescriptor.Singleton(typeof(ISqlStatementBuilderFactory), sp => sp.GetRequiredService<HatTrick.DbEx.MsSql.Assembler.v2017.MsSqlStatementBuilderFactory>()));
+            services.Services.TryAdd(ServiceDescriptor.Singleton<ISqlStatementBuilderFactory>(sp => sp.GetRequiredService<HatTrick.DbEx.MsSql.Assembler.v2017.MsSqlStatementBuilderFactory>()));
 
             services.AddMsSql<T>(
                 (serviceProvider, configBuilder) =>
@@ -278,7 +278,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var services = builder as ServiceCollectionRuntimeSqlDatabaseConfigurationBuilder ?? throw new DbExpressionConfigurationException($"Expected {nameof(builder)} to be of type {typeof(ServiceCollectionRuntimeSqlDatabaseConfigurationBuilder)}, but actual type is {builder.GetType()}");
             services.Services.TryAddSingleton<HatTrick.DbEx.MsSql.Assembler.v2019.MsSqlStatementBuilderFactory>();
-            services.Services.TryAdd(ServiceDescriptor.Singleton(typeof(ISqlStatementBuilderFactory), sp => sp.GetRequiredService<HatTrick.DbEx.MsSql.Assembler.v2019.MsSqlStatementBuilderFactory>()));
+            services.Services.TryAdd(ServiceDescriptor.Singleton<ISqlStatementBuilderFactory>(sp => sp.GetRequiredService<HatTrick.DbEx.MsSql.Assembler.v2019.MsSqlStatementBuilderFactory>()));
 
             services.AddMsSql<T>(
                 (serviceProvider, configBuilder) =>
@@ -309,7 +309,6 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.TryAdd(ServiceDescriptor.Singleton<IMapperFactory, MapperFactory>());
             builder.Services.TryAdd(ServiceDescriptor.Singleton<IValueConverterFactory, ValueConverterFactory>());
             builder.Services.TryAdd(ServiceDescriptor.Singleton<IAppenderFactory, AppenderFactory>());
-            builder.Services.TryAdd(ServiceDescriptor.Singleton<IValueConverterFactory, ValueConverterFactory>());
             builder.Services.TryAdd(ServiceDescriptor.Singleton<ISqlStatementExecutorFactory, SqlStatementExecutorFactory>());
             builder.Services.TryAdd(ServiceDescriptor.Singleton<IExecutionPipelineFactory, ExecutionPipelineFactory>());
 

--- a/src/HatTrick.DbEx.MsSql/_Extensions/Configuration/DatabaseConfigurationBuilderExtensions_Configure.cs
+++ b/src/HatTrick.DbEx.MsSql/_Extensions/Configuration/DatabaseConfigurationBuilderExtensions_Configure.cs
@@ -269,7 +269,7 @@ namespace HatTrick.DbEx.MsSql.Configuration
                     .ElementAppender.Use<MsSqlExpressionElementAppenderFactory>()
                     .ParameterBuilder.Use(new MsSqlParameterBuilderFactory(new MsSqlTypeMapFactory(), (builder as IRuntimeSqlDatabaseConfigurationProvider).Configuration.ValueConverterFactory))
                     .ConfigureOutputSettings(
-                        a => a.PrependCommaOnSelectClause = true
+                        a => a.PrependCommaOnSelectClause = false
                     )
                 .Execution
                     .Executor.UseDefaultFactory()

--- a/src/HatTrick.DbEx.Sql/Assembler/ISqlParameterBuilderFactory.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/ISqlParameterBuilderFactory.cs
@@ -16,12 +16,6 @@
 // The latest version of this file can be found at https://github.com/HatTrickLabs/db-ex
 #endregion
 
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace HatTrick.DbEx.Sql.Assembler
 {
     public interface ISqlParameterBuilderFactory

--- a/src/HatTrick.DbEx.Sql/Assembler/SelectSqlStatementAssembler.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/SelectSqlStatementAssembler.cs
@@ -47,14 +47,14 @@ namespace HatTrick.DbEx.Sql.Assembler
             builder.Appender
                 .Indent().Write("SELECT");
 
-            if (expression.Top.HasValue)
-            {
-                builder.Appender.Write(" TOP(").Write(expression.Top.ToString()).Write(")");
-            }
-
             if (expression.Distinct == true)
             {
                 builder.Appender.Write(" DISTINCT");
+            }
+
+            if (expression.Top.HasValue)
+            {
+                builder.Appender.Write(" TOP(").Write(expression.Top.ToString()).Write(")");
             }
 
             builder.Appender.LineBreak()

--- a/src/HatTrick.DbEx.Sql/Configuration/_Conversions/EnumTypeConfigurationBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Configuration/_Conversions/EnumTypeConfigurationBuilder{T}.cs
@@ -40,7 +40,7 @@ namespace HatTrick.DbEx.Sql.Configuration
         #region methods
         public IValueConverterFactoryContinuationConfigurationBuilder PersistAsString()
         {
-            factory.RegisterConverter<T, StringEnumValueConverter>();
+            factory.RegisterConverter<T>(new StringEnumValueConverter<T>());
             return caller;
         }
         #endregion

--- a/src/HatTrick.DbEx.Sql/Converter/StringEnumValueConverter.cs
+++ b/src/HatTrick.DbEx.Sql/Converter/StringEnumValueConverter.cs
@@ -1,0 +1,43 @@
+﻿#region license
+// Copyright (c) HatTrick Labs, LLC.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The latest version of this file can be found at https://github.com/HatTrickLabs/db-ex
+#endregion
+
+using System;
+
+namespace HatTrick.DbEx.Sql.Converter
+{
+    public class StringEnumValueConverter : IValueConverter
+    {
+        private readonly Type type;
+
+        public StringEnumValueConverter(Type enumType)
+        {
+            type = enumType ?? throw new ArgumentNullException(nameof(enumType));
+            if (!enumType.IsEnum)
+                throw new ArgumentException($"Expected {nameof(enumType)} to be of type Enum.");
+        }
+
+        public object ConvertFromDatabase(object value)
+            => value is null ? default : Enum.Parse(type, value as string, true);
+
+        public T ConvertFromDatabase<T>(object value)
+            => value is null ? default : (T)Enum.Parse(typeof(T), value as string);
+
+        public (Type, object) ConvertToDatabase(object value)
+            => value is null ? (typeof(string), null) : (typeof(string), value.ToString());
+    }
+}

--- a/src/HatTrick.DbEx.Sql/Converter/StringEnumValueConverter{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Converter/StringEnumValueConverter{T}.cs
@@ -16,20 +16,14 @@
 // The latest version of this file can be found at https://github.com/HatTrickLabs/db-ex
 #endregion
 
-﻿using System;
-
 namespace HatTrick.DbEx.Sql.Converter
 {
-    public class StringEnumValueConverter : IValueConverter
+
+    public class StringEnumValueConverter<T> : StringEnumValueConverter
     {
-        private static Type type = typeof(string);
-        public object ConvertFromDatabase(object value)
-            => value is null ? default : Enum.Parse(type, value as string, true);
+        public StringEnumValueConverter() : base(typeof(T))
+        {
 
-        public T ConvertFromDatabase<T>(object value)
-            => value is null ? default : (T)Enum.Parse(typeof(T), value as string);
-
-        public (Type, object) ConvertToDatabase(object value)
-            => value is null ? (type, null) : (type, value.ToString());
+        }
     }
 }

--- a/src/HatTrick.DbEx.Sql/Converter/StringValueConverter.cs
+++ b/src/HatTrick.DbEx.Sql/Converter/StringValueConverter.cs
@@ -1,0 +1,51 @@
+﻿#region license
+// Copyright (c) HatTrick Labs, LLC.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The latest version of this file can be found at https://github.com/HatTrickLabs/db-ex
+#endregion
+
+using System;
+
+namespace HatTrick.DbEx.Sql.Converter
+{
+    public class StringValueConverter : NullableValueConverter
+    {
+        public StringValueConverter() : base(typeof(string))
+        {
+        }
+
+        public override object ConvertFromDatabase(object value)
+        {
+            if (value is null)
+                return default;
+
+            if (typeof(string) == value.GetType())
+                return value;
+
+            return Convert.ChangeType(value, typeof(string));
+        }
+
+        public override (Type, object) ConvertToDatabase(object value)
+        {
+            if (value is null)
+                return (typeof(string), default);
+
+            if (typeof(string) == value.GetType())
+                return (typeof(string), value);
+
+            return (typeof(string), Convert.ChangeType(value, typeof(string)));
+        }
+    }
+}

--- a/src/HatTrick.DbEx.Sql/Converter/ValueConverterFactory.cs
+++ b/src/HatTrick.DbEx.Sql/Converter/ValueConverterFactory.cs
@@ -50,7 +50,7 @@ namespace HatTrick.DbEx.Sql.Converter
         private static readonly IValueConverter nullableShortConverter = new NullableValueConverter(typeof(short?));
         private static readonly IValueConverter nullableTimeSpanConverter = new NullableValueConverter(typeof(TimeSpan?));
         
-        private static readonly IValueConverter stringConverter = new NullableValueConverter(typeof(string));
+        private static readonly IValueConverter stringConverter = new StringValueConverter();
         private static readonly IValueConverter byteArrayConverter = new NullableValueConverter(typeof(byte[]));
 
         private static readonly IValueConverter objectConverter = new ObjectConverter();

--- a/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Select/SelectMany.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Database/Executor/_Select/SelectMany.cs
@@ -1,4 +1,5 @@
-﻿using DbEx.DataService;
+﻿using DbEx.Data;
+using DbEx.DataService;
 using DbEx.dboData;
 using DbEx.dboDataService;
 using DbEx.secDataService;
@@ -369,6 +370,54 @@ namespace HatTrick.DbEx.MsSql.Test.Database.Executor
 
             //then
             ((string)persons.First().SocialSecurityNumber).Should().NotBeNull();
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "TOP")]
+        [Trait("Operation", "ORDER BY")]
+        public void Can_top_person_records_select_successfully(int version, int expected = 5)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany(
+                    dbo.Person.FirstName,
+                    dbo.Person.LastName
+                )
+                .Top(expected)
+                .From(dbo.Person)
+                .OrderBy(dbo.Person.LastName.Asc, dbo.Person.FirstName.Asc);
+
+            //when               
+            var persons = exp.Execute();
+
+            //then
+            persons.Should().HaveCount(expected);
+        }
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "TOP")]
+        [Trait("Operation", "ORDER BY")]
+        public void Can_top_distinct_person_records_select_successfully(int version, int expected = 5)
+        {
+            //given
+            ConfigureForMsSqlVersion(version);
+
+            var exp = db.SelectMany(
+                    dbo.Person.FirstName,
+                    dbo.Person.LastName
+                )
+                .Top(expected)
+                .Distinct()
+                .From(dbo.Person)
+                .OrderBy(dbo.Person.LastName.Asc, dbo.Person.FirstName.Asc);
+
+            //when               
+            var persons = exp.Execute();
+
+            //then
+            persons.Should().HaveCount(expected);
         }
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test/TestBase.cs
+++ b/test/HatTrick.DbEx.MsSql.Test/TestBase.cs
@@ -29,7 +29,7 @@ namespace HatTrick.DbEx.MsSql.Test
                 );
 
                 database.Conversions.UseDefaultFactory(x =>
-                    x.OverrideForEnumType<PaymentMethodType, StringEnumValueConverter>()
+                    x.OverrideForEnumType<PaymentMethodType>().PersistAsString()
                         .OverrideForEnumType<PaymentSourceType>().PersistAsString()
                 );
 


### PR DESCRIPTION
- Fixed issue with "Top" and "Distinct" where they were rendered as elements in the wrong order
- Fixed issues with Enum and string value conversion
- Changes service registrations in dependency injection for consistency with other registrations
- Flipped default flag for prepending commas on sql statements (should not prepend commas by default)