### PR TITLE
Tuples as 'left' expression of FilterExpression

### DIFF
--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_CharIndex/Int64CharIndexFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_CharIndex/Int64CharIndexFunctionExpression.generated.cs
@@ -1990,16 +1990,28 @@ namespace HatTrick.DbEx.MsSql.Expression
         
         public static FilterExpression<bool?> operator ==(Int64CharIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int64CharIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int64CharIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int64CharIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int64CharIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int64CharIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int64CharIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int64CharIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int64CharIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int64CharIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int64CharIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int64CharIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_CharIndex/NullableInt64CharIndexFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_CharIndex/NullableInt64CharIndexFunctionExpression.generated.cs
@@ -2025,16 +2025,28 @@ namespace HatTrick.DbEx.MsSql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt64CharIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt64CharIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt64CharIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt64CharIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt64CharIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt64CharIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt64CharIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt64CharIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt64CharIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt64CharIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt64CharIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt64CharIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_GetDate/GetDateFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_GetDate/GetDateFunctionExpression.generated.cs
@@ -214,16 +214,28 @@ namespace HatTrick.DbEx.MsSql.Expression
         
         public static FilterExpression<bool?> operator ==(GetDateFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, GetDateFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(GetDateFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, GetDateFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(GetDateFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, GetDateFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(GetDateFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, GetDateFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(GetDateFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, GetDateFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(GetDateFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, GetDateFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_GetUtcDate/GetUtcDateFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_GetUtcDate/GetUtcDateFunctionExpression.generated.cs
@@ -214,16 +214,28 @@ namespace HatTrick.DbEx.MsSql.Expression
         
         public static FilterExpression<bool?> operator ==(GetUtcDateFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, GetUtcDateFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(GetUtcDateFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, GetUtcDateFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(GetUtcDateFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, GetUtcDateFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(GetUtcDateFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, GetUtcDateFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(GetUtcDateFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, GetUtcDateFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(GetUtcDateFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, GetUtcDateFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_PatIndex/Int64PatIndexFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_PatIndex/Int64PatIndexFunctionExpression.generated.cs
@@ -1990,16 +1990,28 @@ namespace HatTrick.DbEx.MsSql.Expression
         
         public static FilterExpression<bool?> operator ==(Int64PatIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int64PatIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int64PatIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int64PatIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int64PatIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int64PatIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int64PatIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int64PatIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int64PatIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int64PatIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int64PatIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int64PatIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_PatIndex/NullableInt64PatIndexFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_PatIndex/NullableInt64PatIndexFunctionExpression.generated.cs
@@ -2025,16 +2025,28 @@ namespace HatTrick.DbEx.MsSql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt64PatIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt64PatIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt64PatIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt64PatIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt64PatIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt64PatIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt64PatIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt64PatIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt64PatIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt64PatIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt64PatIndexFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt64PatIndexFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/DecimalRoundFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/DecimalRoundFunctionExpression.generated.cs
@@ -1990,16 +1990,28 @@ namespace HatTrick.DbEx.MsSql.Expression
         
         public static FilterExpression<bool?> operator ==(DecimalRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DecimalRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DecimalRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DecimalRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DecimalRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DecimalRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DecimalRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DecimalRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DecimalRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DecimalRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DecimalRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DecimalRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/DoubleRoundFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/DoubleRoundFunctionExpression.generated.cs
@@ -1990,16 +1990,28 @@ namespace HatTrick.DbEx.MsSql.Expression
         
         public static FilterExpression<bool?> operator ==(DoubleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DoubleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DoubleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DoubleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DoubleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DoubleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DoubleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DoubleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DoubleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DoubleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DoubleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DoubleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/Int32RoundFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/Int32RoundFunctionExpression.generated.cs
@@ -1990,16 +1990,28 @@ namespace HatTrick.DbEx.MsSql.Expression
         
         public static FilterExpression<bool?> operator ==(Int32RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int32RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int32RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int32RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int32RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int32RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int32RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int32RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int32RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int32RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int32RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int32RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/Int64RoundFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/Int64RoundFunctionExpression.generated.cs
@@ -1990,16 +1990,28 @@ namespace HatTrick.DbEx.MsSql.Expression
         
         public static FilterExpression<bool?> operator ==(Int64RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int64RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int64RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int64RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int64RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int64RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int64RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int64RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int64RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int64RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int64RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int64RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/NullableDecimalRoundFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/NullableDecimalRoundFunctionExpression.generated.cs
@@ -2025,16 +2025,28 @@ namespace HatTrick.DbEx.MsSql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDecimalRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDecimalRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDecimalRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDecimalRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDecimalRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDecimalRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDecimalRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDecimalRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDecimalRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDecimalRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDecimalRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDecimalRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/NullableDoubleRoundFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/NullableDoubleRoundFunctionExpression.generated.cs
@@ -2025,16 +2025,28 @@ namespace HatTrick.DbEx.MsSql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDoubleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDoubleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDoubleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDoubleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDoubleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDoubleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDoubleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDoubleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDoubleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDoubleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDoubleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDoubleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/NullableInt32RoundFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/NullableInt32RoundFunctionExpression.generated.cs
@@ -2025,16 +2025,28 @@ namespace HatTrick.DbEx.MsSql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt32RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt32RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt32RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt32RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt32RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt32RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt32RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt32RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt32RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt32RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt32RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt32RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/NullableInt64RoundFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/NullableInt64RoundFunctionExpression.generated.cs
@@ -2025,16 +2025,28 @@ namespace HatTrick.DbEx.MsSql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt64RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt64RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt64RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt64RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt64RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt64RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt64RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt64RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt64RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt64RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt64RoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt64RoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/NullableObjectRoundFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/NullableObjectRoundFunctionExpression.generated.cs
@@ -1529,16 +1529,28 @@ namespace HatTrick.DbEx.MsSql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableObjectRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableObjectRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableObjectRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableObjectRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableObjectRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableObjectRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableObjectRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableObjectRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableObjectRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableObjectRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableObjectRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableObjectRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/NullableSingleRoundFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/NullableSingleRoundFunctionExpression.generated.cs
@@ -2025,16 +2025,28 @@ namespace HatTrick.DbEx.MsSql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/SingleRoundFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_Round/SingleRoundFunctionExpression.generated.cs
@@ -1990,16 +1990,28 @@ namespace HatTrick.DbEx.MsSql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleRoundFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleRoundFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_SysDateTime/SysDateTimeFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_SysDateTime/SysDateTimeFunctionExpression.generated.cs
@@ -214,16 +214,28 @@ namespace HatTrick.DbEx.MsSql.Expression
         
         public static FilterExpression<bool?> operator ==(SysDateTimeFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SysDateTimeFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SysDateTimeFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SysDateTimeFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SysDateTimeFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SysDateTimeFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SysDateTimeFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SysDateTimeFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SysDateTimeFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SysDateTimeFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SysDateTimeFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SysDateTimeFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_SysDateTimeOffset/SysDateTimeOffsetFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_SysDateTimeOffset/SysDateTimeOffsetFunctionExpression.generated.cs
@@ -214,16 +214,28 @@ namespace HatTrick.DbEx.MsSql.Expression
         
         public static FilterExpression<bool?> operator ==(SysDateTimeOffsetFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SysDateTimeOffsetFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SysDateTimeOffsetFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SysDateTimeOffsetFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SysDateTimeOffsetFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SysDateTimeOffsetFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SysDateTimeOffsetFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SysDateTimeOffsetFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SysDateTimeOffsetFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SysDateTimeOffsetFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SysDateTimeOffsetFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SysDateTimeOffsetFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.MsSql/Expression/_Function/_SysUtcDateTime/SysUtcDateTimeFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.MsSql/Expression/_Function/_SysUtcDateTime/SysUtcDateTimeFunctionExpression.generated.cs
@@ -214,16 +214,28 @@ namespace HatTrick.DbEx.MsSql.Expression
         
         public static FilterExpression<bool?> operator ==(SysUtcDateTimeFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SysUtcDateTimeFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SysUtcDateTimeFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SysUtcDateTimeFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SysUtcDateTimeFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SysUtcDateTimeFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SysUtcDateTimeFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SysUtcDateTimeFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SysUtcDateTimeFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SysUtcDateTimeFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SysUtcDateTimeFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SysUtcDateTimeFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/BooleanFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/BooleanFieldExpression.generated.cs
@@ -112,8 +112,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(BooleanFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<bool>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, BooleanFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<bool>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(BooleanFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<bool>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, BooleanFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<bool>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/ByteFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/ByteFieldExpression.generated.cs
@@ -1980,16 +1980,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(ByteFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, ByteFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(ByteFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, ByteFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(ByteFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, ByteFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(ByteFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, ByteFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(ByteFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, ByteFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(ByteFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, ByteFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/DateTimeFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/DateTimeFieldExpression.generated.cs
@@ -903,16 +903,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DateTimeFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DateTimeFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DateTimeFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DateTimeFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DateTimeFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DateTimeFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DateTimeFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DateTimeFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DateTimeFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DateTimeFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DateTimeFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DateTimeFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/DateTimeOffsetFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/DateTimeOffsetFieldExpression.generated.cs
@@ -903,16 +903,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DateTimeOffsetFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DateTimeOffsetFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DateTimeOffsetFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DateTimeOffsetFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DateTimeOffsetFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DateTimeOffsetFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DateTimeOffsetFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DateTimeOffsetFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DateTimeOffsetFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DateTimeOffsetFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DateTimeOffsetFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DateTimeOffsetFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/DecimalFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/DecimalFieldExpression.generated.cs
@@ -1980,16 +1980,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DecimalFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DecimalFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DecimalFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DecimalFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DecimalFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DecimalFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DecimalFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DecimalFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DecimalFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DecimalFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DecimalFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DecimalFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/DoubleFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/DoubleFieldExpression.generated.cs
@@ -1980,16 +1980,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DoubleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DoubleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DoubleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DoubleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DoubleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DoubleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DoubleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DoubleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DoubleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DoubleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DoubleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DoubleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/GuidFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/GuidFieldExpression.generated.cs
@@ -112,8 +112,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(GuidFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, GuidFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<Guid>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(GuidFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, GuidFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<Guid>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/Int16FieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/Int16FieldExpression.generated.cs
@@ -1980,16 +1980,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int16FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int16FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int16FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int16FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int16FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int16FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int16FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int16FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int16FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int16FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int16FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int16FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/Int32FieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/Int32FieldExpression.generated.cs
@@ -1980,16 +1980,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int32FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int32FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int32FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int32FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int32FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int32FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int32FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int32FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int32FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int32FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int32FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int32FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/Int64FieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/Int64FieldExpression.generated.cs
@@ -1980,16 +1980,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int64FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int64FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int64FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int64FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int64FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int64FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int64FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int64FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int64FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int64FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int64FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int64FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableBooleanFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableBooleanFieldExpression.generated.cs
@@ -112,8 +112,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableBooleanFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<bool?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableBooleanFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<bool?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableBooleanFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<bool?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableBooleanFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<bool?>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableByteFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableByteFieldExpression.generated.cs
@@ -2182,16 +2182,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableByteFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableByteFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableByteFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableByteFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableByteFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableByteFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableByteFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableByteFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableByteFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableByteFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableByteFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableByteFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDateTimeFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDateTimeFieldExpression.generated.cs
@@ -973,16 +973,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDateTimeFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDateTimeFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDateTimeFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDateTimeFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDateTimeFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDateTimeFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDateTimeFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDateTimeFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDateTimeFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDateTimeFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDateTimeFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDateTimeFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDateTimeOffsetFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDateTimeOffsetFieldExpression.generated.cs
@@ -973,16 +973,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDateTimeOffsetFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDateTimeOffsetFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDateTimeOffsetFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDateTimeOffsetFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDateTimeOffsetFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDateTimeOffsetFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDateTimeOffsetFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDateTimeOffsetFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDateTimeOffsetFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDateTimeOffsetFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDateTimeOffsetFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDateTimeOffsetFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDecimalFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDecimalFieldExpression.generated.cs
@@ -2182,16 +2182,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDecimalFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDecimalFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDecimalFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDecimalFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDecimalFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDecimalFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDecimalFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDecimalFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDecimalFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDecimalFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDecimalFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDecimalFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDoubleFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableDoubleFieldExpression.generated.cs
@@ -2182,16 +2182,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDoubleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDoubleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDoubleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDoubleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDoubleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDoubleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDoubleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDoubleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDoubleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDoubleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDoubleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDoubleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableGuidFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableGuidFieldExpression.generated.cs
@@ -112,8 +112,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableGuidFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableGuidFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<Guid?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableGuidFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableGuidFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<Guid?>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt16FieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt16FieldExpression.generated.cs
@@ -2182,16 +2182,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt16FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt16FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt16FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt16FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt16FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt16FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt16FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt16FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt16FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt16FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt16FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt16FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt32FieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt32FieldExpression.generated.cs
@@ -2182,16 +2182,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt32FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt32FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt32FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt32FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt32FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt32FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt32FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt32FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt32FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt32FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt32FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt32FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt64FieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableInt64FieldExpression.generated.cs
@@ -2182,16 +2182,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt64FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt64FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt64FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt64FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt64FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt64FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt64FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt64FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt64FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt64FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt64FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt64FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableSingleFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableSingleFieldExpression.generated.cs
@@ -2182,16 +2182,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableStringFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableStringFieldExpression.generated.cs
@@ -238,16 +238,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableStringFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableStringFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableStringFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableStringFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableStringFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableStringFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableStringFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableStringFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableStringFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableStringFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableStringFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableStringFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/NullableTimeSpanFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/NullableTimeSpanFieldExpression.generated.cs
@@ -167,8 +167,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableTimeSpanFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableTimeSpanFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableTimeSpanFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableTimeSpanFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan?>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/SingleFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/SingleFieldExpression.generated.cs
@@ -1980,16 +1980,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/StringFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/StringFieldExpression.generated.cs
@@ -330,16 +330,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(StringFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, StringFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(StringFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, StringFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(StringFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, StringFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(StringFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, StringFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(StringFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, StringFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(StringFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, StringFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Field/TimeSpanFieldExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Field/TimeSpanFieldExpression.generated.cs
@@ -254,8 +254,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(TimeSpanFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, TimeSpanFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(TimeSpanFieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, TimeSpanFieldExpression b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/DecimalAverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/DecimalAverageFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DecimalAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DecimalAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DecimalAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DecimalAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DecimalAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DecimalAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DecimalAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DecimalAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DecimalAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DecimalAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DecimalAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DecimalAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/DoubleAverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/DoubleAverageFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DoubleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DoubleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DoubleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DoubleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DoubleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DoubleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DoubleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DoubleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DoubleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DoubleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DoubleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DoubleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/Int32AverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/Int32AverageFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int32AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int32AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int32AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int32AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int32AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int32AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int32AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int32AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int32AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int32AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int32AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int32AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/Int64AverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/Int64AverageFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int64AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int64AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int64AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int64AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int64AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int64AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int64AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int64AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int64AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int64AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int64AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int64AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableDecimalAverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableDecimalAverageFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDecimalAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDecimalAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDecimalAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDecimalAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDecimalAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDecimalAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDecimalAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDecimalAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDecimalAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDecimalAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDecimalAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDecimalAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableDoubleAverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableDoubleAverageFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDoubleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDoubleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDoubleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDoubleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDoubleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDoubleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDoubleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDoubleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDoubleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDoubleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDoubleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDoubleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableInt32AverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableInt32AverageFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt32AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt32AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt32AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt32AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt32AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt32AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt32AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt32AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt32AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt32AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt32AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt32AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableInt64AverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableInt64AverageFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt64AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt64AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt64AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt64AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt64AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt64AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt64AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt64AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt64AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt64AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt64AverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt64AverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableObjectAverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableObjectAverageFunctionExpression.generated.cs
@@ -1528,16 +1528,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableObjectAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableObjectAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableObjectAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableObjectAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableObjectAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableObjectAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableObjectAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableObjectAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableObjectAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableObjectAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableObjectAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableObjectAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableSingleAverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableSingleAverageFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/SingleAverageFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/SingleAverageFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleAverageFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleAverageFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Count/Int32CountFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Count/Int32CountFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int32CountFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int32CountFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int32CountFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int32CountFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int32CountFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int32CountFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int32CountFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int32CountFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int32CountFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int32CountFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int32CountFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int32CountFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Count/NullableObjectCountFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Count/NullableObjectCountFunctionExpression.generated.cs
@@ -1528,16 +1528,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableObjectCountFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableObjectCountFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableObjectCountFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableObjectCountFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableObjectCountFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableObjectCountFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableObjectCountFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableObjectCountFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableObjectCountFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableObjectCountFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableObjectCountFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableObjectCountFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/ByteMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/ByteMaximumFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(ByteMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, ByteMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(ByteMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, ByteMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(ByteMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, ByteMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(ByteMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, ByteMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(ByteMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, ByteMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(ByteMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, ByteMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DateTimeMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DateTimeMaximumFunctionExpression.generated.cs
@@ -787,16 +787,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DateTimeMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DateTimeMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DateTimeMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DateTimeMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DateTimeMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DateTimeMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DateTimeMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DateTimeMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DateTimeMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DateTimeMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DateTimeMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DateTimeMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DateTimeOffsetMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DateTimeOffsetMaximumFunctionExpression.generated.cs
@@ -787,16 +787,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DateTimeOffsetMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DateTimeOffsetMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DateTimeOffsetMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DateTimeOffsetMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DateTimeOffsetMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DateTimeOffsetMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DateTimeOffsetMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DateTimeOffsetMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DateTimeOffsetMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DateTimeOffsetMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DateTimeOffsetMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DateTimeOffsetMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DecimalMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DecimalMaximumFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DecimalMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DecimalMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DecimalMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DecimalMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DecimalMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DecimalMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DecimalMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DecimalMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DecimalMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DecimalMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DecimalMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DecimalMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DoubleMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DoubleMaximumFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DoubleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DoubleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DoubleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DoubleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DoubleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DoubleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DoubleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DoubleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DoubleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DoubleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DoubleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DoubleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/GuidMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/GuidMaximumFunctionExpression.generated.cs
@@ -151,8 +151,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(GuidMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, GuidMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<Guid>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(GuidMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, GuidMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<Guid>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/Int16MaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/Int16MaximumFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int16MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int16MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int16MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int16MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int16MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int16MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int16MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int16MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int16MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int16MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int16MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int16MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/Int32MaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/Int32MaximumFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int32MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int32MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int32MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int32MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int32MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int32MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int32MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int32MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int32MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int32MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int32MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int32MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/Int64MaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/Int64MaximumFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int64MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int64MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int64MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int64MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int64MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int64MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int64MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int64MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int64MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int64MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int64MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int64MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableByteMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableByteMaximumFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableByteMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableByteMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableByteMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableByteMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableByteMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableByteMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableByteMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableByteMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableByteMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableByteMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableByteMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableByteMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDateTimeMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDateTimeMaximumFunctionExpression.generated.cs
@@ -807,16 +807,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDateTimeMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDateTimeMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDateTimeMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDateTimeMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDateTimeMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDateTimeMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDateTimeMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDateTimeMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDateTimeMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDateTimeMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDateTimeMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDateTimeMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDateTimeOffsetMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDateTimeOffsetMaximumFunctionExpression.generated.cs
@@ -807,16 +807,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDateTimeOffsetMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDateTimeOffsetMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDateTimeOffsetMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDateTimeOffsetMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDateTimeOffsetMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDateTimeOffsetMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDateTimeOffsetMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDateTimeOffsetMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDateTimeOffsetMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDateTimeOffsetMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDateTimeOffsetMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDateTimeOffsetMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDecimalMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDecimalMaximumFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDecimalMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDecimalMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDecimalMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDecimalMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDecimalMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDecimalMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDecimalMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDecimalMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDecimalMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDecimalMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDecimalMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDecimalMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDoubleMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDoubleMaximumFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDoubleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDoubleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDoubleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDoubleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDoubleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDoubleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDoubleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDoubleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDoubleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDoubleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDoubleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDoubleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableGuidMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableGuidMaximumFunctionExpression.generated.cs
@@ -182,8 +182,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableGuidMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableGuidMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<Guid?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableGuidMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableGuidMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<Guid?>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableInt16MaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableInt16MaximumFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt16MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt16MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt16MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt16MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt16MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt16MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt16MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt16MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt16MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt16MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt16MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt16MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableInt32MaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableInt32MaximumFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt32MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt32MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt32MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt32MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt32MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt32MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt32MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt32MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt32MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt32MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt32MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt32MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableInt64MaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableInt64MaximumFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt64MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt64MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt64MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt64MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt64MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt64MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt64MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt64MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt64MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt64MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt64MaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt64MaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableObjectMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableObjectMaximumFunctionExpression.generated.cs
@@ -1528,16 +1528,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableObjectMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableObjectMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableObjectMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableObjectMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableObjectMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableObjectMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableObjectMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableObjectMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableObjectMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableObjectMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableObjectMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableObjectMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableSingleMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableSingleMaximumFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableTimeSpanMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableTimeSpanMaximumFunctionExpression.generated.cs
@@ -182,8 +182,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableTimeSpanMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableTimeSpanMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableTimeSpanMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableTimeSpanMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan?>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/SingleMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/SingleMaximumFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/StringMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/StringMaximumFunctionExpression.generated.cs
@@ -175,16 +175,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(StringMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, StringMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(StringMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, StringMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(StringMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, StringMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(StringMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, StringMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(StringMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, StringMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(StringMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, StringMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/TimeSpanMaximumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/TimeSpanMaximumFunctionExpression.generated.cs
@@ -151,8 +151,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(TimeSpanMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, TimeSpanMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(TimeSpanMaximumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, TimeSpanMaximumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/ByteMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/ByteMinimumFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(ByteMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, ByteMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(ByteMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, ByteMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(ByteMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, ByteMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(ByteMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, ByteMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(ByteMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, ByteMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(ByteMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, ByteMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DateTimeMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DateTimeMinimumFunctionExpression.generated.cs
@@ -787,16 +787,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DateTimeMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DateTimeMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DateTimeMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DateTimeMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DateTimeMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DateTimeMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DateTimeMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DateTimeMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DateTimeMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DateTimeMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DateTimeMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DateTimeMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DateTimeOffsetMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DateTimeOffsetMinimumFunctionExpression.generated.cs
@@ -787,16 +787,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DateTimeOffsetMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DateTimeOffsetMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DateTimeOffsetMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DateTimeOffsetMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DateTimeOffsetMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DateTimeOffsetMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DateTimeOffsetMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DateTimeOffsetMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DateTimeOffsetMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DateTimeOffsetMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DateTimeOffsetMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DateTimeOffsetMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DecimalMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DecimalMinimumFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DecimalMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DecimalMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DecimalMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DecimalMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DecimalMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DecimalMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DecimalMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DecimalMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DecimalMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DecimalMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DecimalMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DecimalMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DoubleMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DoubleMinimumFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DoubleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DoubleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DoubleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DoubleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DoubleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DoubleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DoubleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DoubleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DoubleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DoubleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DoubleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DoubleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/GuidMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/GuidMinimumFunctionExpression.generated.cs
@@ -151,8 +151,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(GuidMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, GuidMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<Guid>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(GuidMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, GuidMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<Guid>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/Int16MinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/Int16MinimumFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int16MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int16MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int16MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int16MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int16MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int16MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int16MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int16MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int16MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int16MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int16MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int16MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/Int32MinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/Int32MinimumFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int32MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int32MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int32MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int32MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int32MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int32MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int32MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int32MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int32MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int32MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int32MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int32MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/Int64MinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/Int64MinimumFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int64MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int64MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int64MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int64MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int64MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int64MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int64MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int64MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int64MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int64MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int64MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int64MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableByteMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableByteMinimumFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableByteMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableByteMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableByteMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableByteMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableByteMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableByteMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableByteMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableByteMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableByteMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableByteMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableByteMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableByteMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDateTimeMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDateTimeMinimumFunctionExpression.generated.cs
@@ -807,16 +807,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDateTimeMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDateTimeMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDateTimeMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDateTimeMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDateTimeMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDateTimeMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDateTimeMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDateTimeMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDateTimeMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDateTimeMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDateTimeMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDateTimeMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDateTimeOffsetMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDateTimeOffsetMinimumFunctionExpression.generated.cs
@@ -807,16 +807,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDateTimeOffsetMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDateTimeOffsetMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDateTimeOffsetMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDateTimeOffsetMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDateTimeOffsetMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDateTimeOffsetMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDateTimeOffsetMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDateTimeOffsetMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDateTimeOffsetMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDateTimeOffsetMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDateTimeOffsetMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDateTimeOffsetMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDecimalMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDecimalMinimumFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDecimalMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDecimalMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDecimalMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDecimalMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDecimalMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDecimalMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDecimalMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDecimalMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDecimalMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDecimalMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDecimalMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDecimalMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDoubleMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDoubleMinimumFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDoubleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDoubleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDoubleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDoubleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDoubleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDoubleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDoubleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDoubleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDoubleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDoubleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDoubleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDoubleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableGuidMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableGuidMinimumFunctionExpression.generated.cs
@@ -182,8 +182,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableGuidMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableGuidMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<Guid?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableGuidMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableGuidMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<Guid?>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableInt16MinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableInt16MinimumFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt16MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt16MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt16MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt16MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt16MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt16MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt16MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt16MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt16MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt16MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt16MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt16MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableInt32MinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableInt32MinimumFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt32MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt32MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt32MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt32MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt32MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt32MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt32MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt32MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt32MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt32MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt32MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt32MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableInt64MinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableInt64MinimumFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt64MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt64MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt64MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt64MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt64MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt64MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt64MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt64MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt64MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt64MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt64MinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt64MinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableObjectMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableObjectMinimumFunctionExpression.generated.cs
@@ -1528,16 +1528,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableObjectMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableObjectMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableObjectMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableObjectMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableObjectMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableObjectMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableObjectMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableObjectMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableObjectMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableObjectMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableObjectMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableObjectMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableSingleMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableSingleMinimumFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableTimeSpanMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableTimeSpanMinimumFunctionExpression.generated.cs
@@ -182,8 +182,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableTimeSpanMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableTimeSpanMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableTimeSpanMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableTimeSpanMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan?>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/SingleMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/SingleMinimumFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/StringMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/StringMinimumFunctionExpression.generated.cs
@@ -175,16 +175,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(StringMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, StringMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(StringMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, StringMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(StringMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, StringMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(StringMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, StringMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(StringMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, StringMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(StringMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, StringMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/TimeSpanMinimumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/TimeSpanMinimumFunctionExpression.generated.cs
@@ -151,8 +151,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(TimeSpanMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, TimeSpanMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(TimeSpanMinimumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, TimeSpanMinimumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationStandardDeviation/NullableSinglePopulationStandardDeviationFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationStandardDeviation/NullableSinglePopulationStandardDeviationFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSinglePopulationStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSinglePopulationStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSinglePopulationStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSinglePopulationStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSinglePopulationStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSinglePopulationStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSinglePopulationStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSinglePopulationStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSinglePopulationStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSinglePopulationStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSinglePopulationStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSinglePopulationStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationStandardDeviation/SinglePopulationStandardDeviationFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationStandardDeviation/SinglePopulationStandardDeviationFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SinglePopulationStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SinglePopulationStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SinglePopulationStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SinglePopulationStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SinglePopulationStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SinglePopulationStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SinglePopulationStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SinglePopulationStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SinglePopulationStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SinglePopulationStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SinglePopulationStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SinglePopulationStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationVariance/NullableSinglePopulationVarianceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationVariance/NullableSinglePopulationVarianceFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSinglePopulationVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSinglePopulationVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSinglePopulationVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSinglePopulationVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSinglePopulationVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSinglePopulationVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSinglePopulationVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSinglePopulationVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSinglePopulationVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSinglePopulationVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSinglePopulationVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSinglePopulationVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationVariance/SinglePopulationVarianceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationVariance/SinglePopulationVarianceFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SinglePopulationVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SinglePopulationVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SinglePopulationVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SinglePopulationVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SinglePopulationVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SinglePopulationVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SinglePopulationVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SinglePopulationVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SinglePopulationVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SinglePopulationVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SinglePopulationVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SinglePopulationVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_StandardDeviation/NullableSingleStandardDeviationFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_StandardDeviation/NullableSingleStandardDeviationFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_StandardDeviation/SingleStandardDeviationFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_StandardDeviation/SingleStandardDeviationFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleStandardDeviationFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleStandardDeviationFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/DecimalSumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/DecimalSumFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DecimalSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DecimalSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DecimalSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DecimalSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DecimalSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DecimalSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DecimalSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DecimalSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DecimalSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DecimalSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DecimalSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DecimalSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/DoubleSumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/DoubleSumFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DoubleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DoubleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DoubleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DoubleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DoubleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DoubleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DoubleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DoubleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DoubleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DoubleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DoubleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DoubleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/Int32SumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/Int32SumFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int32SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int32SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int32SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int32SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int32SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int32SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int32SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int32SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int32SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int32SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int32SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int32SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/Int64SumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/Int64SumFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int64SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int64SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int64SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int64SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int64SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int64SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int64SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int64SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int64SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int64SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int64SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int64SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableDecimalSumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableDecimalSumFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDecimalSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDecimalSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDecimalSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDecimalSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDecimalSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDecimalSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDecimalSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDecimalSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDecimalSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDecimalSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDecimalSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDecimalSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableDoubleSumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableDoubleSumFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDoubleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDoubleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDoubleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDoubleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDoubleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDoubleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDoubleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDoubleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDoubleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDoubleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDoubleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDoubleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableInt32SumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableInt32SumFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt32SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt32SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt32SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt32SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt32SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt32SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt32SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt32SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt32SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt32SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt32SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt32SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableInt64SumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableInt64SumFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt64SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt64SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt64SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt64SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt64SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt64SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt64SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt64SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt64SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt64SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt64SumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt64SumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableObjectSumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableObjectSumFunctionExpression.generated.cs
@@ -1528,16 +1528,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableObjectSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableObjectSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableObjectSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableObjectSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableObjectSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableObjectSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableObjectSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableObjectSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableObjectSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableObjectSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableObjectSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableObjectSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableSingleSumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableSingleSumFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/SingleSumFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/SingleSumFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleSumFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleSumFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Variance/NullableSingleVarianceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Variance/NullableSingleVarianceFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Variance/SingleVarianceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Variance/SingleVarianceFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleVarianceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleVarianceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/BooleanCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/BooleanCastFunctionExpression.generated.cs
@@ -187,8 +187,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(BooleanCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<bool>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, BooleanCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<bool>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(BooleanCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<bool>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, BooleanCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<bool>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/ByteCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/ByteCastFunctionExpression.generated.cs
@@ -2157,16 +2157,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(ByteCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, ByteCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(ByteCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, ByteCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(ByteCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, ByteCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(ByteCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, ByteCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(ByteCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, ByteCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(ByteCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, ByteCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/DateTimeCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/DateTimeCastFunctionExpression.generated.cs
@@ -963,16 +963,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DateTimeCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DateTimeCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DateTimeCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DateTimeCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DateTimeCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DateTimeCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DateTimeCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DateTimeCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DateTimeCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DateTimeCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DateTimeCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DateTimeCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/DateTimeOffsetCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/DateTimeOffsetCastFunctionExpression.generated.cs
@@ -963,16 +963,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DateTimeOffsetCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DateTimeOffsetCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DateTimeOffsetCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DateTimeOffsetCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DateTimeOffsetCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DateTimeOffsetCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DateTimeOffsetCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DateTimeOffsetCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DateTimeOffsetCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DateTimeOffsetCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DateTimeOffsetCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DateTimeOffsetCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/DecimalCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/DecimalCastFunctionExpression.generated.cs
@@ -2157,16 +2157,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DecimalCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DecimalCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DecimalCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DecimalCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DecimalCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DecimalCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DecimalCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DecimalCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DecimalCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DecimalCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DecimalCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DecimalCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/DoubleCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/DoubleCastFunctionExpression.generated.cs
@@ -2157,16 +2157,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DoubleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DoubleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DoubleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DoubleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DoubleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DoubleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DoubleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DoubleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DoubleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DoubleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DoubleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DoubleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/GuidCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/GuidCastFunctionExpression.generated.cs
@@ -187,8 +187,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(GuidCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, GuidCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<Guid>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(GuidCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, GuidCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<Guid>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/Int16CastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/Int16CastFunctionExpression.generated.cs
@@ -2157,16 +2157,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int16CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int16CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int16CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int16CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int16CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int16CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int16CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int16CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int16CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int16CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int16CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int16CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/Int32CastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/Int32CastFunctionExpression.generated.cs
@@ -2157,16 +2157,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int32CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int32CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int32CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int32CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int32CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int32CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int32CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int32CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int32CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int32CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int32CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int32CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/Int64CastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/Int64CastFunctionExpression.generated.cs
@@ -2157,16 +2157,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int64CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int64CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int64CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int64CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int64CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int64CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int64CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int64CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int64CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int64CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int64CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int64CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableBooleanCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableBooleanCastFunctionExpression.generated.cs
@@ -239,8 +239,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableBooleanCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<bool?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableBooleanCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<bool?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableBooleanCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<bool?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableBooleanCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<bool?>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableByteCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableByteCastFunctionExpression.generated.cs
@@ -2209,16 +2209,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableByteCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableByteCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableByteCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableByteCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableByteCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableByteCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableByteCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableByteCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableByteCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableByteCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableByteCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableByteCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableDateTimeCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableDateTimeCastFunctionExpression.generated.cs
@@ -1003,16 +1003,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDateTimeCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDateTimeCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDateTimeCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDateTimeCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDateTimeCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDateTimeCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDateTimeCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDateTimeCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDateTimeCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDateTimeCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDateTimeCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDateTimeCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableDateTimeOffsetCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableDateTimeOffsetCastFunctionExpression.generated.cs
@@ -1003,16 +1003,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDateTimeOffsetCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDateTimeOffsetCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDateTimeOffsetCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDateTimeOffsetCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDateTimeOffsetCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDateTimeOffsetCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDateTimeOffsetCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDateTimeOffsetCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDateTimeOffsetCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDateTimeOffsetCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDateTimeOffsetCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDateTimeOffsetCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableDecimalCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableDecimalCastFunctionExpression.generated.cs
@@ -2212,16 +2212,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDecimalCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDecimalCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDecimalCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDecimalCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDecimalCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDecimalCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDecimalCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDecimalCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDecimalCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDecimalCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDecimalCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDecimalCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableDoubleCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableDoubleCastFunctionExpression.generated.cs
@@ -2212,16 +2212,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDoubleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDoubleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDoubleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDoubleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDoubleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDoubleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDoubleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDoubleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDoubleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDoubleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDoubleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDoubleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableGuidCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableGuidCastFunctionExpression.generated.cs
@@ -239,8 +239,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableGuidCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableGuidCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<Guid?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableGuidCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableGuidCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<Guid?>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableInt16CastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableInt16CastFunctionExpression.generated.cs
@@ -2212,16 +2212,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt16CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt16CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt16CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt16CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt16CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt16CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt16CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt16CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt16CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt16CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt16CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt16CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableInt32CastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableInt32CastFunctionExpression.generated.cs
@@ -2212,16 +2212,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt32CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt32CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt32CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt32CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt32CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt32CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt32CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt32CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt32CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt32CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt32CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt32CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableInt64CastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableInt64CastFunctionExpression.generated.cs
@@ -2212,16 +2212,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt64CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt64CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt64CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt64CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt64CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt64CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt64CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt64CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt64CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt64CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt64CastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt64CastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableSingleCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableSingleCastFunctionExpression.generated.cs
@@ -2212,16 +2212,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableStringCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableStringCastFunctionExpression.generated.cs
@@ -269,16 +269,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableStringCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableStringCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableStringCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableStringCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableStringCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableStringCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableStringCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableStringCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableStringCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableStringCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableStringCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableStringCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableTimeSpanCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/NullableTimeSpanCastFunctionExpression.generated.cs
@@ -242,8 +242,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableTimeSpanCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableTimeSpanCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableTimeSpanCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableTimeSpanCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan?>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/SingleCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/SingleCastFunctionExpression.generated.cs
@@ -2157,16 +2157,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/StringCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/StringCastFunctionExpression.generated.cs
@@ -233,16 +233,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(StringCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, StringCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(StringCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, StringCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(StringCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, StringCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(StringCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, StringCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(StringCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, StringCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(StringCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, StringCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/TimeSpanCastFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Conversion/_Cast/TimeSpanCastFunctionExpression.generated.cs
@@ -187,8 +187,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(TimeSpanCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, TimeSpanCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(TimeSpanCastFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, TimeSpanCastFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DateAndTime/_CurrentTimestamp/CurrentTimestampFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DateAndTime/_CurrentTimestamp/CurrentTimestampFunctionExpression.generated.cs
@@ -185,16 +185,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(CurrentTimestampFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, CurrentTimestampFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(CurrentTimestampFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, CurrentTimestampFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(CurrentTimestampFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, CurrentTimestampFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(CurrentTimestampFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, CurrentTimestampFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(CurrentTimestampFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, CurrentTimestampFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(CurrentTimestampFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, CurrentTimestampFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DateAndTime/_DateAdd/DateTimeDateAddFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DateAndTime/_DateAdd/DateTimeDateAddFunctionExpression.generated.cs
@@ -435,16 +435,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DateTimeDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DateTimeDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DateTimeDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DateTimeDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DateTimeDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DateTimeDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DateTimeDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DateTimeDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DateTimeDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DateTimeDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DateTimeDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DateTimeDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DateAndTime/_DateAdd/DateTimeOffsetDateAddFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DateAndTime/_DateAdd/DateTimeOffsetDateAddFunctionExpression.generated.cs
@@ -435,16 +435,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DateTimeOffsetDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DateTimeOffsetDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DateTimeOffsetDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DateTimeOffsetDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DateTimeOffsetDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DateTimeOffsetDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DateTimeOffsetDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DateTimeOffsetDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DateTimeOffsetDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DateTimeOffsetDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DateTimeOffsetDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DateTimeOffsetDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DateAndTime/_DateAdd/NullableDateTimeDateAddFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DateAndTime/_DateAdd/NullableDateTimeDateAddFunctionExpression.generated.cs
@@ -445,16 +445,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDateTimeDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDateTimeDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDateTimeDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDateTimeDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDateTimeDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDateTimeDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDateTimeDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDateTimeDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDateTimeDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDateTimeDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDateTimeDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDateTimeDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DateAndTime/_DateAdd/NullableDateTimeOffsetDateAddFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DateAndTime/_DateAdd/NullableDateTimeOffsetDateAddFunctionExpression.generated.cs
@@ -445,16 +445,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDateTimeOffsetDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDateTimeOffsetDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDateTimeOffsetDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDateTimeOffsetDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDateTimeOffsetDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDateTimeOffsetDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDateTimeOffsetDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDateTimeOffsetDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDateTimeOffsetDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDateTimeOffsetDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDateTimeOffsetDateAddFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDateTimeOffsetDateAddFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DateAndTime/_DateDiff/Int32DateDiffFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DateAndTime/_DateDiff/Int32DateDiffFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int32DateDiffFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int32DateDiffFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int32DateDiffFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int32DateDiffFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int32DateDiffFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int32DateDiffFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int32DateDiffFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int32DateDiffFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int32DateDiffFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int32DateDiffFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int32DateDiffFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int32DateDiffFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DateAndTime/_DateDiff/NullableInt32DateDiffFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DateAndTime/_DateDiff/NullableInt32DateDiffFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt32DateDiffFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt32DateDiffFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt32DateDiffFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt32DateDiffFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt32DateDiffFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt32DateDiffFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt32DateDiffFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt32DateDiffFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt32DateDiffFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt32DateDiffFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt32DateDiffFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt32DateDiffFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DateAndTime/_DatePart/Int32DatePartFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DateAndTime/_DatePart/Int32DatePartFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int32DatePartFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int32DatePartFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int32DatePartFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int32DatePartFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int32DatePartFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int32DatePartFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int32DatePartFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int32DatePartFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int32DatePartFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int32DatePartFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int32DatePartFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int32DatePartFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DateAndTime/_DatePart/NullableInt32DatePartFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DateAndTime/_DatePart/NullableInt32DatePartFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt32DatePartFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt32DatePartFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt32DatePartFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt32DatePartFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt32DatePartFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt32DatePartFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt32DatePartFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt32DatePartFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt32DatePartFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt32DatePartFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt32DatePartFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt32DatePartFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_Coalesce/EnumCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_Coalesce/EnumCoalesceFunctionExpression.generated.cs
@@ -53,5 +53,15 @@ namespace HatTrick.DbEx.Sql.Expression
 
         public static FilterExpression<bool?> operator !=(TEnum? a, EnumCoalesceFunctionExpression<TEnum> b) => new FilterExpression<bool?>(new LiteralExpression<TEnum?>(a), b, FilterExpressionOperator.NotEqual);
         #endregion
+
+        #region alias
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, EnumCoalesceFunctionExpression<TEnum> b) => new FilterExpression<bool?>(new AliasExpression<TEnum?>(a), b, FilterExpressionOperator.Equal);
+
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, EnumCoalesceFunctionExpression<TEnum> b) => new FilterExpression<bool?>(new AliasExpression<TEnum?>(a), b, FilterExpressionOperator.NotEqual);
+
+        public static FilterExpression<bool?> operator ==(EnumCoalesceFunctionExpression<TEnum> a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TEnum?>(b), FilterExpressionOperator.Equal);
+
+        public static FilterExpression<bool?> operator !=(EnumCoalesceFunctionExpression<TEnum> a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TEnum?>(b), FilterExpressionOperator.NotEqual);
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_Coalesce/NullableEnumCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_Coalesce/NullableEnumCoalesceFunctionExpression.generated.cs
@@ -54,5 +54,15 @@ namespace HatTrick.DbEx.Sql.Expression
 
         public static FilterExpression<bool?> operator !=(TEnum a, NullableEnumCoalesceFunctionExpression<TEnum> b) => new FilterExpression<bool?>(new LiteralExpression<TEnum>(a), b, FilterExpressionOperator.NotEqual);
         #endregion
+
+        #region alias
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableEnumCoalesceFunctionExpression<TEnum> b) => new FilterExpression<bool?>(new AliasExpression<TEnum?>(a), b, FilterExpressionOperator.Equal);
+
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableEnumCoalesceFunctionExpression<TEnum> b) => new FilterExpression<bool?>(new AliasExpression<TEnum?>(a), b, FilterExpressionOperator.NotEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableEnumCoalesceFunctionExpression<TEnum> a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TEnum?>(b), FilterExpressionOperator.Equal);
+
+        public static FilterExpression<bool?> operator !=(NullableEnumCoalesceFunctionExpression<TEnum> a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TEnum?>(b), FilterExpressionOperator.NotEqual);
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_Coalesce/NullableObjectCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_Coalesce/NullableObjectCoalesceFunctionExpression.generated.cs
@@ -551,16 +551,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableObjectCoalesceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableObjectCoalesceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableObjectCoalesceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableObjectCoalesceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableObjectCoalesceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableObjectCoalesceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableObjectCoalesceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableObjectCoalesceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableObjectCoalesceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableObjectCoalesceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableObjectCoalesceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableObjectCoalesceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_Coalesce/ObjectCoalesceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_Coalesce/ObjectCoalesceFunctionExpression.generated.cs
@@ -1287,16 +1287,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(ObjectCoalesceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, ObjectCoalesceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(ObjectCoalesceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, ObjectCoalesceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(ObjectCoalesceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, ObjectCoalesceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(ObjectCoalesceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, ObjectCoalesceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(ObjectCoalesceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, ObjectCoalesceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(ObjectCoalesceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, ObjectCoalesceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/BooleanIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/BooleanIsNullFunctionExpression.generated.cs
@@ -187,8 +187,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(BooleanIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<bool>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, BooleanIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<bool>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(BooleanIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<bool>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, BooleanIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<bool>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/ByteIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/ByteIsNullFunctionExpression.generated.cs
@@ -2157,16 +2157,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(ByteIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, ByteIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(ByteIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, ByteIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(ByteIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, ByteIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(ByteIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, ByteIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(ByteIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, ByteIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(ByteIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, ByteIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/DateTimeIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/DateTimeIsNullFunctionExpression.generated.cs
@@ -963,16 +963,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DateTimeIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DateTimeIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DateTimeIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DateTimeIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DateTimeIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DateTimeIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DateTimeIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DateTimeIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DateTimeIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DateTimeIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DateTimeIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DateTimeIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/DateTimeOffsetIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/DateTimeOffsetIsNullFunctionExpression.generated.cs
@@ -963,16 +963,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DateTimeOffsetIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DateTimeOffsetIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DateTimeOffsetIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DateTimeOffsetIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DateTimeOffsetIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DateTimeOffsetIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DateTimeOffsetIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DateTimeOffsetIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DateTimeOffsetIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DateTimeOffsetIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DateTimeOffsetIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DateTimeOffsetIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/DecimalIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/DecimalIsNullFunctionExpression.generated.cs
@@ -2157,16 +2157,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DecimalIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DecimalIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DecimalIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DecimalIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DecimalIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DecimalIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DecimalIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DecimalIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DecimalIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DecimalIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DecimalIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DecimalIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/DoubleIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/DoubleIsNullFunctionExpression.generated.cs
@@ -2157,16 +2157,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DoubleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DoubleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DoubleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DoubleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DoubleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DoubleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DoubleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DoubleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DoubleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DoubleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DoubleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DoubleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/EnumIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/EnumIsNullFunctionExpression.generated.cs
@@ -53,5 +53,15 @@ namespace HatTrick.DbEx.Sql.Expression
 
         public static FilterExpression<bool?> operator !=(TEnum? a, EnumIsNullFunctionExpression<TEnum> b) => new FilterExpression<bool?>(new LiteralExpression<TEnum?>(a), b, FilterExpressionOperator.NotEqual);
         #endregion
+
+        #region alias
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, EnumIsNullFunctionExpression<TEnum> b) => new FilterExpression<bool?>(new AliasExpression<TEnum?>(a), b, FilterExpressionOperator.Equal);
+
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, EnumIsNullFunctionExpression<TEnum> b) => new FilterExpression<bool?>(new AliasExpression<TEnum?>(a), b, FilterExpressionOperator.NotEqual);
+
+        public static FilterExpression<bool?> operator ==(EnumIsNullFunctionExpression<TEnum> a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TEnum?>(b), FilterExpressionOperator.Equal);
+
+        public static FilterExpression<bool?> operator !=(EnumIsNullFunctionExpression<TEnum> a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TEnum?>(b), FilterExpressionOperator.NotEqual);
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/GuidIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/GuidIsNullFunctionExpression.generated.cs
@@ -187,8 +187,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(GuidIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, GuidIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<Guid>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(GuidIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, GuidIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<Guid>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/Int16IsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/Int16IsNullFunctionExpression.generated.cs
@@ -2157,16 +2157,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int16IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int16IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int16IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int16IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int16IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int16IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int16IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int16IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int16IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int16IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int16IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int16IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/Int32IsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/Int32IsNullFunctionExpression.generated.cs
@@ -2157,16 +2157,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int32IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int32IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int32IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int32IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int32IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int32IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int32IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int32IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int32IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int32IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int32IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int32IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/Int64IsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/Int64IsNullFunctionExpression.generated.cs
@@ -2157,16 +2157,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int64IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int64IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int64IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int64IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int64IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int64IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int64IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int64IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int64IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int64IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int64IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int64IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableBooleanIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableBooleanIsNullFunctionExpression.generated.cs
@@ -239,8 +239,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableBooleanIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<bool?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableBooleanIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<bool?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableBooleanIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<bool?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableBooleanIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<bool?>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableByteIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableByteIsNullFunctionExpression.generated.cs
@@ -2209,16 +2209,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableByteIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableByteIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableByteIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableByteIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableByteIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableByteIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableByteIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableByteIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableByteIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableByteIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableByteIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableByteIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableDateTimeIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableDateTimeIsNullFunctionExpression.generated.cs
@@ -1003,16 +1003,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDateTimeIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDateTimeIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDateTimeIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDateTimeIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDateTimeIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDateTimeIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDateTimeIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDateTimeIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDateTimeIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDateTimeIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDateTimeIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDateTimeIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableDateTimeOffsetIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableDateTimeOffsetIsNullFunctionExpression.generated.cs
@@ -1003,16 +1003,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDateTimeOffsetIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDateTimeOffsetIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDateTimeOffsetIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDateTimeOffsetIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDateTimeOffsetIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDateTimeOffsetIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDateTimeOffsetIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDateTimeOffsetIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDateTimeOffsetIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDateTimeOffsetIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDateTimeOffsetIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDateTimeOffsetIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableDecimalIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableDecimalIsNullFunctionExpression.generated.cs
@@ -2212,16 +2212,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDecimalIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDecimalIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDecimalIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDecimalIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDecimalIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDecimalIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDecimalIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDecimalIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDecimalIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDecimalIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDecimalIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDecimalIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableDoubleIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableDoubleIsNullFunctionExpression.generated.cs
@@ -2212,16 +2212,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDoubleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDoubleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDoubleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDoubleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDoubleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDoubleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDoubleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDoubleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDoubleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDoubleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDoubleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDoubleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableEnumIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableEnumIsNullFunctionExpression.generated.cs
@@ -54,5 +54,15 @@ namespace HatTrick.DbEx.Sql.Expression
 
         public static FilterExpression<bool?> operator !=(TEnum a, NullableEnumIsNullFunctionExpression<TEnum> b) => new FilterExpression<bool?>(new LiteralExpression<TEnum>(a), b, FilterExpressionOperator.NotEqual);
         #endregion
+
+        #region alias
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableEnumIsNullFunctionExpression<TEnum> b) => new FilterExpression<bool?>(new AliasExpression<TEnum?>(a), b, FilterExpressionOperator.Equal);
+
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableEnumIsNullFunctionExpression<TEnum> b) => new FilterExpression<bool?>(new AliasExpression<TEnum?>(a), b, FilterExpressionOperator.NotEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableEnumIsNullFunctionExpression<TEnum> a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TEnum?>(b), FilterExpressionOperator.Equal);
+
+        public static FilterExpression<bool?> operator !=(NullableEnumIsNullFunctionExpression<TEnum> a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TEnum?>(b), FilterExpressionOperator.NotEqual);
+        #endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableGuidIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableGuidIsNullFunctionExpression.generated.cs
@@ -239,8 +239,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableGuidIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableGuidIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<Guid?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableGuidIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableGuidIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<Guid?>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableInt16IsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableInt16IsNullFunctionExpression.generated.cs
@@ -2212,16 +2212,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt16IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt16IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt16IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt16IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt16IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt16IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt16IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt16IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt16IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt16IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt16IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt16IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableInt32IsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableInt32IsNullFunctionExpression.generated.cs
@@ -2212,16 +2212,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt32IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt32IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt32IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt32IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt32IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt32IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt32IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt32IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt32IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt32IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt32IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt32IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableInt64IsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableInt64IsNullFunctionExpression.generated.cs
@@ -2212,16 +2212,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt64IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt64IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt64IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt64IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt64IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt64IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt64IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt64IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt64IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt64IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt64IsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt64IsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableObjectIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableObjectIsNullFunctionExpression.generated.cs
@@ -1679,16 +1679,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableObjectIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableObjectIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableObjectIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableObjectIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableObjectIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableObjectIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableObjectIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableObjectIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableObjectIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableObjectIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableObjectIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableObjectIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableSingleIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableSingleIsNullFunctionExpression.generated.cs
@@ -2212,16 +2212,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableStringIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableStringIsNullFunctionExpression.generated.cs
@@ -269,16 +269,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableStringIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableStringIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableStringIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableStringIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableStringIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableStringIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableStringIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableStringIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableStringIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableStringIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableStringIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableStringIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableTimeSpanIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/NullableTimeSpanIsNullFunctionExpression.generated.cs
@@ -242,8 +242,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableTimeSpanIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableTimeSpanIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableTimeSpanIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableTimeSpanIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan?>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/SingleIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/SingleIsNullFunctionExpression.generated.cs
@@ -2157,16 +2157,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/StringIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/StringIsNullFunctionExpression.generated.cs
@@ -233,16 +233,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(StringIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, StringIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(StringIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, StringIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(StringIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, StringIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(StringIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, StringIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(StringIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, StringIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(StringIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, StringIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/TimeSpanIsNullFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Expression/_IsNull/TimeSpanIsNullFunctionExpression.generated.cs
@@ -187,8 +187,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(TimeSpanIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, TimeSpanIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(TimeSpanIsNullFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, TimeSpanIsNullFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_ACos/NullableSingleACosFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_ACos/NullableSingleACosFunctionExpression.generated.cs
@@ -1004,16 +1004,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleACosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleACosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleACosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleACosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleACosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleACosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleACosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleACosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleACosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleACosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleACosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleACosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_ACos/SingleACosFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_ACos/SingleACosFunctionExpression.generated.cs
@@ -981,16 +981,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleACosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleACosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleACosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleACosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleACosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleACosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleACosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleACosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleACosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleACosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleACosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleACosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_ASin/NullableSingleASinFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_ASin/NullableSingleASinFunctionExpression.generated.cs
@@ -1004,16 +1004,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleASinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleASinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleASinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleASinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleASinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleASinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleASinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleASinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleASinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleASinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleASinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleASinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_ASin/SingleASinFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_ASin/SingleASinFunctionExpression.generated.cs
@@ -981,16 +981,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleASinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleASinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleASinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleASinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleASinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleASinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleASinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleASinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleASinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleASinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleASinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleASinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_ATan/NullableSingleATanFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_ATan/NullableSingleATanFunctionExpression.generated.cs
@@ -1004,16 +1004,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleATanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleATanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleATanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleATanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleATanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleATanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleATanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleATanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleATanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleATanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleATanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleATanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_ATan/SingleATanFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_ATan/SingleATanFunctionExpression.generated.cs
@@ -981,16 +981,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleATanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleATanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleATanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleATanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleATanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleATanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleATanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleATanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleATanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleATanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleATanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleATanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/ByteAbsFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/ByteAbsFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(ByteAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, ByteAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(ByteAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, ByteAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(ByteAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, ByteAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(ByteAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, ByteAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(ByteAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, ByteAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(ByteAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, ByteAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/DecimalAbsFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/DecimalAbsFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DecimalAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DecimalAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DecimalAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DecimalAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DecimalAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DecimalAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DecimalAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DecimalAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DecimalAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DecimalAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DecimalAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DecimalAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/DoubleAbsFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/DoubleAbsFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DoubleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DoubleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DoubleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DoubleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DoubleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DoubleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DoubleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DoubleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DoubleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DoubleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DoubleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DoubleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/Int16AbsFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/Int16AbsFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int16AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int16AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int16AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int16AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int16AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int16AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int16AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int16AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int16AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int16AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int16AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int16AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/Int32AbsFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/Int32AbsFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int32AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int32AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int32AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int32AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int32AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int32AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int32AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int32AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int32AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int32AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int32AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int32AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/Int64AbsFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/Int64AbsFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int64AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int64AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int64AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int64AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int64AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int64AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int64AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int64AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int64AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int64AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int64AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int64AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/NullableByteAbsFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/NullableByteAbsFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableByteAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableByteAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableByteAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableByteAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableByteAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableByteAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableByteAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableByteAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableByteAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableByteAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableByteAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableByteAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/NullableDecimalAbsFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/NullableDecimalAbsFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDecimalAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDecimalAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDecimalAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDecimalAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDecimalAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDecimalAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDecimalAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDecimalAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDecimalAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDecimalAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDecimalAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDecimalAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/NullableDoubleAbsFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/NullableDoubleAbsFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDoubleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDoubleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDoubleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDoubleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDoubleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDoubleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDoubleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDoubleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDoubleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDoubleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDoubleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDoubleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/NullableInt16AbsFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/NullableInt16AbsFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt16AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt16AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt16AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt16AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt16AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt16AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt16AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt16AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt16AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt16AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt16AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt16AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/NullableInt32AbsFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/NullableInt32AbsFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt32AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt32AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt32AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt32AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt32AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt32AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt32AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt32AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt32AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt32AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt32AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt32AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/NullableInt64AbsFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/NullableInt64AbsFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt64AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt64AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt64AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt64AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt64AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt64AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt64AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt64AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt64AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt64AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt64AbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt64AbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/NullableObjectAbsFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/NullableObjectAbsFunctionExpression.generated.cs
@@ -1528,16 +1528,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableObjectAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableObjectAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableObjectAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableObjectAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableObjectAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableObjectAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableObjectAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableObjectAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableObjectAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableObjectAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableObjectAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableObjectAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/NullableSingleAbsFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/NullableSingleAbsFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/SingleAbsFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Abs/SingleAbsFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleAbsFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleAbsFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/ByteCeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/ByteCeilingFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(ByteCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, ByteCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(ByteCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, ByteCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(ByteCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, ByteCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(ByteCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, ByteCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(ByteCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, ByteCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(ByteCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, ByteCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/DecimalCeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/DecimalCeilingFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DecimalCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DecimalCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DecimalCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DecimalCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DecimalCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DecimalCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DecimalCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DecimalCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DecimalCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DecimalCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DecimalCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DecimalCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/DoubleCeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/DoubleCeilingFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DoubleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DoubleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DoubleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DoubleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DoubleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DoubleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DoubleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DoubleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DoubleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DoubleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DoubleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DoubleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/Int16CeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/Int16CeilingFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int16CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int16CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int16CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int16CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int16CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int16CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int16CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int16CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int16CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int16CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int16CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int16CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/Int32CeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/Int32CeilingFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int32CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int32CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int32CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int32CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int32CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int32CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int32CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int32CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int32CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int32CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int32CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int32CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/Int64CeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/Int64CeilingFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int64CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int64CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int64CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int64CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int64CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int64CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int64CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int64CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int64CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int64CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int64CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int64CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/NullableByteCeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/NullableByteCeilingFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableByteCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableByteCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableByteCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableByteCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableByteCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableByteCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableByteCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableByteCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableByteCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableByteCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableByteCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableByteCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/NullableDecimalCeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/NullableDecimalCeilingFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDecimalCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDecimalCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDecimalCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDecimalCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDecimalCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDecimalCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDecimalCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDecimalCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDecimalCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDecimalCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDecimalCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDecimalCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/NullableDoubleCeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/NullableDoubleCeilingFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDoubleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDoubleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDoubleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDoubleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDoubleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDoubleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDoubleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDoubleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDoubleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDoubleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDoubleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDoubleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/NullableInt16CeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/NullableInt16CeilingFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt16CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt16CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt16CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt16CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt16CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt16CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt16CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt16CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt16CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt16CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt16CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt16CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/NullableInt32CeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/NullableInt32CeilingFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt32CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt32CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt32CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt32CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt32CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt32CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt32CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt32CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt32CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt32CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt32CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt32CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/NullableInt64CeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/NullableInt64CeilingFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt64CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt64CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt64CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt64CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt64CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt64CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt64CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt64CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt64CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt64CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt64CeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt64CeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/NullableObjectCeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/NullableObjectCeilingFunctionExpression.generated.cs
@@ -1528,16 +1528,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableObjectCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableObjectCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableObjectCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableObjectCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableObjectCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableObjectCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableObjectCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableObjectCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableObjectCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableObjectCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableObjectCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableObjectCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/NullableSingleCeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/NullableSingleCeilingFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/SingleCeilingFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Ceil/SingleCeilingFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleCeilingFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleCeilingFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Cos/NullableSingleCosFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Cos/NullableSingleCosFunctionExpression.generated.cs
@@ -1004,16 +1004,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleCosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleCosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleCosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleCosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleCosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleCosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleCosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleCosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleCosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleCosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleCosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleCosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Cos/SingleCosFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Cos/SingleCosFunctionExpression.generated.cs
@@ -981,16 +981,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleCosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleCosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleCosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleCosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleCosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleCosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleCosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleCosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleCosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleCosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleCosFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleCosFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Cot/NullableSingleCotFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Cot/NullableSingleCotFunctionExpression.generated.cs
@@ -1004,16 +1004,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleCotFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleCotFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleCotFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleCotFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleCotFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleCotFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleCotFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleCotFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleCotFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleCotFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleCotFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleCotFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Cot/SingleCotFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Cot/SingleCotFunctionExpression.generated.cs
@@ -981,16 +981,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleCotFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleCotFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleCotFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleCotFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleCotFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleCotFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleCotFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleCotFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleCotFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleCotFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleCotFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleCotFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Exp/NullableSingleExpFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Exp/NullableSingleExpFunctionExpression.generated.cs
@@ -1004,16 +1004,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleExpFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleExpFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleExpFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleExpFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleExpFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleExpFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleExpFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleExpFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleExpFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleExpFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleExpFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleExpFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Exp/SingleExpFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Exp/SingleExpFunctionExpression.generated.cs
@@ -981,16 +981,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleExpFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleExpFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleExpFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleExpFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleExpFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleExpFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleExpFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleExpFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleExpFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleExpFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleExpFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleExpFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/ByteFloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/ByteFloorFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(ByteFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, ByteFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(ByteFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, ByteFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(ByteFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, ByteFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(ByteFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, ByteFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(ByteFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, ByteFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(ByteFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, ByteFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/DecimalFloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/DecimalFloorFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DecimalFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DecimalFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DecimalFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DecimalFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DecimalFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DecimalFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DecimalFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DecimalFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DecimalFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DecimalFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DecimalFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DecimalFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/DoubleFloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/DoubleFloorFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DoubleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DoubleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DoubleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DoubleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DoubleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DoubleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DoubleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DoubleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DoubleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DoubleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DoubleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DoubleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/Int16FloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/Int16FloorFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int16FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int16FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int16FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int16FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int16FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int16FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int16FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int16FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int16FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int16FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int16FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int16FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/Int32FloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/Int32FloorFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int32FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int32FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int32FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int32FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int32FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int32FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int32FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int32FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int32FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int32FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int32FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int32FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/Int64FloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/Int64FloorFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int64FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int64FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int64FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int64FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int64FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int64FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int64FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int64FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int64FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int64FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int64FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int64FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/NullableByteFloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/NullableByteFloorFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableByteFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableByteFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableByteFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableByteFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableByteFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableByteFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableByteFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableByteFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableByteFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableByteFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableByteFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableByteFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/NullableDecimalFloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/NullableDecimalFloorFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDecimalFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDecimalFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDecimalFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDecimalFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDecimalFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDecimalFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDecimalFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDecimalFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDecimalFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDecimalFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDecimalFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDecimalFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/NullableDoubleFloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/NullableDoubleFloorFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDoubleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDoubleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDoubleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDoubleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDoubleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDoubleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDoubleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDoubleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDoubleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDoubleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDoubleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDoubleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/NullableInt16FloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/NullableInt16FloorFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt16FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt16FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt16FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt16FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt16FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt16FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt16FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt16FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt16FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt16FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt16FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt16FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/NullableInt32FloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/NullableInt32FloorFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt32FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt32FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt32FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt32FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt32FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt32FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt32FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt32FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt32FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt32FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt32FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt32FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/NullableInt64FloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/NullableInt64FloorFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt64FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt64FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt64FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt64FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt64FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt64FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt64FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt64FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt64FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt64FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt64FloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt64FloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/NullableObjectFloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/NullableObjectFloorFunctionExpression.generated.cs
@@ -1528,16 +1528,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableObjectFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableObjectFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableObjectFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableObjectFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableObjectFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableObjectFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableObjectFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableObjectFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableObjectFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableObjectFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableObjectFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableObjectFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/NullableSingleFloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/NullableSingleFloorFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/SingleFloorFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Floor/SingleFloorFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleFloorFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleFloorFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Log/NullableSingleLogFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Log/NullableSingleLogFunctionExpression.generated.cs
@@ -1004,16 +1004,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleLogFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleLogFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleLogFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleLogFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleLogFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleLogFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleLogFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleLogFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleLogFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleLogFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleLogFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleLogFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Log/SingleLogFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Log/SingleLogFunctionExpression.generated.cs
@@ -981,16 +981,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleLogFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleLogFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleLogFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleLogFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleLogFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleLogFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleLogFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleLogFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleLogFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleLogFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleLogFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleLogFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Sin/NullableSingleSinFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Sin/NullableSingleSinFunctionExpression.generated.cs
@@ -1004,16 +1004,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleSinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleSinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleSinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleSinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleSinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleSinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleSinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleSinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleSinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleSinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleSinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleSinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Sin/SingleSinFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Sin/SingleSinFunctionExpression.generated.cs
@@ -981,16 +981,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleSinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleSinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleSinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleSinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleSinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleSinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleSinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleSinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleSinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleSinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleSinFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleSinFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Sqrt/NullableSingleSqrtFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Sqrt/NullableSingleSqrtFunctionExpression.generated.cs
@@ -1004,16 +1004,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleSqrtFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleSqrtFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleSqrtFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleSqrtFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleSqrtFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleSqrtFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleSqrtFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleSqrtFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleSqrtFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleSqrtFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleSqrtFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleSqrtFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Sqrt/SingleSqrtFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Sqrt/SingleSqrtFunctionExpression.generated.cs
@@ -981,16 +981,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleSqrtFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleSqrtFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleSqrtFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleSqrtFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleSqrtFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleSqrtFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleSqrtFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleSqrtFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleSqrtFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleSqrtFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleSqrtFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleSqrtFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Square/NullableSingleSquareFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Square/NullableSingleSquareFunctionExpression.generated.cs
@@ -1004,16 +1004,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleSquareFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleSquareFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleSquareFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleSquareFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleSquareFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleSquareFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleSquareFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleSquareFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleSquareFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleSquareFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleSquareFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleSquareFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Square/SingleSquareFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Square/SingleSquareFunctionExpression.generated.cs
@@ -981,16 +981,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleSquareFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleSquareFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleSquareFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleSquareFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleSquareFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleSquareFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleSquareFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleSquareFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleSquareFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleSquareFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleSquareFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleSquareFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Tan/NullableSingleTanFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Tan/NullableSingleTanFunctionExpression.generated.cs
@@ -1004,16 +1004,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleTanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleTanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleTanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleTanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleTanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleTanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleTanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleTanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleTanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleTanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleTanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleTanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Tan/SingleTanFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Mathematical/_Tan/SingleTanFunctionExpression.generated.cs
@@ -981,16 +981,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleTanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleTanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleTanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleTanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleTanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleTanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleTanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleTanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleTanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleTanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleTanFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleTanFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Concat/StringConcatFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Concat/StringConcatFunctionExpression.generated.cs
@@ -161,16 +161,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(StringConcatFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, StringConcatFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(StringConcatFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, StringConcatFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(StringConcatFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, StringConcatFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(StringConcatFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, StringConcatFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(StringConcatFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, StringConcatFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(StringConcatFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, StringConcatFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_LTrim/NullableStringLTrimFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_LTrim/NullableStringLTrimFunctionExpression.generated.cs
@@ -206,16 +206,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableStringLTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableStringLTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableStringLTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableStringLTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableStringLTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableStringLTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableStringLTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableStringLTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableStringLTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableStringLTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableStringLTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableStringLTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_LTrim/StringLTrimFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_LTrim/StringLTrimFunctionExpression.generated.cs
@@ -161,16 +161,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(StringLTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, StringLTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(StringLTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, StringLTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(StringLTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, StringLTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(StringLTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, StringLTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(StringLTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, StringLTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(StringLTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, StringLTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Left/NullableStringLeftFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Left/NullableStringLeftFunctionExpression.generated.cs
@@ -206,16 +206,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableStringLeftFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableStringLeftFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableStringLeftFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableStringLeftFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableStringLeftFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableStringLeftFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableStringLeftFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableStringLeftFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableStringLeftFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableStringLeftFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableStringLeftFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableStringLeftFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Left/StringLeftFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Left/StringLeftFunctionExpression.generated.cs
@@ -175,16 +175,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(StringLeftFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, StringLeftFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(StringLeftFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, StringLeftFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(StringLeftFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, StringLeftFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(StringLeftFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, StringLeftFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(StringLeftFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, StringLeftFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(StringLeftFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, StringLeftFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Length/Int64LengthFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Length/Int64LengthFunctionExpression.generated.cs
@@ -1989,16 +1989,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int64LengthFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int64LengthFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int64LengthFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int64LengthFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int64LengthFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int64LengthFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int64LengthFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int64LengthFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int64LengthFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int64LengthFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int64LengthFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int64LengthFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Length/NullableInt64LengthFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Length/NullableInt64LengthFunctionExpression.generated.cs
@@ -2024,16 +2024,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt64LengthFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt64LengthFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt64LengthFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt64LengthFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt64LengthFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt64LengthFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt64LengthFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt64LengthFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt64LengthFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt64LengthFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt64LengthFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt64LengthFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_RTrim/NullableStringRTrimFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_RTrim/NullableStringRTrimFunctionExpression.generated.cs
@@ -206,16 +206,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableStringRTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableStringRTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableStringRTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableStringRTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableStringRTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableStringRTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableStringRTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableStringRTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableStringRTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableStringRTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableStringRTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableStringRTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_RTrim/StringRTrimFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_RTrim/StringRTrimFunctionExpression.generated.cs
@@ -161,16 +161,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(StringRTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, StringRTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(StringRTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, StringRTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(StringRTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, StringRTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(StringRTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, StringRTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(StringRTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, StringRTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(StringRTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, StringRTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Replace/NullableObjectReplaceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Replace/NullableObjectReplaceFunctionExpression.generated.cs
@@ -1528,16 +1528,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableObjectReplaceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableObjectReplaceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableObjectReplaceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableObjectReplaceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableObjectReplaceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableObjectReplaceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableObjectReplaceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableObjectReplaceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableObjectReplaceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableObjectReplaceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableObjectReplaceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableObjectReplaceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Replace/NullableStringReplaceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Replace/NullableStringReplaceFunctionExpression.generated.cs
@@ -206,16 +206,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableStringReplaceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableStringReplaceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableStringReplaceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableStringReplaceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableStringReplaceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableStringReplaceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableStringReplaceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableStringReplaceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableStringReplaceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableStringReplaceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableStringReplaceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableStringReplaceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Replace/StringReplaceFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Replace/StringReplaceFunctionExpression.generated.cs
@@ -161,16 +161,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(StringReplaceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, StringReplaceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(StringReplaceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, StringReplaceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(StringReplaceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, StringReplaceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(StringReplaceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, StringReplaceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(StringReplaceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, StringReplaceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(StringReplaceFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, StringReplaceFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Right/NullableStringRightFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Right/NullableStringRightFunctionExpression.generated.cs
@@ -206,16 +206,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableStringRightFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableStringRightFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableStringRightFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableStringRightFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableStringRightFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableStringRightFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableStringRightFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableStringRightFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableStringRightFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableStringRightFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableStringRightFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableStringRightFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Right/StringRightFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Right/StringRightFunctionExpression.generated.cs
@@ -175,16 +175,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(StringRightFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, StringRightFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(StringRightFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, StringRightFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(StringRightFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, StringRightFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(StringRightFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, StringRightFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(StringRightFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, StringRightFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(StringRightFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, StringRightFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Substring/NullableStringSubstringFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Substring/NullableStringSubstringFunctionExpression.generated.cs
@@ -206,16 +206,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableStringSubstringFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableStringSubstringFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableStringSubstringFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableStringSubstringFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableStringSubstringFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableStringSubstringFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableStringSubstringFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableStringSubstringFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableStringSubstringFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableStringSubstringFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableStringSubstringFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableStringSubstringFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Substring/StringSubstringFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Substring/StringSubstringFunctionExpression.generated.cs
@@ -161,16 +161,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(StringSubstringFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, StringSubstringFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(StringSubstringFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, StringSubstringFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(StringSubstringFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, StringSubstringFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(StringSubstringFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, StringSubstringFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(StringSubstringFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, StringSubstringFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(StringSubstringFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, StringSubstringFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Trim/NullableStringTrimFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Trim/NullableStringTrimFunctionExpression.generated.cs
@@ -206,16 +206,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableStringTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableStringTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableStringTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableStringTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableStringTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableStringTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableStringTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableStringTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableStringTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableStringTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableStringTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableStringTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
 
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Trim/StringTrimFunctionExpression.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_String/_Trim/StringTrimFunctionExpression.generated.cs
@@ -161,16 +161,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(StringTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, StringTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(StringTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, StringTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(StringTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, StringTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(StringTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, StringTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(StringTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, StringTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(StringTrimFunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, StringTrimFunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/BooleanExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/BooleanExpressionMediator.generated.cs
@@ -98,8 +98,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(BooleanExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<bool>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, BooleanExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<bool>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(BooleanExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<bool>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, BooleanExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<bool>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/ByteExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/ByteExpressionMediator.generated.cs
@@ -4340,16 +4340,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(ByteExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, ByteExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(ByteExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, ByteExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(ByteExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, ByteExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(ByteExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, ByteExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(ByteExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, ByteExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(ByteExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, ByteExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<byte>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/DateTimeExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/DateTimeExpressionMediator.generated.cs
@@ -1985,16 +1985,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DateTimeExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DateTimeExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DateTimeExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DateTimeExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DateTimeExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DateTimeExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DateTimeExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DateTimeExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DateTimeExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DateTimeExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DateTimeExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DateTimeExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTime>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/DateTimeOffsetExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/DateTimeOffsetExpressionMediator.generated.cs
@@ -1985,16 +1985,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DateTimeOffsetExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DateTimeOffsetExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DateTimeOffsetExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DateTimeOffsetExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DateTimeOffsetExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DateTimeOffsetExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/DecimalExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/DecimalExpressionMediator.generated.cs
@@ -4340,16 +4340,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DecimalExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DecimalExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DecimalExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DecimalExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DecimalExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DecimalExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DecimalExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DecimalExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DecimalExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DecimalExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DecimalExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DecimalExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<decimal>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/DoubleExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/DoubleExpressionMediator.generated.cs
@@ -4340,16 +4340,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(DoubleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, DoubleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(DoubleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, DoubleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(DoubleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, DoubleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(DoubleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, DoubleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(DoubleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, DoubleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(DoubleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, DoubleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<double>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/GuidExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/GuidExpressionMediator.generated.cs
@@ -98,8 +98,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(GuidExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, GuidExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<Guid>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(GuidExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, GuidExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<Guid>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int16ExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int16ExpressionMediator.generated.cs
@@ -4340,16 +4340,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int16ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int16ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int16ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int16ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int16ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int16ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int16ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int16ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int16ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int16ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int16ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int16ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<short>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int32ExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int32ExpressionMediator.generated.cs
@@ -4340,16 +4340,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int32ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int32ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int32ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int32ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int32ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int32ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int32ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int32ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int32ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int32ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int32ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int32ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<int>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int64ExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/Int64ExpressionMediator.generated.cs
@@ -4340,16 +4340,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(Int64ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Int64ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(Int64ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Int64ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(Int64ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, Int64ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(Int64ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, Int64ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(Int64ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, Int64ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(Int64ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, Int64ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<long>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableBooleanExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableBooleanExpressionMediator.generated.cs
@@ -107,8 +107,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableBooleanExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<bool?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<bool?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableBooleanExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<bool?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableBooleanExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<bool?>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableByteExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableByteExpressionMediator.generated.cs
@@ -4124,16 +4124,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableByteExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableByteExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableByteExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableByteExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableByteExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableByteExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<byte?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableByteExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<byte?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDateTimeExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDateTimeExpressionMediator.generated.cs
@@ -1859,16 +1859,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDateTimeExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDateTimeExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDateTimeExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDateTimeExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDateTimeExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDateTimeExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTime?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDateTimeExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTime?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDateTimeOffsetExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDateTimeOffsetExpressionMediator.generated.cs
@@ -1859,16 +1859,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDateTimeOffsetExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDateTimeOffsetExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDateTimeOffsetExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDateTimeOffsetExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDateTimeOffsetExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDateTimeOffsetExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<DateTimeOffset?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDateTimeOffsetExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<DateTimeOffset?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDecimalExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDecimalExpressionMediator.generated.cs
@@ -4124,16 +4124,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDecimalExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDecimalExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDecimalExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDecimalExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDecimalExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDecimalExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<decimal?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDecimalExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<decimal?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDoubleExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableDoubleExpressionMediator.generated.cs
@@ -4124,16 +4124,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableDoubleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableDoubleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableDoubleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableDoubleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableDoubleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableDoubleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<double?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableDoubleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<double?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableGuidExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableGuidExpressionMediator.generated.cs
@@ -107,8 +107,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableGuidExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<Guid?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableGuidExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<Guid?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableGuidExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<Guid?>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt16ExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt16ExpressionMediator.generated.cs
@@ -4124,16 +4124,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt16ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt16ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt16ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt16ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt16ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt16ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<short?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt16ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<short?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt32ExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt32ExpressionMediator.generated.cs
@@ -4124,16 +4124,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt32ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt32ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt32ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt32ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt32ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt32ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<int?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt32ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<int?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt64ExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableInt64ExpressionMediator.generated.cs
@@ -4124,16 +4124,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableInt64ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableInt64ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableInt64ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableInt64ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableInt64ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableInt64ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<long?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableInt64ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<long?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableObjectExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableObjectExpressionMediator.generated.cs
@@ -884,16 +884,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableObjectExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableObjectExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableObjectExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableObjectExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableObjectExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableObjectExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableObjectExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableObjectExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableObjectExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableObjectExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableObjectExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableObjectExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableSingleExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableSingleExpressionMediator.generated.cs
@@ -4124,16 +4124,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableSingleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableSingleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableSingleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableSingleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableSingleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableSingleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableSingleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<float?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableStringExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableStringExpressionMediator.generated.cs
@@ -236,16 +236,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableStringExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableStringExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableStringExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableStringExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(NullableStringExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, NullableStringExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(NullableStringExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, NullableStringExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(NullableStringExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, NullableStringExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(NullableStringExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, NullableStringExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableTimeSpanExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/NullableTimeSpanExpressionMediator.generated.cs
@@ -206,8 +206,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(NullableTimeSpanExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableTimeSpanExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(NullableTimeSpanExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableTimeSpanExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan?>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/ObjectExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/ObjectExpressionMediator.generated.cs
@@ -643,16 +643,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(ObjectExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, ObjectExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(ObjectExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, ObjectExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(ObjectExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, ObjectExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(ObjectExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, ObjectExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(ObjectExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, ObjectExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(ObjectExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, ObjectExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<object?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/SingleExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/SingleExpressionMediator.generated.cs
@@ -4340,16 +4340,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(SingleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, SingleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(SingleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, SingleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(SingleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, SingleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(SingleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, SingleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(SingleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, SingleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(SingleExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<float>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, SingleExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<float>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/StringExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/StringExpressionMediator.generated.cs
@@ -232,16 +232,28 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(StringExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, StringExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(StringExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, StringExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.NotEqual);
+
         public static FilterExpression<bool?> operator <(StringExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThan);
         
+        public static FilterExpression<bool?> operator <((string TableName, string FieldName) a, StringExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThan);
+
         public static FilterExpression<bool?> operator >(StringExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThan);
         
+        public static FilterExpression<bool?> operator >((string TableName, string FieldName) a, StringExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThan);
+
         public static FilterExpression<bool?> operator <=(StringExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.LessThanOrEqual);
         
+        public static FilterExpression<bool?> operator <=((string TableName, string FieldName) a, StringExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.LessThanOrEqual);
+
         public static FilterExpression<bool?> operator >=(StringExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<string?>(b), FilterExpressionOperator.GreaterThanOrEqual);
         
+        public static FilterExpression<bool?> operator >=((string TableName, string FieldName) a, StringExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<string?>(a), b, FilterExpressionOperator.GreaterThanOrEqual);
+
         #endregion
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Mediator/TimeSpanExpressionMediator.generated.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Mediator/TimeSpanExpressionMediator.generated.cs
@@ -164,8 +164,12 @@ namespace HatTrick.DbEx.Sql.Expression
         
         public static FilterExpression<bool?> operator ==(TimeSpanExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan>(b), FilterExpressionOperator.Equal);
         
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, TimeSpanExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan>(a), b, FilterExpressionOperator.Equal);
+
         public static FilterExpression<bool?> operator !=(TimeSpanExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TimeSpan>(b), FilterExpressionOperator.NotEqual);
         
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, TimeSpanExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<TimeSpan>(a), b, FilterExpressionOperator.NotEqual);
+
         #endregion
         #endregion
     }

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/dbex_AliasTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/dbex_AliasTests.cs
@@ -589,7 +589,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration
 
         [Theory]
         [MsSqlVersions.AllVersions]
-        public void Can_use_alias_of_subquery_string_field(int version, int expected = 9)
+        public void Can_use_alias_of_subquery_string_field_as_right_arg_of_join_condition(int version, int expected = 9)
         {
             //given
             var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
@@ -607,6 +607,32 @@ namespace HatTrick.DbEx.MsSql.Test.Integration
                     dbo.Product.Name
                 ).From(dbo.Product)
             ).As("inner").On(dbo.Product.Id == ("inner", "Id"))
+            .Execute();
+
+            //then
+            values.Should().HaveCount(expected);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Can_use_alias_of_subquery_string_field_as_left_arg_of_join_condition(int version, int expected = 9)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            //when
+            IList<dynamic> values = db.SelectMany(
+                dbo.Product.Id,
+                dbo.Product.Name,
+                dbex.Alias<string?>("inner", "Name").As("inner_name")
+            )
+            .From(dbo.Product)
+            .InnerJoin(
+                db.SelectMany(
+                    dbo.Product.Id,
+                    dbo.Product.Name
+                ).From(dbo.Product)
+            ).As("inner").On(("inner", "Id") == dbo.Product.Id)
             .Execute();
 
             //then

--- a/test/HatTrick.DbEx.MsSql.Test.Unit/AliasTupleFilterExpressionTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Unit/AliasTupleFilterExpressionTests.cs
@@ -1,0 +1,380 @@
+﻿using DbEx.DataService;
+using DbEx.dboDataService;
+using FluentAssertions;
+using HatTrick.DbEx.Sql.Expression;
+using System.Linq;
+using Xunit;
+
+namespace HatTrick.DbEx.MsSql.Test.Unit
+{
+    public class AliasTupleFilterExpressionTests : TestBase
+    {
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Int_field_expression_equal_to_tuple_alias_create_valid_filter_expression(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            //when
+            FilterExpression exp = dbo.Person.Id == ("foo", "bar");
+
+            //then
+            exp.ExpressionOperator.Should().Be(FilterExpressionOperator.Equal);
+
+            exp.LeftArg.Should().Be(dbo.Person.Id);
+
+            exp.RightArg.Should().BeOfType<AliasExpression<int>>();
+            exp.RightArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.TableAlias.Should().Be("foo");
+            exp.RightArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.FieldAlias.Should().Be("bar");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Int_field_expression_not_equal_to_tuple_alias_create_valid_filter_expression(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            //when
+            FilterExpression exp = dbo.Person.Id != ("foo", "bar");
+
+            //then
+            exp.ExpressionOperator.Should().Be(FilterExpressionOperator.NotEqual);
+
+            exp.LeftArg.Should().Be(dbo.Person.Id);
+
+            exp.RightArg.Should().BeOfType<AliasExpression<int>>();
+            exp.RightArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.TableAlias.Should().Be("foo");
+            exp.RightArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.FieldAlias.Should().Be("bar");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Alias_tuple_expression_equal_to_int_field_expression_create_valid_filter_expression(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            //when
+            FilterExpression exp = ("foo", "bar") == dbo.Person.Id;
+
+            //then
+            exp.ExpressionOperator.Should().Be(FilterExpressionOperator.Equal);
+
+            exp.RightArg.Should().Be(dbo.Person.Id);
+
+            exp.LeftArg.Should().BeOfType<AliasExpression<int>>();
+            exp.LeftArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.TableAlias.Should().Be("foo");
+            exp.LeftArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.FieldAlias.Should().Be("bar");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Alias_tuple_expression_not_equal_to_int_field_expression_create_valid_filter_expression(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            //when
+            FilterExpression exp = ("foo", "bar") != dbo.Person.Id;
+
+            //then
+            exp.ExpressionOperator.Should().Be(FilterExpressionOperator.NotEqual);
+
+            exp.RightArg.Should().Be(dbo.Person.Id);
+
+            exp.LeftArg.Should().BeOfType<AliasExpression<int>>();
+            exp.LeftArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.TableAlias.Should().Be("foo");
+            exp.LeftArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.FieldAlias.Should().Be("bar");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void String_field_expression_equal_to_tuple_alias_create_valid_filter_expression(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            //when
+            FilterExpression exp = dbo.Person.FirstName == ("foo", "bar");
+
+            //then
+            exp.ExpressionOperator.Should().Be(FilterExpressionOperator.Equal);
+
+            exp.LeftArg.Should().Be(dbo.Person.FirstName);
+
+            exp.RightArg.Should().BeOfType<AliasExpression<string>>();
+            exp.RightArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.TableAlias.Should().Be("foo");
+            exp.RightArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.FieldAlias.Should().Be("bar");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void String_field_expression_not_equal_to_tuple_alias_create_valid_filter_expression(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            //when
+            FilterExpression exp = dbo.Person.FirstName != ("foo", "bar");
+
+            //then
+            exp.ExpressionOperator.Should().Be(FilterExpressionOperator.NotEqual);
+
+            exp.LeftArg.Should().Be(dbo.Person.FirstName);
+
+            exp.RightArg.Should().BeOfType<AliasExpression<string>>();
+            exp.RightArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.TableAlias.Should().Be("foo");
+            exp.RightArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.FieldAlias.Should().Be("bar");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Alias_tuple_expression_equal_to_string_field_expression_create_valid_filter_expression(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            //when
+            FilterExpression exp = ("foo", "bar") == dbo.Person.FirstName;
+
+            //then
+            exp.ExpressionOperator.Should().Be(FilterExpressionOperator.Equal);
+
+            exp.RightArg.Should().Be(dbo.Person.FirstName);
+
+            exp.LeftArg.Should().BeOfType<AliasExpression<string>>();
+            exp.LeftArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.TableAlias.Should().Be("foo");
+            exp.LeftArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.FieldAlias.Should().Be("bar");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Alias_tuple_expression_not_equal_to_string_field_expression_create_valid_filter_expression(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            //when
+            FilterExpression exp = ("foo", "bar") != dbo.Person.FirstName;
+
+            //then
+            exp.ExpressionOperator.Should().Be(FilterExpressionOperator.NotEqual);
+
+            exp.RightArg.Should().Be(dbo.Person.FirstName);
+
+            exp.LeftArg.Should().BeOfType<AliasExpression<string>>();
+            exp.LeftArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.TableAlias.Should().Be("foo");
+            exp.LeftArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.FieldAlias.Should().Be("bar");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Int_function_expression_equal_to_tuple_alias_create_valid_filter_expression(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            //when
+            FilterExpression exp = db.fx.Abs(dbo.Person.Id) == ("foo", "bar");
+
+            //then
+            exp.ExpressionOperator.Should().Be(FilterExpressionOperator.Equal);
+
+            exp.LeftArg.Should().BeOfType<Int32AbsFunctionExpression>();
+            exp.LeftArg.Should().BeAssignableTo<IExpressionProvider<IExpressionElement>>()
+                .Which?.Expression?.Should().Be(dbo.Person.Id);
+
+            exp.RightArg.Should().BeOfType<AliasExpression<int>>();
+            exp.RightArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.TableAlias.Should().Be("foo");
+            exp.RightArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.FieldAlias.Should().Be("bar");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Int_function_expression_not_equal_to_tuple_alias_create_valid_filter_expression(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            //when
+            FilterExpression exp = db.fx.Abs(dbo.Person.Id) != ("foo", "bar");
+
+            //then
+            exp.ExpressionOperator.Should().Be(FilterExpressionOperator.NotEqual);
+
+            exp.LeftArg.Should().BeOfType<Int32AbsFunctionExpression>();
+            exp.LeftArg.Should().BeAssignableTo<IExpressionProvider<IExpressionElement>>()
+                .Which?.Expression?.Should().Be(dbo.Person.Id);
+
+            exp.RightArg.Should().BeOfType<AliasExpression<int>>();
+            exp.RightArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.TableAlias.Should().Be("foo");
+            exp.RightArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.FieldAlias.Should().Be("bar");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Alias_tuple_expression_equal_to_int_function_expression_create_valid_filter_expression(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            //when
+            FilterExpression exp = ("foo", "bar") == db.fx.Abs(dbo.Person.Id);
+
+            //then
+            exp.ExpressionOperator.Should().Be(FilterExpressionOperator.Equal);
+
+            exp.RightArg.Should().BeOfType<Int32AbsFunctionExpression>();
+            exp.RightArg.Should().BeAssignableTo<IExpressionProvider<IExpressionElement>>()
+                .Which?.Expression?.Should().Be(dbo.Person.Id);
+
+            exp.LeftArg.Should().BeOfType<AliasExpression<int>>();
+            exp.LeftArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.TableAlias.Should().Be("foo");
+            exp.LeftArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.FieldAlias.Should().Be("bar");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Alias_tuple_expression_not_equal_to_int_function_expression_create_valid_filter_expression(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            //when
+            FilterExpression exp = ("foo", "bar") != db.fx.Abs(dbo.Person.Id);
+
+            //then
+            exp.ExpressionOperator.Should().Be(FilterExpressionOperator.NotEqual);
+
+            exp.RightArg.Should().BeOfType<Int32AbsFunctionExpression>();
+            exp.RightArg.Should().BeAssignableTo<IExpressionProvider<IExpressionElement>>()
+                .Which?.Expression?.Should().Be(dbo.Person.Id);
+
+            exp.LeftArg.Should().BeOfType<AliasExpression<int>>();
+            exp.LeftArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.TableAlias.Should().Be("foo");
+            exp.LeftArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.FieldAlias.Should().Be("bar");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void String_function_expression_equal_to_tuple_alias_create_valid_filter_expression(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            //when
+            FilterExpression exp = db.fx.Concat(dbo.Person.FirstName, "") == ("foo", "bar");
+
+            //then
+            exp.ExpressionOperator.Should().Be(FilterExpressionOperator.Equal);
+
+            exp.LeftArg.Should().BeOfType<StringConcatFunctionExpression>();
+            exp.LeftArg.Should().BeAssignableTo<IExpressionListProvider<IExpressionElement>>()
+                .Which?.Expressions?.First().Should().Be(dbo.Person.FirstName);
+
+            exp.RightArg.Should().BeOfType<AliasExpression<string>>();
+            exp.RightArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.TableAlias.Should().Be("foo");
+            exp.RightArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.FieldAlias.Should().Be("bar");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void String_function_expression_not_equal_to_tuple_alias_create_valid_filter_expression(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            //when
+            FilterExpression exp = db.fx.Concat(dbo.Person.FirstName, "") != ("foo", "bar");
+
+            //then
+            exp.ExpressionOperator.Should().Be(FilterExpressionOperator.NotEqual);
+
+            exp.LeftArg.Should().BeOfType<StringConcatFunctionExpression>();
+            exp.LeftArg.Should().BeAssignableTo<IExpressionListProvider<IExpressionElement>>()
+                .Which?.Expressions?.First().Should().Be(dbo.Person.FirstName);
+
+            exp.RightArg.Should().BeOfType<AliasExpression<string>>();
+            exp.RightArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.TableAlias.Should().Be("foo");
+            exp.RightArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.FieldAlias.Should().Be("bar");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Alias_tuple_expression_equal_to_string_function_expression_create_valid_filter_expression(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            //when
+            FilterExpression exp = ("foo", "bar") == db.fx.Concat(dbo.Person.FirstName, "");
+
+            //then
+            exp.ExpressionOperator.Should().Be(FilterExpressionOperator.Equal);
+
+            exp.RightArg.Should().BeOfType<StringConcatFunctionExpression>();
+            exp.RightArg.Should().BeAssignableTo<IExpressionListProvider<IExpressionElement>>()
+                .Which?.Expressions?.First().Should().Be(dbo.Person.FirstName);
+
+            exp.LeftArg.Should().BeOfType<AliasExpression<string>>();
+            exp.LeftArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.TableAlias.Should().Be("foo");
+            exp.LeftArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.FieldAlias.Should().Be("bar");
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Alias_tuple_expression_not_equal_to_string_function_expression_create_valid_filter_expression(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            //when
+            FilterExpression exp = ("foo", "bar") != db.fx.Concat(dbo.Person.FirstName, "");
+
+            //then
+            exp.ExpressionOperator.Should().Be(FilterExpressionOperator.NotEqual);
+
+            exp.RightArg.Should().BeOfType<StringConcatFunctionExpression>();
+            exp.RightArg.Should().BeAssignableTo<IExpressionListProvider<IExpressionElement>>()
+                .Which?.Expressions?.First().Should().Be(dbo.Person.FirstName);
+
+            exp.LeftArg.Should().BeOfType<AliasExpression<string>>();
+            exp.LeftArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.TableAlias.Should().Be("foo");
+            exp.LeftArg.Should().BeAssignableTo<IExpressionProvider<AliasExpression.AliasExpressionElements>>()
+                .Which?.Expression?.FieldAlias.Should().Be("bar");
+        }
+    }
+}

--- a/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Field/NullableTypedFieldExpression.htt
+++ b/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Field/NullableTypedFieldExpression.htt
@@ -223,6 +223,8 @@ namespace {Namespace}
         {-#each Operations-}
         public static FilterExpression<bool?> operator {FilterOperatorSymbol}(Nullable{:fieldExpressionType.Name}FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<{:fieldExpressionType.NullableAlias}>(b), FilterExpressionOperator.{FilterOperatorName});
         
+        public static FilterExpression<bool?> operator {FilterOperatorSymbol}((string TableName, string FieldName) a, Nullable{:fieldExpressionType.Name}FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<{:fieldExpressionType.NullableAlias}>(a), b, FilterExpressionOperator.{FilterOperatorName});
+
         {-/each-}
         {-/each-}
         #endregion

--- a/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Field/TypedFieldExpression.htt
+++ b/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Field/TypedFieldExpression.htt
@@ -211,6 +211,8 @@ namespace {Namespace}
         {-#each Operations-}
         public static FilterExpression<bool?> operator {FilterOperatorSymbol}({:fieldExpressionType.Name}FieldExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<{:fieldExpressionType.Alias}>(b), FilterExpressionOperator.{FilterOperatorName});
         
+        public static FilterExpression<bool?> operator {FilterOperatorSymbol}((string TableName, string FieldName) a, {:fieldExpressionType.Name}FieldExpression b) => new FilterExpression<bool?>(new AliasExpression<{:fieldExpressionType.Alias}>(a), b, FilterExpressionOperator.{FilterOperatorName});
+
         {-/each-}
         {-/each-}
         #endregion

--- a/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Function/EnumFunctionExpression.htt
+++ b/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Function/EnumFunctionExpression.htt
@@ -57,5 +57,15 @@ namespace {Namespace}
 
         public static FilterExpression<bool?> operator !=(TEnum? a, Enum{:functionName}FunctionExpression<TEnum> b) => new FilterExpression<bool?>(new LiteralExpression<TEnum?>(a), b, FilterExpressionOperator.NotEqual);
         #endregion
+
+        #region alias
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, Enum{:functionName}FunctionExpression<TEnum> b) => new FilterExpression<bool?>(new AliasExpression<TEnum?>(a), b, FilterExpressionOperator.Equal);
+
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, Enum{:functionName}FunctionExpression<TEnum> b) => new FilterExpression<bool?>(new AliasExpression<TEnum?>(a), b, FilterExpressionOperator.NotEqual);
+
+        public static FilterExpression<bool?> operator ==(Enum{:functionName}FunctionExpression<TEnum> a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TEnum?>(b), FilterExpressionOperator.Equal);
+
+        public static FilterExpression<bool?> operator !=(Enum{:functionName}FunctionExpression<TEnum> a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TEnum?>(b), FilterExpressionOperator.NotEqual);
+        #endregion
     }}
 }}

--- a/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Function/FunctionExpression.htt
+++ b/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Function/FunctionExpression.htt
@@ -171,6 +171,8 @@ namespace {Namespace}
         {-#each Operations-}
         public static FilterExpression<bool?> operator {FilterOperatorSymbol}({:functionName}FunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<object>(b), FilterExpressionOperator.{FilterOperatorName});
         
+        public static FilterExpression<bool?> operator {FilterOperatorSymbol}((string TableName, string FieldName) a, {:functionName}FunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<object>(a), b, FilterExpressionOperator.{FilterOperatorName});
+
         {-/each-}
         {-/each-}
         #endregion

--- a/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Function/NullableEnumFunctionExpression.htt
+++ b/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Function/NullableEnumFunctionExpression.htt
@@ -58,5 +58,15 @@ namespace {Namespace}
 
         public static FilterExpression<bool?> operator !=(TEnum a, NullableEnum{:functionName}FunctionExpression<TEnum> b) => new FilterExpression<bool?>(new LiteralExpression<TEnum>(a), b, FilterExpressionOperator.NotEqual);
         #endregion
+
+        #region alias
+        public static FilterExpression<bool?> operator ==((string TableName, string FieldName) a, NullableEnum{:functionName}FunctionExpression<TEnum> b) => new FilterExpression<bool?>(new AliasExpression<TEnum?>(a), b, FilterExpressionOperator.Equal);
+
+        public static FilterExpression<bool?> operator !=((string TableName, string FieldName) a, NullableEnum{:functionName}FunctionExpression<TEnum> b) => new FilterExpression<bool?>(new AliasExpression<TEnum?>(a), b, FilterExpressionOperator.NotEqual);
+
+        public static FilterExpression<bool?> operator ==(NullableEnum{:functionName}FunctionExpression<TEnum> a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TEnum?>(b), FilterExpressionOperator.Equal);
+
+        public static FilterExpression<bool?> operator !=(NullableEnum{:functionName}FunctionExpression<TEnum> a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<TEnum?>(b), FilterExpressionOperator.NotEqual);
+        #endregion
     }}
 }}

--- a/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Function/NullableTypedFunctionExpression.htt
+++ b/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Function/NullableTypedFunctionExpression.htt
@@ -235,6 +235,8 @@ namespace {Namespace}
         {-#each Operations-}
         public static FilterExpression<bool?> operator {FilterOperatorSymbol}(Nullable{:dataType.Name}{:functionName}FunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<{:dataType.NullableAlias}>(b), FilterExpressionOperator.{FilterOperatorName});
         
+        public static FilterExpression<bool?> operator {FilterOperatorSymbol}((string TableName, string FieldName) a, Nullable{:dataType.Name}{:functionName}FunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<{:dataType.NullableAlias}>(a), b, FilterExpressionOperator.{FilterOperatorName});
+
         {-/each-}
         {-/each-}
         #endregion

--- a/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Function/TypedFunctionExpression.htt
+++ b/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Function/TypedFunctionExpression.htt
@@ -229,6 +229,8 @@ namespace {Namespace}
         {-#each Operations-}
         public static FilterExpression<bool?> operator {FilterOperatorSymbol}({:dataType.Name}{:functionName}FunctionExpression a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<{:dataType.Alias}>(b), FilterExpressionOperator.{FilterOperatorName});
         
+        public static FilterExpression<bool?> operator {FilterOperatorSymbol}((string TableName, string FieldName) a, {:dataType.Name}{:functionName}FunctionExpression b) => new FilterExpression<bool?>(new AliasExpression<{:dataType.Alias}>(a), b, FilterExpressionOperator.{FilterOperatorName});
+
         {-/each-}
         {-/each-}
         #endregion

--- a/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Mediator/NullableTypedExpressionMediator.htt
+++ b/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Mediator/NullableTypedExpressionMediator.htt
@@ -285,6 +285,8 @@ namespace {Namespace}
         {-#each Operations-}
         public static FilterExpression<bool?> operator {FilterOperatorSymbol}(Nullable{:mediatorType.Name}ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<{:mediatorType.NullableAlias}>(b), FilterExpressionOperator.{FilterOperatorName});
         
+        public static FilterExpression<bool?> operator {FilterOperatorSymbol}((string TableName, string FieldName) a, Nullable{:mediatorType.Name}ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<{:mediatorType.NullableAlias}>(a), b, FilterExpressionOperator.{FilterOperatorName});
+
         {-/each-}
         {-/each-}
         #endregion

--- a/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Mediator/TypedExpressionMediator.htt
+++ b/tools/HatTrick.DbEx.CodeTemplating/Templates/Sql/Expression/_Mediator/TypedExpressionMediator.htt
@@ -326,6 +326,8 @@ namespace {Namespace}
         {-#each Operations-}
         public static FilterExpression<bool?> operator {FilterOperatorSymbol}({:mediatorType.Name}ExpressionMediator a, (string TableName, string FieldName) b) => new FilterExpression<bool?>(a, new AliasExpression<{:mediatorType.Alias}>(b), FilterExpressionOperator.{FilterOperatorName});
         
+        public static FilterExpression<bool?> operator {FilterOperatorSymbol}((string TableName, string FieldName) a, {:mediatorType.Name}ExpressionMediator b) => new FilterExpression<bool?>(new AliasExpression<{:mediatorType.Alias}>(a), b, FilterExpressionOperator.{FilterOperatorName});
+
         {-/each-}
         {-/each-}
         #endregion


### PR DESCRIPTION
Added ability to use tuples for aliases as 'left' expression of filter expressions.